### PR TITLE
refactor(ci): drop arm64 build to speed up release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,9 +123,6 @@ jobs:
           git commit -m "chore: bump version to ${{ steps.version.outputs.new_version }}"
           git tag -fa "v${{ steps.version.outputs.new_version }}" -m "Release v${{ steps.version.outputs.new_version }}"
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -161,7 +158,8 @@ jobs:
             VCS_REF=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
-          platforms: linux/amd64,linux/arm64
+          # amd64-only: production target is x86_64. Re-add arm64 with native runners if needed.
+          platforms: linux/amd64
 
       - name: Push changes to repository
         env:


### PR DESCRIPTION
## Résumé technique

### Contexte
Le pipeline de release met ~8.5 minutes, dont **443s (90%)** sur le build Docker multi-plateforme. L'émulation QEMU pour arm64 sur les runners GitHub amd64 est le bottleneck identifié. Le serveur de production (battistella.ovh) est exclusivement amd64 — aucun consommateur arm64 connu.

### Approche retenue
Suppression du build arm64 et du step QEMU du pipeline CI. Décision issue d'un fast-meeting avec 3 personas (DevOps, Architect, Backend) : consensus 2/3 pour la suppression pure et simple (YAGNI), 1/3 proposait des runners ARM natifs (rejeté comme sur-ingénierie pour un projet hobby).

### Changements implémentés
| Fichier | Modification | Justification technique |
|---------|-------------|------------------------|
| `.github/workflows/release.yml` | Suppression du step `Set up QEMU` | Plus nécessaire sans build cross-platform |
| `.github/workflows/release.yml` | `platforms: linux/amd64` (était `linux/amd64,linux/arm64`) | Cible de déploiement = amd64 uniquement |

### Points d'attention pour la revue
- Si arm64 est nécessaire à l'avenir, réactiver avec des runners ARM natifs (`ubuntu-24.04-arm`) plutôt que QEMU — changement trivial d'une ligne
- Le GHA cache (`cache-from/cache-to: type=gha`) reste en place pour le build amd64
- Aucun impact sur le Dockerfile ni sur le compose.yml de production

### Tests
- Pas de suite de tests automatisés impactée (changement CI uniquement)
- Validation attendue : le prochain run du pipeline devrait passer de ~8.5min à ~3-4min

### Prochaines étapes
- [ ] Revue de code par l'équipe
- [ ] Vérifier le temps de build après merge (objectif : < 4 min)
- [ ] Merge après approbation

---
_Implémentation générée automatiquement par IA 🤖_
_Version : fast-meeting v1.1.0_