### PR TITLE
fix(frontend): add missing commonGameCount to getGroups API type

### DIFF
--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -24,7 +24,7 @@ export const api = {
   logout: () => request('/auth/logout', { method: 'POST' }),
 
   // Groups
-  getGroups: () => request<{ id: string; name: string; role: string; createdAt: string; memberCount: number; lastSession: { gameName: string; gameAppId: number; closedAt: string } | null }[]>('/groups'),
+  getGroups: () => request<{ id: string; name: string; role: string; createdAt: string; memberCount: number; commonGameCount: number; lastSession: { gameName: string; gameAppId: number; closedAt: string } | null }[]>('/groups'),
   getGroup: (id: string) => request<{
     id: string; name: string; createdBy: string; commonGameThreshold: number | null; createdAt: string;
     members: { id: string; steamId: string; displayName: string; avatarUrl: string; libraryVisible: boolean; role: string; joinedAt: string }[]


### PR DESCRIPTION
The backend returns commonGameCount in the /groups response but the
frontend API client type was missing it, causing a TypeScript build error.

https://claude.ai/code/session_01QRGG5YYVxDGbseniR6aPwj