### PR TITLE
feat(groups): add search filter for Mes Groupes dashboard

### DIFF
--- a/packages/frontend/src/i18n/locales/en.json
+++ b/packages/frontend/src/i18n/locales/en.json
@@ -20,7 +20,10 @@
     "logoutConfirmDescription": "You will be redirected to the login page.",
     "logoutConfirm": "Log out",
     "logoutCancel": "Cancel",
-    "commonGames": "{{count}} common games"
+    "commonGames": "{{count}} common games",
+    "searchGroups": "Search for a group...",
+    "noSearchResults": "No groups match your search.",
+    "clearSearch": "Clear search"
   },
   "createGroup": {
     "title": "Create a group",

--- a/packages/frontend/src/i18n/locales/fr.json
+++ b/packages/frontend/src/i18n/locales/fr.json
@@ -20,7 +20,10 @@
     "logoutConfirmDescription": "Tu seras redirigé vers la page de connexion.",
     "logoutConfirm": "Se déconnecter",
     "logoutCancel": "Annuler",
-    "commonGames": "{{count}} jeux en commun"
+    "commonGames": "{{count}} jeux en commun",
+    "searchGroups": "Rechercher un groupe...",
+    "noSearchResults": "Aucun groupe ne correspond à ta recherche.",
+    "clearSearch": "Effacer la recherche"
   },
   "createGroup": {
     "title": "Créer un groupe",

--- a/packages/frontend/src/pages/GroupsPage.tsx
+++ b/packages/frontend/src/pages/GroupsPage.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
-import { Plus, LogIn, Users, Gamepad2, Trophy, Crown } from 'lucide-react'
+import { Plus, LogIn, Users, Gamepad2, Trophy, Crown, Search, X } from 'lucide-react'
 import { toast } from 'sonner'
 import { useTranslation } from 'react-i18next'
 import { useGroupStore } from '@/stores/group.store'
@@ -29,6 +29,16 @@ export function GroupsPage() {
   const [inviteResult, setInviteResult] = useState<string | null>(null)
   const [createError, setCreateError] = useState<string | null>(null)
   const [joinError, setJoinError] = useState<string | null>(null)
+  const [searchQuery, setSearchQuery] = useState('')
+
+  const normalize = (s: string) =>
+    s.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase()
+
+  const filteredGroups = useMemo(() => {
+    if (!searchQuery.trim()) return groups
+    const q = normalize(searchQuery)
+    return groups.filter((g) => normalize(g.name).includes(q))
+  }, [groups, searchQuery])
 
   useEffect(() => {
     fetchGroups()
@@ -92,6 +102,30 @@ export function GroupsPage() {
             </Button>
           </div>
         </div>
+
+        {/* Search Groups */}
+        {groups.length > 3 && (
+          <div className="relative mb-4" role="search">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
+            <Input
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder={t('groups.searchGroups')}
+              aria-label={t('groups.searchGroups')}
+              className="pl-9 pr-9"
+            />
+            {searchQuery && (
+              <button
+                type="button"
+                onClick={() => setSearchQuery('')}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                aria-label={t('groups.clearSearch')}
+              >
+                <X className="w-4 h-4" />
+              </button>
+            )}
+          </div>
+        )}
 
         {/* Create Group Dialog */}
         <ResponsiveDialog open={showCreate} onOpenChange={(open) => { setShowCreate(open); if (!open) setInviteResult(null) }}>
@@ -175,9 +209,20 @@ export function GroupsPage() {
             <h3 className="text-xl font-semibold mb-2">{t('groups.noGroups')}</h3>
             <p className="text-muted-foreground mb-6">{t('groups.noGroupsHint')}</p>
           </div>
+        ) : filteredGroups.length === 0 && searchQuery ? (
+          <div className="text-center py-8">
+            <p className="text-sm text-muted-foreground mb-2">{t('groups.noSearchResults')}</p>
+            <button
+              type="button"
+              onClick={() => setSearchQuery('')}
+              className="text-sm text-primary hover:underline"
+            >
+              {t('groups.clearSearch')}
+            </button>
+          </div>
         ) : (
           <div className="space-y-3">
-            {groups.map((group) => (
+            {filteredGroups.map((group) => (
               <Link key={group.id} to={`/groups/${group.id}`} className="block">
                 <Card className="p-4 hover:border-primary/50 transition-colors">
                   <div className="flex items-center justify-between">


### PR DESCRIPTION
## Analyse de réunion rapide

### Question posée
Comment implémenter la recherche/filtre de groupes dans la section "Mes Groupes" du dashboard ?

### Participants
| Persona | Rôle | Position |
|---------|------|----------|
| Mohammed | Senior Frontend Engineer | Filtrage client-side avec `useState` + `useMemo`, même pattern que GameGrid |
| Sarah | Product Owner | Approche minimale, filtre par nom uniquement, pas de scope creep |
| Didier | Tech Lead / Architect | Architecture cohérente avec l'existant, pas de Zustand ni backend |

### Recommandation retenue
Filtrage client-side avec `useState` + `useMemo` dans `GroupsPage.tsx`. Un champ `Input` avec icône `Search` placé entre le header et la liste, filtrant sur `group.name` avec normalisation des accents (NFD). Pas de debounce, pas de Zustand, pas de backend.

**Justification :**
- Liste de 5-20 éléments : filtrage en mémoire instantané, aucun besoin de backend
- Pattern déjà prouvé dans `GameGrid` — cohérence UX assurée
- Changement minimal : ~40 lignes, 3 fichiers modifiés, 0 nouvelle dépendance

### Risques identifiés
- Confusion état vide vs aucun résultat → État "aucun résultat" distinct avec bouton "Effacer la recherche"
- Scope creep (filtres avancés, composant réutilisable) → Filtrage par nom uniquement, inline, YAGNI

### Changements implémentés
- **`packages/frontend/src/pages/GroupsPage.tsx`** : ajout du champ de recherche avec icône Search/X, state `searchQuery`, `useMemo` pour le filtrage avec normalisation des accents, état "aucun résultat" distinct. La barre de recherche s'affiche uniquement quand l'utilisateur a plus de 3 groupes.
- **`packages/frontend/src/i18n/locales/fr.json`** : ajout des clés `groups.searchGroups`, `groups.noSearchResults`, `groups.clearSearch`
- **`packages/frontend/src/i18n/locales/en.json`** : mêmes clés en anglais

### Prochaines étapes
- [ ] Revue de code par l'équipe
- [ ] Validation des tests
- [ ] Merge après approbation

---
_Analyse et implémentation générées automatiquement par fast-meeting avec personas IA_

🤖 Generated with [Claude Code](https://claude.com/claude-code)