### PR TITLE
fix(auth): validate CORS_ORIGIN and API_URL in production to prevent …

### DIFF
--- a/packages/backend/src/config/env.ts
+++ b/packages/backend/src/config/env.ts
@@ -30,5 +30,13 @@ export function validateEnv(): void {
     if (env.BETTER_AUTH_SECRET.length < 32) {
       throw new Error('BETTER_AUTH_SECRET must be at least 32 characters')
     }
+
+    if (env.CORS_ORIGIN.includes('localhost')) {
+      throw new Error('CORS_ORIGIN must not contain localhost in production')
+    }
+
+    if (env.API_URL.includes('localhost')) {
+      throw new Error('API_URL must not contain localhost in production')
+    }
   }
 }


### PR DESCRIPTION
…localhost fallback

Closes #6 — Steam authentication callback was redirecting to localhost:5173 instead of the production URL after successful OpenID login.

The root cause is that CORS_ORIGIN defaults to http://localhost:5173 when the environment variable is not set. All post-auth redirects in auth.routes.ts use env.CORS_ORIGIN, so a missing variable causes ERR_CONNECTION_REFUSED on production.

Add startup validation in validateEnv() to reject localhost values for CORS_ORIGIN and API_URL in production, failing fast instead of silently misconfiguring redirects.

https://claude.ai/code/session_0138X3Vo5K3QSQxumMq5gWLg