### PR TITLE
feat(groups): add group rename for owners

### DIFF
--- a/packages/backend/src/presentation/routes/group.routes.ts
+++ b/packages/backend/src/presentation/routes/group.routes.ts
@@ -169,6 +169,44 @@ router.post('/', async (req: Request, res: Response) => {
   })
 })
 
+// Rename group (owner only)
+router.patch('/:id', async (req: Request, res: Response) => {
+  const userId = req.userId!
+  const groupId = String(req.params['id'])
+  const { name } = req.body as { name: string }
+
+  if (!name || name.trim().length === 0) {
+    res.status(400).json({ error: 'validation', message: 'Group name is required' })
+    return
+  }
+
+  if (name.trim().length > 100) {
+    res.status(400).json({ error: 'validation', message: 'Group name must be 100 characters or less' })
+    return
+  }
+
+  const membership = await db('group_members')
+    .where({ group_id: groupId, user_id: userId, role: 'owner' })
+    .first()
+
+  if (!membership) {
+    res.status(403).json({ error: 'forbidden', message: 'Only the group owner can rename the group' })
+    return
+  }
+
+  const trimmedName = name.trim()
+
+  await db('groups').where({ id: groupId }).update({
+    name: trimmedName,
+    updated_at: db.fn.now(),
+  })
+
+  getIO().to(`group:${groupId}`).emit('group:renamed', { groupId, newName: trimmedName })
+
+  logger.info({ userId, groupId, newName: trimmedName }, 'group renamed')
+  res.json({ id: groupId, name: trimmedName })
+})
+
 // Generate new invite link (owner only)
 router.post('/:id/invite', async (req: Request, res: Response) => {
   const userId = req.userId!

--- a/packages/frontend/src/components/group-sidebar.tsx
+++ b/packages/frontend/src/components/group-sidebar.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react'
-import { RefreshCw, UserPlus, Users, Trophy, History, Crown, UserMinus, Trash2, LogOut } from 'lucide-react'
+import { RefreshCw, UserPlus, Users, Trophy, History, Crown, UserMinus, Trash2, LogOut, Pencil } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Card, CardHeader, CardContent } from '@/components/ui/card'
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
 import {
   ResponsiveDialog,
   ResponsiveDialogContent,
@@ -32,6 +33,7 @@ interface VoteHistoryEntry {
 
 interface GroupSidebarProps {
   members: Member[]
+  groupName: string
   syncing: boolean
   inviteToken: string | null
   voteHistory: VoteHistoryEntry[]
@@ -43,15 +45,19 @@ interface GroupSidebarProps {
   onLeaveGroup: () => void
   onKickMember: (userId: string) => void
   onDeleteGroup: () => void
+  onRenameGroup: (name: string) => Promise<void>
   /** When true, renders a compact layout for mobile bottom sheets (no Card wrappers) */
   compact?: boolean
 }
 
-export function GroupSidebar({ members, syncing, inviteToken, voteHistory, onlineMembers, currentUserId, currentUserRole, onSync, onGenerateInvite, onLeaveGroup, onKickMember, onDeleteGroup, compact = false }: GroupSidebarProps) {
+export function GroupSidebar({ members, groupName, syncing, inviteToken, voteHistory, onlineMembers, currentUserId, currentUserRole, onSync, onGenerateInvite, onLeaveGroup, onKickMember, onDeleteGroup, onRenameGroup, compact = false }: GroupSidebarProps) {
   const { t, i18n } = useTranslation()
   const [confirmLeave, setConfirmLeave] = useState(false)
   const [confirmDelete, setConfirmDelete] = useState(false)
   const [confirmKick, setConfirmKick] = useState<Member | null>(null)
+  const [renameOpen, setRenameOpen] = useState(false)
+  const [renameName, setRenameName] = useState('')
+  const [renaming, setRenaming] = useState(false)
 
   const isOwner = currentUserRole === 'owner'
 
@@ -159,6 +165,17 @@ export function GroupSidebar({ members, syncing, inviteToken, voteHistory, onlin
         >
           <RefreshCw className={`w-4 h-4 mr-2 ${syncing ? 'animate-spin text-primary' : ''}`} />
           {t('group.syncLibraries')}
+        </Button>
+      )}
+
+      {isOwner && (
+        <Button
+          variant="outline"
+          className="w-full"
+          onClick={() => { setRenameName(groupName); setRenameOpen(true) }}
+        >
+          <Pencil className="w-4 h-4 mr-2" />
+          {t('group.renameGroup')}
         </Button>
       )}
 
@@ -286,6 +303,43 @@ export function GroupSidebar({ members, syncing, inviteToken, voteHistory, onlin
             <Button variant="outline" onClick={() => setConfirmKick(null)}>{t('group.cancel')}</Button>
             <Button variant="destructive" onClick={() => { if (confirmKick) { onKickMember(confirmKick.id); setConfirmKick(null) } }}>{t('group.kickConfirm')}</Button>
           </ResponsiveDialogFooter>
+        </ResponsiveDialogContent>
+      </ResponsiveDialog>
+
+      {/* Rename group dialog */}
+      <ResponsiveDialog open={renameOpen} onOpenChange={setRenameOpen}>
+        <ResponsiveDialogContent>
+          <ResponsiveDialogHeader>
+            <ResponsiveDialogTitle>{t('group.renameTitle')}</ResponsiveDialogTitle>
+            <ResponsiveDialogDescription>{t('group.renameDescription')}</ResponsiveDialogDescription>
+          </ResponsiveDialogHeader>
+          <form onSubmit={async (e) => {
+            e.preventDefault()
+            if (!renameName.trim() || renaming) return
+            setRenaming(true)
+            try {
+              await onRenameGroup(renameName.trim())
+              setRenameOpen(false)
+            } finally {
+              setRenaming(false)
+            }
+          }}>
+            <div className="px-4 pb-4">
+              <label htmlFor="rename-input" className="text-sm font-medium mb-2 block">{t('group.renameLabel')}</label>
+              <Input
+                id="rename-input"
+                value={renameName}
+                onChange={(e) => setRenameName(e.target.value)}
+                placeholder={t('group.renamePlaceholder')}
+                maxLength={100}
+                autoFocus
+              />
+            </div>
+            <ResponsiveDialogFooter>
+              <Button type="button" variant="outline" onClick={() => setRenameOpen(false)}>{t('group.cancel')}</Button>
+              <Button type="submit" disabled={!renameName.trim() || renameName.trim() === groupName || renaming}>{t('group.renameSubmit')}</Button>
+            </ResponsiveDialogFooter>
+          </form>
         </ResponsiveDialogContent>
       </ResponsiveDialog>
     </aside>

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -42,6 +42,10 @@ export const api = {
     method: 'POST',
     body: JSON.stringify({ name }),
   }),
+  renameGroup: (groupId: string, name: string) => request<{ id: string; name: string }>(`/groups/${groupId}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ name }),
+  }),
   joinGroup: (token: string) => request<{ id: string; name: string; alreadyMember: boolean }>('/groups/join', {
     method: 'POST',
     body: JSON.stringify({ token }),

--- a/packages/frontend/src/pages/GroupPage.tsx
+++ b/packages/frontend/src/pages/GroupPage.tsx
@@ -26,7 +26,7 @@ export function GroupPage() {
   const { t } = useTranslation()
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
-  const { currentGroup, fetchGroup, leaveGroup, deleteGroup } = useGroupStore()
+  const { currentGroup, fetchGroup, leaveGroup, deleteGroup, renameGroup } = useGroupStore()
   const { user } = useAuthStore()
   const [commonGames, setCommonGames] = useState<{ steamAppId: number; gameId?: string; gameName: string; headerImageUrl: string; ownerCount: number; totalMembers: number; isMultiplayer: boolean | null; isCoop: boolean | null; genres: { id: string; description: string }[] | null; metacriticScore: number | null; type: string | null; shortDescription: string | null; platforms: { windows: boolean; mac: boolean; linux: boolean } | null; recommendationsTotal: number | null; releaseDate: string | null; comingSoon: boolean | null; controllerSupport: string | null; isFree: boolean | null }[]>([])
   const [syncing, setSyncing] = useState(false)
@@ -97,6 +97,10 @@ export function GroupPage() {
       toast(t('group.groupDeleted', { name: data.groupName }))
       navigate('/')
     })
+    socket.on('group:renamed', (data) => {
+      fetchGroup(id)
+      toast(t('group.groupRenamed', { name: data.newName }))
+    })
     socket.on('library:synced', () => loadCommonGames(id, activeFilter))
     socket.on('session:created', (data) => {
       // Only show join prompt to participants (or all if no participantIds — legacy)
@@ -126,6 +130,7 @@ export function GroupPage() {
       socket.off('member:left')
       socket.off('member:kicked')
       socket.off('group:deleted')
+      socket.off('group:renamed')
       socket.off('library:synced')
       socket.off('session:created')
     }
@@ -196,6 +201,17 @@ export function GroupPage() {
       navigate('/')
     } catch (err) {
       toast.error(err instanceof Error ? err.message : t('group.deleteError'))
+    }
+  }
+
+  const handleRenameGroup = async (name: string) => {
+    if (!id) return
+    try {
+      await renameGroup(id, name)
+      toast.success(t('group.renameSuccess'))
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : t('group.renameError'))
+      throw err
     }
   }
 
@@ -368,6 +384,7 @@ export function GroupPage() {
             </ResponsiveDialogHeader>
             <GroupSidebar
               members={currentGroup.members}
+              groupName={currentGroup.name}
               syncing={syncing}
               inviteToken={inviteToken}
               voteHistory={voteHistory}
@@ -379,6 +396,7 @@ export function GroupPage() {
               onLeaveGroup={handleLeaveGroup}
               onKickMember={handleKickMember}
               onDeleteGroup={handleDeleteGroup}
+              onRenameGroup={handleRenameGroup}
               compact
             />
           </ResponsiveDialogContent>

--- a/packages/frontend/src/stores/group.store.ts
+++ b/packages/frontend/src/stores/group.store.ts
@@ -11,6 +11,7 @@ interface GroupState {
   fetchGroups: () => Promise<void>
   fetchGroup: (id: string) => Promise<void>
   createGroup: (name: string) => Promise<{ id: string; inviteToken: string }>
+  renameGroup: (groupId: string, name: string) => Promise<void>
   joinGroup: (token: string) => Promise<{ id: string; name: string }>
   leaveGroup: (groupId: string, userId: string) => Promise<void>
   deleteGroup: (groupId: string) => Promise<void>
@@ -33,6 +34,13 @@ export const useGroupStore = create<GroupState>((set) => ({
   createGroup: async (name: string) => {
     const result = await api.createGroup(name)
     return { id: result.id, inviteToken: result.inviteToken }
+  },
+  renameGroup: async (groupId: string, name: string) => {
+    const result = await api.renameGroup(groupId, name)
+    set((state) => ({
+      groups: state.groups.map((g) => g.id === groupId ? { ...g, name: result.name } : g),
+      currentGroup: state.currentGroup?.id === groupId ? { ...state.currentGroup, name: result.name } : state.currentGroup,
+    }))
   },
   joinGroup: async (token: string) => {
     const result = await api.joinGroup(token)

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -169,6 +169,7 @@ export interface ServerToClientEvents {
   'member:left': (data: { groupId: string; userId: string }) => void
   'member:kicked': (data: { groupId: string; userId: string }) => void
   'group:deleted': (data: { groupId: string; groupName: string }) => void
+  'group:renamed': (data: { groupId: string; newName: string }) => void
   'library:synced': (data: { groupId: string; userId: string; gameCount: number }) => void
   'session:created': (data: { sessionId: string; groupId: string; createdBy: string; participantIds?: string[]; scheduledAt?: string }) => void
   'group:presence': (data: { onlineUserIds: string[] }) => void


### PR DESCRIPTION
## Analyse de réunion rapide

### Question posée
Le propriétaire d'un groupe doit-il pouvoir renommer celui-ci ?

### Participants
| Persona | Rôle | Position |
|---------|------|----------|
| Sarah | Product Owner | Oui, feature essentielle de qualité de vie. Pas d'unicité sur le nom. |
| Alex | Senior Backend Engineer | PATCH /groups/:id, pas de contrainte UNIQUE. Validation identique à la création. |
| Mohammed | Frontend Engineer | Dialog de renommage dans la sidebar, owner-only. Socket event pour le temps réel. |
| Didier | Tech Lead / Architect | Architecture simple, pas de migration nécessaire. Pas de sur-ingénierie. |

### Recommandation retenue
Implémenter un endpoint `PATCH /groups/:id` réservé au propriétaire, permettant de modifier le nom du groupe. **Aucune contrainte d'unicité** sur le nom — les groupes sont privés, deux groupes différents peuvent porter le même nom sans confusion.

**Justification :**
- Les noms de groupes sont des labels cosmétiques, pas des identifiants
- Forcer l'unicité créerait une friction UX injustifiée
- Le pattern owner-only est déjà bien établi dans le codebase

### Risques identifiés
- Désynchronisation temps réel → Émission d'un événement Socket.io `group:renamed` à tous les membres
- Noms invalides → Réutilisation de la même validation que la création (non-vide, max 100 chars, trim)

### Changements implémentés
- **`packages/types/src/index.ts`** — Ajout du type `group:renamed` dans `ServerToClientEvents`
- **`packages/backend/src/presentation/routes/group.routes.ts`** — Ajout de la route `PATCH /:id` avec vérification owner, validation du nom, mise à jour en BDD, et émission Socket.io
- **`packages/frontend/src/lib/api.ts`** — Ajout de la méthode `renameGroup(groupId, name)`
- **`packages/frontend/src/stores/group.store.ts`** — Ajout de l'action `renameGroup` dans le store Zustand
- **`packages/frontend/src/components/group-sidebar.tsx`** — Ajout du bouton "Renommer" (Pencil icon) et du dialog de renommage, visibles uniquement pour le propriétaire
- **`packages/frontend/src/pages/GroupPage.tsx`** — Ajout du handler `handleRenameGroup`, du listener Socket.io `group:renamed`, et passage des nouvelles props au sidebar
- **`packages/frontend/src/i18n/locales/fr.json`** et **`en.json`** — Ajout des clés i18n pour le renommage

### Prochaines étapes
- [ ] Revue de code par l'équipe
- [ ] Validation des tests
- [ ] Merge après approbation

---
_Analyse et implémentation générées automatiquement par fast-meeting avec personas IA_

🤖 Generated with [Claude Code](https://claude.com/claude-code)