### PR TITLE
feat(auth): CSRF protection and categorized auth logging

### DIFF
--- a/packages/backend/src/config/session.ts
+++ b/packages/backend/src/config/session.ts
@@ -1,3 +1,4 @@
 export const SESSION_COOKIE_NAME = 'wawptn.session_token'
 export const SESSION_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000 // 7 days
 export const SESSION_TOKEN_BYTES = 32
+export const CSRF_COOKIE_NAME = 'wawptn.csrf_state'

--- a/packages/backend/src/infrastructure/socket/socket.ts
+++ b/packages/backend/src/infrastructure/socket/socket.ts
@@ -54,6 +54,7 @@ export function createSocketServer(httpServer: HttpServer): TypedServer {
     try {
       const cookieHeader = socket.handshake.headers.cookie
       if (!cookieHeader) {
+        socketLogger.debug('socket auth: no cookie header')
         return next(new Error('unauthorized'))
       }
 
@@ -61,6 +62,7 @@ export function createSocketServer(httpServer: HttpServer): TypedServer {
       const cookies = parseCookie(cookieHeader)
       const raw = cookies[SESSION_COOKIE_NAME]
       if (!raw) {
+        socketLogger.debug('socket auth: no session cookie')
         return next(new Error('unauthorized'))
       }
 
@@ -69,6 +71,7 @@ export function createSocketServer(httpServer: HttpServer): TypedServer {
         ? unsign(raw.slice(2), env.BETTER_AUTH_SECRET)
         : raw // fallback for unsigned cookies during transition
       if (!token) {
+        socketLogger.info('socket auth: invalid cookie signature')
         return next(new Error('unauthorized'))
       }
 
@@ -78,12 +81,14 @@ export function createSocketServer(httpServer: HttpServer): TypedServer {
         .first()
 
       if (!session) {
+        socketLogger.info('socket auth: expired or invalid session')
         return next(new Error('unauthorized'))
       }
 
       socket.data.userId = session.user_id
       next()
-    } catch {
+    } catch (error) {
+      socketLogger.error({ error: String(error) }, 'socket auth: database error')
       next(new Error('unauthorized'))
     }
   })

--- a/packages/backend/src/presentation/middleware/auth.middleware.ts
+++ b/packages/backend/src/presentation/middleware/auth.middleware.ts
@@ -1,5 +1,6 @@
 import type { Request, Response, NextFunction } from 'express'
 import { db } from '../../infrastructure/database/connection.js'
+import { authLogger } from '../../infrastructure/logger/logger.js'
 import { SESSION_COOKIE_NAME } from '../../config/session.js'
 
 // Extend Express Request
@@ -15,6 +16,7 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
   try {
     const token = req.signedCookies?.[SESSION_COOKIE_NAME]
     if (!token) {
+      authLogger.debug({ path: req.path }, 'auth middleware: no token provided')
       res.status(401).json({ error: 'unauthorized', message: 'Authentication required' })
       return
     }
@@ -25,13 +27,15 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
       .first()
 
     if (!session) {
+      authLogger.info({ path: req.path }, 'auth middleware: expired or invalid token')
       res.status(401).json({ error: 'unauthorized', message: 'Invalid or expired session' })
       return
     }
 
     req.userId = session.user_id
     next()
-  } catch {
+  } catch (error) {
+    authLogger.error({ error: String(error), path: req.path }, 'auth middleware: database error')
     res.status(401).json({ error: 'unauthorized', message: 'Invalid or expired session' })
   }
 }

--- a/packages/backend/src/presentation/routes/auth.routes.ts
+++ b/packages/backend/src/presentation/routes/auth.routes.ts
@@ -4,7 +4,7 @@ import { db } from '../../infrastructure/database/connection.js'
 import { getSteamLoginUrl, verifySteamLogin, getPlayerSummary, getOwnedGames, getHeaderImageUrl } from '../../infrastructure/steam/steam-client.js'
 import { authLogger, steamLogger } from '../../infrastructure/logger/logger.js'
 import { env } from '../../config/env.js'
-import { SESSION_COOKIE_NAME, SESSION_MAX_AGE_MS, SESSION_TOKEN_BYTES } from '../../config/session.js'
+import { SESSION_COOKIE_NAME, SESSION_MAX_AGE_MS, SESSION_TOKEN_BYTES, CSRF_COOKIE_NAME } from '../../config/session.js'
 
 const router = Router()
 
@@ -51,6 +51,17 @@ router.get('/steam/login', (req: Request, res: Response) => {
     })
   }
 
+  // CSRF protection: set a signed nonce cookie, verified on callback
+  const csrfState = crypto.randomBytes(16).toString('hex')
+  res.cookie(CSRF_COOKIE_NAME, csrfState, {
+    httpOnly: true,
+    signed: true,
+    secure: env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    maxAge: 10 * 60 * 1000, // 10 minutes
+    path: '/api/auth/steam/callback',
+  })
+
   const returnUrl = `${env.API_URL}/api/auth/steam/callback`
   const loginUrl = getSteamLoginUrl(returnUrl)
   res.redirect(loginUrl)
@@ -59,13 +70,22 @@ router.get('/steam/login', (req: Request, res: Response) => {
 // Steam OpenID callback
 router.get('/steam/callback', async (req: Request, res: Response) => {
   try {
+    // CSRF verification: ensure the login was initiated from our /steam/login endpoint
+    const csrfState = req.signedCookies?.[CSRF_COOKIE_NAME]
+    res.clearCookie(CSRF_COOKIE_NAME, { path: '/api/auth/steam/callback' })
+    if (!csrfState) {
+      authLogger.warn('steam callback rejected: missing CSRF state cookie')
+      res.redirect(`${env.CORS_ORIGIN}/#/login?error=auth_failed`)
+      return
+    }
+
     const params = req.query as Record<string, string>
 
     // Validate return_to matches our callback URL
     const returnTo = params['openid.return_to']
     const expectedReturnTo = `${env.API_URL}/api/auth/steam/callback`
     if (returnTo !== expectedReturnTo) {
-      authLogger.warn({ returnTo, expected: expectedReturnTo }, 'return_to mismatch')
+      authLogger.warn({ returnTo, expected: expectedReturnTo }, 'steam callback rejected: return_to mismatch')
       res.redirect(`${env.CORS_ORIGIN}/#/login?error=auth_failed`)
       return
     }
@@ -73,6 +93,7 @@ router.get('/steam/callback', async (req: Request, res: Response) => {
     // Verify with Steam
     const steamId = await verifySteamLogin(params)
     if (!steamId) {
+      authLogger.warn('steam callback rejected: OpenID verification failed')
       res.redirect(`${env.CORS_ORIGIN}/#/login?error=auth_failed`)
       return
     }
@@ -80,6 +101,7 @@ router.get('/steam/callback', async (req: Request, res: Response) => {
     // Get player profile from Steam
     const profile = await getPlayerSummary(steamId)
     if (!profile) {
+      authLogger.warn({ steamId }, 'steam callback rejected: failed to fetch player profile')
       res.redirect(`${env.CORS_ORIGIN}/#/login?error=steam_profile_failed`)
       return
     }
@@ -166,18 +188,21 @@ router.get('/me', async (req: Request, res: Response) => {
   try {
     const token = req.signedCookies?.[SESSION_COOKIE_NAME]
     if (!token) {
+      authLogger.debug('get session: no token provided')
       res.status(401).json({ error: 'unauthorized', message: 'No session' })
       return
     }
 
     const userId = await getSessionUserId(token)
     if (!userId) {
+      authLogger.info('get session: expired or invalid token')
       res.status(401).json({ error: 'unauthorized', message: 'No session' })
       return
     }
 
     const user = await db('users').where({ id: userId }).first()
     if (!user) {
+      authLogger.warn({ userId }, 'get session: user not found for valid session')
       res.status(401).json({ error: 'unauthorized', message: 'No session' })
       return
     }
@@ -190,7 +215,7 @@ router.get('/me', async (req: Request, res: Response) => {
       libraryVisible: user.library_visible ?? true,
     })
   } catch (error) {
-    authLogger.error({ error: String(error) }, 'get session failed')
+    authLogger.error({ error: String(error) }, 'get session: database error')
     res.status(500).json({ error: 'internal', message: 'Failed to get session' })
   }
 })


### PR DESCRIPTION
## Summary
- Add CSRF protection on Steam login flow (signed nonce cookie)
- Categorize auth error logging across middleware, Socket.io, and routes

## Détail des changements

### Protection CSRF sur `/steam/login`
- Génère un nonce aléatoire signé (`wawptn.csrf_state`) lors de l'initiation du login
- Vérifie la présence du cookie sur `/steam/callback` avant de traiter la requête
- Rejette les requêtes callback non initiées depuis notre endpoint login
- Cookie scopé au path callback, expire en 10 minutes, nettoyé après usage

### Catégorisation des logs d'authentification

| Scénario | Niveau | Localisation |
|----------|--------|-------------|
| Pas de token fourni | `debug` | middleware, Socket.io, `/me` |
| Token expiré/invalide | `info` | middleware, Socket.io, `/me` |
| Signature cookie invalide | `info` | Socket.io |
| Utilisateur introuvable pour session valide | `warn` | `/me` |
| État CSRF manquant | `warn` | callback |
| Vérification OpenID échouée | `warn` | callback |
| Erreur base de données | `error` | middleware, Socket.io, `/me` |

### Fichiers modifiés
- `packages/backend/src/config/session.ts` — Ajout constante `CSRF_COOKIE_NAME`
- `packages/backend/src/presentation/routes/auth.routes.ts` — CSRF nonce + logs catégorisés
- `packages/backend/src/presentation/middleware/auth.middleware.ts` — Logs catégorisés
- `packages/backend/src/infrastructure/socket/socket.ts` — Logs catégorisés

## Test plan
- [ ] Vérifier que le login Steam fonctionne toujours (le cookie CSRF est transparent)
- [ ] Vérifier qu'un accès direct à `/api/auth/steam/callback` sans passer par `/steam/login` est rejeté
- [ ] Vérifier les logs en mode debug pour confirmer la catégorisation
- [ ] Vérifier que Socket.io se connecte toujours correctement après login

🤖 Generated with [Claude Code](https://claude.com/claude-code)