### PR TITLE
feat(discord): add /wawptn-vote and /wawptn-random slash commands

### DIFF
--- a/packages/backend/src/domain/create-session.ts
+++ b/packages/backend/src/domain/create-session.ts
@@ -1,0 +1,178 @@
+import { db } from '../infrastructure/database/connection.js'
+import { computeCommonGames } from '../infrastructure/database/common-games.js'
+import { getIO } from '../infrastructure/socket/socket.js'
+import { notifySessionCreated } from '../infrastructure/discord/notifier.js'
+import { logger } from '../infrastructure/logger/logger.js'
+
+export interface CreateSessionParams {
+  groupId: string
+  createdBy: string
+  participantIds: string[]
+  filter?: string
+  scheduledAt?: Date | null
+}
+
+export interface SessionGame {
+  steamAppId: number
+  gameId?: string
+  gameName: string
+  headerImageUrl: string | null
+}
+
+export interface CreateSessionResult {
+  session: {
+    id: string
+    groupId: string
+    status: string
+    createdBy: string
+    scheduledAt: string | null
+    createdAt: string
+  }
+  games: SessionGame[]
+}
+
+/**
+ * Create a voting session for a group.
+ * Computes common games, sorts by popularity, inserts session + participants + games,
+ * emits Socket.io event, and notifies Discord webhook.
+ *
+ * Throws on validation errors (with a `statusCode` property on the error).
+ */
+export async function createVotingSession(params: CreateSessionParams): Promise<CreateSessionResult> {
+  const { groupId, createdBy, participantIds, filter, scheduledAt } = params
+
+  // Check no open session exists
+  const existingSession = await db('voting_sessions')
+    .where({ group_id: groupId, status: 'open' })
+    .first()
+
+  if (existingSession) {
+    const err = new Error('A voting session is already open') as Error & { statusCode: number; errorCode: string }
+    err.statusCode = 409
+    err.errorCode = 'conflict'
+    throw err
+  }
+
+  // Validate participantIds
+  if (participantIds.length < 2) {
+    const err = new Error('At least 2 participant IDs are required') as Error & { statusCode: number; errorCode: string }
+    err.statusCode = 400
+    err.errorCode = 'validation'
+    throw err
+  }
+
+  // Validate all participant IDs are group members
+  const validMembers = await db('group_members')
+    .where({ group_id: groupId })
+    .whereIn('user_id', participantIds)
+    .pluck('user_id')
+
+  const invalidIds = participantIds.filter(id => !validMembers.includes(id))
+  if (invalidIds.length > 0) {
+    const err = new Error('Some user IDs are not group members') as Error & { statusCode: number; errorCode: string; invalidIds: string[] }
+    err.statusCode = 422
+    err.errorCode = 'invalid_members'
+    ;(err as Error & { invalidIds: string[] }).invalidIds = invalidIds
+    throw err
+  }
+
+  // Get common games for the selected participants
+  const group = await db('groups').where({ id: groupId }).first()
+  const threshold = group?.common_game_threshold
+    ? Math.min(group.common_game_threshold, validMembers.length)
+    : validMembers.length
+
+  const commonGames = await computeCommonGames(validMembers, { filter, threshold })
+
+  if (commonGames.length === 0) {
+    const err = new Error('No common games found. Make sure all members have synced their Steam libraries and they are public.') as Error & { statusCode: number; errorCode: string }
+    err.statusCode = 422
+    err.errorCode = 'no_common_games'
+    throw err
+  }
+
+  // Order common games by popularity in previous sessions (most voted-for first)
+  const previousVoteCounts = await db('votes')
+    .join('voting_sessions', 'votes.session_id', 'voting_sessions.id')
+    .where({ 'voting_sessions.group_id': groupId, 'voting_sessions.status': 'closed', 'votes.vote': true })
+    .groupBy('votes.steam_app_id')
+    .select('votes.steam_app_id', db.raw('COUNT(*) as vote_count'))
+
+  const voteCountMap = new Map<number, number>()
+  for (const row of previousVoteCounts) {
+    voteCountMap.set(row.steam_app_id, Number(row.vote_count))
+  }
+
+  const selectedGames = commonGames.sort((a, b) => {
+    const countA = voteCountMap.get(a.steamAppId) || 0
+    const countB = voteCountMap.get(b.steamAppId) || 0
+    if (countA !== countB) return countB - countA
+    return a.gameName.localeCompare(b.gameName)
+  })
+
+  // Create session
+  const [session] = await db('voting_sessions').insert({
+    group_id: groupId,
+    status: 'open',
+    created_by: createdBy,
+    ...(scheduledAt ? { scheduled_at: scheduledAt } : {}),
+  }).returning('*')
+
+  // Insert session participants
+  await db('voting_session_participants').insert(
+    validMembers.map(uid => ({
+      session_id: session.id,
+      user_id: uid,
+    }))
+  )
+
+  // Insert session games
+  await db('voting_session_games').insert(
+    selectedGames.map(g => ({
+      session_id: session.id,
+      steam_app_id: g.steamAppId,
+      game_id: g.gameId || null,
+      game_name: g.gameName,
+      header_image_url: g.headerImageUrl,
+    }))
+  )
+
+  // Notify group (include participantIds so frontend can filter)
+  getIO().to(`group:${groupId}`).emit('session:created', {
+    sessionId: session.id,
+    groupId,
+    createdBy,
+    participantIds: validMembers,
+    ...(scheduledAt ? { scheduledAt: scheduledAt.toISOString() } : {}),
+  })
+
+  // Notify Discord channel (non-blocking)
+  notifySessionCreated(groupId, session.id, selectedGames.map(g => ({
+    gameName: g.gameName,
+    steamAppId: g.steamAppId,
+    headerImageUrl: g.headerImageUrl,
+  }))).catch(err =>
+    logger.warn({ error: String(err), groupId }, 'Discord session notification failed')
+  )
+
+  logger.info({ sessionId: session.id, groupId, gameCount: selectedGames.length, participants: validMembers.length }, 'voting session created')
+
+  const result: CreateSessionResult = {
+    session: {
+      id: session.id,
+      groupId,
+      status: 'open',
+      createdBy,
+      scheduledAt: session.scheduled_at || null,
+      createdAt: session.created_at,
+    },
+    games: selectedGames.map(g => ({
+      steamAppId: g.steamAppId,
+      gameId: g.gameId || undefined,
+      gameName: g.gameName,
+      headerImageUrl: g.headerImageUrl,
+    })),
+  }
+
+  return result
+}

--- a/packages/backend/src/presentation/routes/discord.routes.ts
+++ b/packages/backend/src/presentation/routes/discord.routes.ts
@@ -6,6 +6,7 @@ import { getIO } from '../../infrastructure/socket/socket.js'
 import { logger } from '../../infrastructure/logger/logger.js'
 import { env } from '../../config/env.js'
 import { requireAuth } from '../middleware/auth.middleware.js'
+import { createVotingSession } from '../../domain/create-session.js'
 
 const router = Router()
 
@@ -216,6 +217,128 @@ router.get('/games', async (req: Request, res: Response) => {
       ownerCount: g.ownerCount,
       totalMembers: memberIds.length,
     })),
+  })
+})
+
+// Get groups for the linked Discord user
+router.get('/groups', async (req: Request, res: Response) => {
+  const userId = req.userId
+
+  if (!userId) {
+    res.status(403).json({ error: 'forbidden', message: 'Discord account not linked. Use /wawptn-link first.' })
+    return
+  }
+
+  const groups = await db('group_members')
+    .join('groups', 'group_members.group_id', 'groups.id')
+    .where({ 'group_members.user_id': userId })
+    .select('groups.id', 'groups.name')
+
+  res.json({ groups })
+})
+
+// Start a voting session from Discord
+router.post('/vote/start', async (req: Request, res: Response) => {
+  const userId = req.userId
+
+  if (!userId) {
+    res.status(403).json({ error: 'forbidden', message: 'Discord account not linked. Use /wawptn-link first.' })
+    return
+  }
+
+  const { groupId } = req.body as { groupId: string }
+
+  if (!groupId) {
+    res.status(400).json({ error: 'validation', message: 'groupId is required' })
+    return
+  }
+
+  // Verify user is a member of this group
+  const membership = await db('group_members')
+    .where({ group_id: groupId, user_id: userId })
+    .first()
+
+  if (!membership) {
+    res.status(403).json({ error: 'forbidden', message: 'Vous n\'êtes pas membre de ce groupe' })
+    return
+  }
+
+  // Get all group members as participants
+  const memberIds = await db('group_members')
+    .where({ group_id: groupId })
+    .pluck('user_id')
+
+  try {
+    const result = await createVotingSession({
+      groupId,
+      createdBy: userId,
+      participantIds: memberIds,
+    })
+
+    res.status(201).json(result)
+  } catch (error) {
+    const err = error as Error & { statusCode?: number; errorCode?: string }
+    const status = err.statusCode || 500
+    res.status(status).json({
+      error: err.errorCode || 'internal',
+      message: err.message,
+    })
+  }
+})
+
+// Pick a random common game for a group
+router.get('/random', async (req: Request, res: Response) => {
+  const userId = req.userId
+
+  if (!userId) {
+    res.status(403).json({ error: 'forbidden', message: 'Discord account not linked. Use /wawptn-link first.' })
+    return
+  }
+
+  const groupId = req.query['groupId'] as string
+
+  if (!groupId) {
+    res.status(400).json({ error: 'validation', message: 'groupId query parameter required' })
+    return
+  }
+
+  // Verify user is a member
+  const membership = await db('group_members')
+    .where({ group_id: groupId, user_id: userId })
+    .first()
+
+  if (!membership) {
+    res.status(403).json({ error: 'forbidden', message: 'Vous n\'êtes pas membre de ce groupe' })
+    return
+  }
+
+  const group = await db('groups').where({ id: groupId }).first()
+  if (!group) {
+    res.status(404).json({ error: 'not_found', message: 'Group not found' })
+    return
+  }
+
+  const memberIds = await db('group_members')
+    .where({ group_id: groupId })
+    .pluck('user_id')
+
+  const games = await computeCommonGames(memberIds, { threshold: memberIds.length })
+
+  if (games.length === 0) {
+    res.status(422).json({ error: 'no_common_games', message: 'Aucun jeu en commun trouvé pour ce groupe.' })
+    return
+  }
+
+  const randomIndex = Math.floor(Math.random() * games.length)
+  const game = games[randomIndex]!
+
+  res.json({
+    groupName: group.name,
+    game: {
+      gameName: game.gameName,
+      steamAppId: game.steamAppId,
+      headerImageUrl: game.headerImageUrl,
+    },
   })
 })
 

--- a/packages/backend/src/presentation/routes/vote.routes.ts
+++ b/packages/backend/src/presentation/routes/vote.routes.ts
@@ -1,10 +1,8 @@
 import { Router, type Request, type Response } from 'express'
 import { db } from '../../infrastructure/database/connection.js'
-import { computeCommonGames } from '../../infrastructure/database/common-games.js'
 import { getIO } from '../../infrastructure/socket/socket.js'
 import { closeSession } from '../../domain/close-session.js'
-import { notifySessionCreated } from '../../infrastructure/discord/notifier.js'
-import { logger } from '../../infrastructure/logger/logger.js'
+import { createVotingSession } from '../../domain/create-session.js'
 
 const router = Router()
 
@@ -109,16 +107,6 @@ router.post('/:groupId/vote', async (req: Request, res: Response) => {
     return
   }
 
-  // Check no open session exists
-  const existingSession = await db('voting_sessions')
-    .where({ group_id: groupId, status: 'open' })
-    .first()
-
-  if (existingSession) {
-    res.status(409).json({ error: 'conflict', message: 'A voting session is already open' })
-    return
-  }
-
   const { filter, participantIds, scheduledAt } = req.body as { filter?: string; participantIds: string[]; scheduledAt?: string }
 
   // Validate participantIds
@@ -153,116 +141,25 @@ router.post('/:groupId/vote', async (req: Request, res: Response) => {
     return
   }
 
-  // Validate all participant IDs are group members
-  const validMembers = await db('group_members')
-    .where({ group_id: groupId })
-    .whereIn('user_id', participantIds)
-    .pluck('user_id')
-
-  const invalidIds = participantIds.filter(id => !validMembers.includes(id))
-  if (invalidIds.length > 0) {
-    res.status(422).json({ error: 'invalid_members', message: 'Some user IDs are not group members', invalidIds })
-    return
-  }
-
-  // Get common games for the selected participants
-  const group = await db('groups').where({ id: groupId }).first()
-  const threshold = group?.common_game_threshold
-    ? Math.min(group.common_game_threshold, validMembers.length)
-    : validMembers.length
-
-  const commonGames = await computeCommonGames(validMembers, { filter, threshold })
-
-  if (commonGames.length === 0) {
-    res.status(422).json({
-      error: 'no_common_games',
-      message: 'No common games found. Make sure all members have synced their Steam libraries and they are public.',
-    })
-    return
-  }
-
-  // Order common games by popularity in previous sessions (most voted-for first)
-  const previousVoteCounts = await db('votes')
-    .join('voting_sessions', 'votes.session_id', 'voting_sessions.id')
-    .where({ 'voting_sessions.group_id': groupId, 'voting_sessions.status': 'closed', 'votes.vote': true })
-    .groupBy('votes.steam_app_id')
-    .select('votes.steam_app_id', db.raw('COUNT(*) as vote_count'))
-
-  const voteCountMap = new Map<number, number>()
-  for (const row of previousVoteCounts) {
-    voteCountMap.set(row.steam_app_id, Number(row.vote_count))
-  }
-
-  const selectedGames = commonGames.sort((a, b) => {
-    const countA = voteCountMap.get(a.steamAppId) || 0
-    const countB = voteCountMap.get(b.steamAppId) || 0
-    if (countA !== countB) return countB - countA
-    return a.gameName.localeCompare(b.gameName)
-  })
-
-  // Create session
-  const [session] = await db('voting_sessions').insert({
-    group_id: groupId,
-    status: 'open',
-    created_by: userId,
-    ...(parsedScheduledAt ? { scheduled_at: parsedScheduledAt } : {}),
-  }).returning('*')
-
-  // Insert session participants
-  await db('voting_session_participants').insert(
-    validMembers.map(uid => ({
-      session_id: session.id,
-      user_id: uid,
-    }))
-  )
-
-  // Insert session games
-  await db('voting_session_games').insert(
-    selectedGames.map(g => ({
-      session_id: session.id,
-      steam_app_id: g.steamAppId,
-      game_id: g.gameId || null,
-      game_name: g.gameName,
-      header_image_url: g.headerImageUrl,
-    }))
-  )
-
-  // Notify group (include participantIds so frontend can filter)
-  getIO().to(`group:${groupId}`).emit('session:created', {
-    sessionId: session.id,
-    groupId,
-    createdBy: userId,
-    participantIds: validMembers,
-    ...(parsedScheduledAt ? { scheduledAt: parsedScheduledAt.toISOString() } : {}),
-  })
-
-  // Notify Discord channel (non-blocking)
-  notifySessionCreated(groupId, session.id, selectedGames.map(g => ({
-    gameName: g.gameName,
-    steamAppId: g.steamAppId,
-    headerImageUrl: g.headerImageUrl,
-  }))).catch(err =>
-    logger.warn({ error: String(err), groupId }, 'Discord session notification failed')
-  )
-
-  logger.info({ sessionId: session.id, groupId, gameCount: selectedGames.length, participants: validMembers.length }, 'voting session created')
-
-  res.status(201).json({
-    session: {
-      id: session.id,
+  try {
+    const result = await createVotingSession({
       groupId,
-      status: 'open',
       createdBy: userId,
-      scheduledAt: session.scheduled_at || null,
-      createdAt: session.created_at,
-    },
-    games: selectedGames.map(g => ({
-      steamAppId: g.steamAppId,
-      gameId: g.gameId || undefined,
-      gameName: g.gameName,
-      headerImageUrl: g.headerImageUrl,
-    })),
-  })
+      participantIds,
+      filter,
+      scheduledAt: parsedScheduledAt,
+    })
+
+    res.status(201).json(result)
+  } catch (error) {
+    const err = error as Error & { statusCode?: number; errorCode?: string; invalidIds?: string[] }
+    const status = err.statusCode || 500
+    res.status(status).json({
+      error: err.errorCode || 'internal',
+      message: err.message,
+      ...(err.invalidIds ? { invalidIds: err.invalidIds } : {}),
+    })
+  }
 })
 
 // Cast votes (batch: all games in one request)

--- a/packages/discord/src/commands/random.ts
+++ b/packages/discord/src/commands/random.ts
@@ -1,0 +1,48 @@
+import { SlashCommandBuilder, type ChatInputCommandInteraction } from 'discord.js'
+import { backendApi } from '../lib/api.js'
+import { resolveGroup } from '../lib/resolve-group.js'
+import { buildRandomGameEmbed } from '../lib/embeds.js'
+
+interface RandomGameResponse {
+  groupName: string
+  game: {
+    gameName: string
+    steamAppId: number
+    headerImageUrl: string | null
+  }
+}
+
+export const data = new SlashCommandBuilder()
+  .setName('wawptn-random')
+  .setDescription('Choisir un jeu au hasard parmi les jeux en commun')
+
+export async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
+  await interaction.deferReply({ ephemeral: true })
+
+  const group = await resolveGroup(interaction)
+  if (!group) return
+
+  try {
+    const result = await backendApi<RandomGameResponse>(
+      `/api/discord/random?groupId=${group.groupId}`,
+      { discordUserId: interaction.user.id },
+    )
+
+    const embed = buildRandomGameEmbed(result.game, group.groupName)
+
+    // Send the result as a public message
+    if (interaction.channel && 'send' in interaction.channel) {
+      await interaction.channel.send({ embeds: [embed] })
+    }
+
+    await interaction.editReply({
+      content: `🎲 Jeu choisi au hasard dans **${group.groupName}** !`,
+      components: [],
+    })
+  } catch (error) {
+    await interaction.editReply({
+      content: `❌ ${error instanceof Error ? error.message : 'Erreur lors du tirage au sort'}`,
+      components: [],
+    })
+  }
+}

--- a/packages/discord/src/commands/vote.ts
+++ b/packages/discord/src/commands/vote.ts
@@ -1,0 +1,56 @@
+import { SlashCommandBuilder, type ChatInputCommandInteraction } from 'discord.js'
+import { backendApi } from '../lib/api.js'
+import { resolveGroup } from '../lib/resolve-group.js'
+import { buildSessionCreatedEmbed, type SessionGame } from '../lib/embeds.js'
+
+interface VoteStartResponse {
+  session: {
+    id: string
+    groupId: string
+    status: string
+    createdBy: string
+    createdAt: string
+  }
+  games: SessionGame[]
+}
+
+export const data = new SlashCommandBuilder()
+  .setName('wawptn-vote')
+  .setDescription('Lancer une session de vote pour choisir un jeu')
+
+export async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
+  await interaction.deferReply({ ephemeral: true })
+
+  const group = await resolveGroup(interaction)
+  if (!group) return
+
+  try {
+    const result = await backendApi<VoteStartResponse>(`/api/discord/vote/start`, {
+      method: 'POST',
+      discordUserId: interaction.user.id,
+      body: { groupId: group.groupId },
+    })
+
+    const { embeds, components } = buildSessionCreatedEmbed(
+      group.groupName,
+      result.games,
+      interaction.user.displayName,
+      result.session.id,
+    )
+
+    // Send the session announcement as a public message in the channel
+    if (interaction.channel && 'send' in interaction.channel) {
+      await interaction.channel.send({ embeds, components })
+    }
+
+    await interaction.editReply({
+      content: `✅ Session de vote lancée dans **${group.groupName}** !`,
+      components: [],
+    })
+  } catch (error) {
+    await interaction.editReply({
+      content: `❌ ${error instanceof Error ? error.message : 'Erreur lors du lancement du vote'}`,
+      components: [],
+    })
+  }
+}

--- a/packages/discord/src/deploy-commands.ts
+++ b/packages/discord/src/deploy-commands.ts
@@ -3,6 +3,8 @@ import { validateEnv, env } from './env.js'
 import { data as setupCommand } from './commands/setup.js'
 import { data as linkCommand } from './commands/link.js'
 import { data as gamesCommand } from './commands/games.js'
+import { data as voteCommand } from './commands/vote.js'
+import { data as randomCommand } from './commands/random.js'
 
 validateEnv()
 
@@ -10,6 +12,8 @@ const commands = [
   setupCommand.toJSON(),
   linkCommand.toJSON(),
   gamesCommand.toJSON(),
+  voteCommand.toJSON(),
+  randomCommand.toJSON(),
 ]
 
 const rest = new REST({ version: '10' }).setToken(env.DISCORD_BOT_TOKEN)

--- a/packages/discord/src/index.ts
+++ b/packages/discord/src/index.ts
@@ -4,6 +4,8 @@ import { backendApi } from './lib/api.js'
 import * as setupCommand from './commands/setup.js'
 import * as linkCommand from './commands/link.js'
 import * as gamesCommand from './commands/games.js'
+import * as voteCommand from './commands/vote.js'
+import * as randomCommand from './commands/random.js'
 
 validateEnv()
 
@@ -15,6 +17,8 @@ const commands = new Map([
   ['wawptn-setup', setupCommand],
   ['wawptn-link', linkCommand],
   ['wawptn-games', gamesCommand],
+  ['wawptn-vote', voteCommand],
+  ['wawptn-random', randomCommand],
 ])
 
 client.once(Events.ClientReady, (c) => {

--- a/packages/discord/src/lib/embeds.ts
+++ b/packages/discord/src/lib/embeds.ts
@@ -72,6 +72,27 @@ export function buildVoteClosedEmbed(result: VoteResult, groupName: string): Emb
   return [embed]
 }
 
+export function buildRandomGameEmbed(
+  game: { gameName: string; steamAppId: number; headerImageUrl: string | null },
+  groupName: string,
+): EmbedBuilder {
+  const embed = new EmbedBuilder()
+    .setTitle('🎲 La roue a parlé !')
+    .setDescription(`Le groupe **${groupName}** va jouer à :\n\n# ${game.gameName}`)
+    .setColor(0xFEE75C)
+    .setTimestamp()
+
+  if (game.headerImageUrl) {
+    embed.setImage(game.headerImageUrl)
+  }
+
+  if (game.steamAppId) {
+    embed.setURL(`https://store.steampowered.com/app/${game.steamAppId}`)
+  }
+
+  return embed
+}
+
 export function buildLinkEmbed(linkCode: string, frontendUrl: string): EmbedBuilder[] {
   const embed = new EmbedBuilder()
     .setTitle('🔗 Lier votre compte WAWPTN')

--- a/packages/discord/src/lib/resolve-group.ts
+++ b/packages/discord/src/lib/resolve-group.ts
@@ -1,0 +1,115 @@
+import {
+  ActionRowBuilder,
+  StringSelectMenuBuilder,
+  ComponentType,
+  type ChatInputCommandInteraction,
+} from 'discord.js'
+import { backendApi } from './api.js'
+
+interface GroupOption {
+  id: string
+  name: string
+}
+
+interface GroupsResponse {
+  groups: GroupOption[]
+}
+
+/**
+ * Resolve which group to use for a command.
+ * 1. If the channel is linked to a group via /wawptn-setup, use that group.
+ * 2. Otherwise, fetch the user's groups and show a StringSelectMenu.
+ *
+ * Returns the groupId and groupName, or null if resolution failed
+ * (error already replied to the interaction).
+ */
+export async function resolveGroup(
+  interaction: ChatInputCommandInteraction,
+): Promise<{ groupId: string; groupName: string } | null> {
+  // Check if Discord user is linked
+  const status = await backendApi<{ linked: boolean }>(`/api/discord/link/status`, {
+    discordUserId: interaction.user.id,
+  })
+
+  if (!status.linked) {
+    await interaction.editReply({
+      content: '🔗 Vous devez d\'abord lier votre compte ! Utilisez la commande `/wawptn-link`.',
+    })
+    return null
+  }
+
+  // Check if the channel is linked to a group
+  try {
+    const gamesResult = await backendApi<{ groupName: string; games: unknown[] }>(
+      `/api/discord/games?channelId=${interaction.channelId}`,
+    )
+    // Channel is linked — find the groupId
+    const groupsResult = await backendApi<GroupsResponse>(`/api/discord/groups`, {
+      discordUserId: interaction.user.id,
+    })
+    const linkedGroup = groupsResult.groups.find(g => g.name === gamesResult.groupName)
+    if (linkedGroup) {
+      return { groupId: linkedGroup.id, groupName: linkedGroup.name }
+    }
+  } catch {
+    // Channel not linked — continue to group selection
+  }
+
+  // Fetch user's groups
+  const { groups } = await backendApi<GroupsResponse>(`/api/discord/groups`, {
+    discordUserId: interaction.user.id,
+  })
+
+  if (groups.length === 0) {
+    await interaction.editReply({
+      content: '😕 Vous n\'êtes membre d\'aucun groupe WAWPTN.',
+    })
+    return null
+  }
+
+  // If only one group, auto-select
+  if (groups.length === 1) {
+    return { groupId: groups[0]!.id, groupName: groups[0]!.name }
+  }
+
+  // Show a StringSelectMenu for group selection
+  const selectMenu = new StringSelectMenuBuilder()
+    .setCustomId('select-group')
+    .setPlaceholder('Choisissez un groupe...')
+    .addOptions(
+      groups.slice(0, 25).map(g => ({
+        label: g.name,
+        value: g.id,
+      })),
+    )
+
+  const row = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(selectMenu)
+
+  const reply = await interaction.editReply({
+    content: '🎮 Dans quel groupe ?',
+    components: [row],
+  })
+
+  try {
+    const menuInteraction = await reply.awaitMessageComponent({
+      componentType: ComponentType.StringSelect,
+      time: 60_000,
+    })
+
+    const selectedGroupId = menuInteraction.values[0]!
+    const selectedGroup = groups.find(g => g.id === selectedGroupId)!
+
+    await menuInteraction.update({
+      content: `✅ Groupe sélectionné : **${selectedGroup.name}**`,
+      components: [],
+    })
+
+    return { groupId: selectedGroupId, groupName: selectedGroup.name }
+  } catch {
+    await interaction.editReply({
+      content: '⏳ Temps écoulé. Relancez la commande.',
+      components: [],
+    })
+    return null
+  }
+}


### PR DESCRIPTION
## Résumé technique

### Contexte
Le bot Discord existant ne permettait pas de lancer un vote ou de tirer un jeu au sort directement depuis un canal Discord. Les utilisateurs devaient passer par l'interface web pour créer une session de vote.

### Approche retenue
Ajout de deux nouvelles commandes slash avec résolution automatique du groupe :
- **Canal lié** (via `/wawptn-setup`) → le groupe est utilisé automatiquement, zéro friction
- **Canal non lié** → `StringSelectMenu` (dropdown Discord) listant les groupes de l'utilisateur
- **Un seul groupe** → auto-sélection sans interaction supplémentaire

Pattern `StringSelectMenu` choisi plutôt qu'autocomplete car les utilisateurs ont typiquement 2-5 groupes (pas besoin de taper/chercher).

Extraction de la logique de création de session dans un service domaine partagé (`create-session.ts`) pour éviter la duplication entre les routes web et Discord — même pattern que `close-session.ts` existant.

### Changements implémentés
| Fichier | Modification | Justification technique |
|---------|-------------|------------------------|
| `packages/backend/src/domain/create-session.ts` | Nouveau service domaine pour la création de session | Éviter la duplication de 167 lignes entre web et Discord routes |
| `packages/backend/src/presentation/routes/vote.routes.ts` | Refactoring pour utiliser `createVotingSession()` | Le route handler ne fait plus que validation d'entrée + délégation |
| `packages/backend/src/presentation/routes/discord.routes.ts` | 3 nouveaux endpoints : `GET /groups`, `POST /vote/start`, `GET /random` | API bot-authentifiée pour les nouvelles commandes |
| `packages/discord/src/commands/vote.ts` | Commande `/wawptn-vote` | Lance un vote avec tous les membres du groupe |
| `packages/discord/src/commands/random.ts` | Commande `/wawptn-random` | Tire un jeu au hasard parmi les jeux en commun |
| `packages/discord/src/lib/resolve-group.ts` | Helper partagé de résolution de groupe | Logique canal-lié → auto / sinon → dropdown, réutilisé par les 2 commandes |
| `packages/discord/src/lib/embeds.ts` | Nouvel embed `buildRandomGameEmbed` | Affichage du jeu tiré au sort avec image + lien Steam |
| `packages/discord/src/index.ts` | Enregistrement des 2 nouvelles commandes | Map de commandes mise à jour |
| `packages/discord/src/deploy-commands.ts` | Ajout des commandes au déploiement | Enregistrement auprès de l'API Discord |

### Points d'attention pour la revue
- La commande `/wawptn-vote` inclut **tous les membres du groupe** comme participants (pas de sélection individuelle côté Discord — simplification volontaire)
- Le message de sélection de groupe est **éphémère** (privé), le résultat (vote/random) est **public** dans le canal
- Le `StringSelectMenu` a un timeout de 60 secondes avec message de cleanup
- Après merge, il faut exécuter `npm run deploy-commands -w @wawptn/discord` pour enregistrer les nouvelles commandes auprès de Discord

### Tests
- Type-check passé sur les 3 packages (types, backend, discord)
- Lint passé via pre-commit hook
- Pas de suite de tests automatisée pour le package discord

### Prochaines étapes
- [ ] Revue de code par l'équipe
- [ ] Exécuter `npm run deploy-commands` après déploiement
- [ ] Validation manuelle sur un serveur Discord de test

---
_Implémentation générée automatiquement par IA 🤖_
_Version : fast-meeting v1.1.0_