### PR TITLE
feat(ci): replace Watchtower with SSH deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,3 +170,11 @@ jobs:
           body_path: ${{ steps.changelog.outputs.changelog_file }}
           draft: false
           prerelease: false
+
+      - name: Deploy to production
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: deploy
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script: /home/deploy/deploy-wawptn.sh

--- a/compose.yml
+++ b/compose.yml
@@ -35,7 +35,6 @@ services:
       - "traefik.http.routers.wawptn.tls=true"
       - "traefik.http.routers.wawptn.tls.certresolver=letsencrypt"
       - "traefik.http.services.wawptn.loadBalancer.server.port=8080"
-      - com.centurylinklabs.watchtower.enable=true
     security_opt:
       - no-new-privileges:true
     cap_drop:

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# deploy.sh — Restricted deploy script for WAWPTN
+# This script is called by GitHub Actions via SSH (command= restricted key).
+# It pulls the latest Docker images and restarts app services.
+# Postgres is intentionally excluded — never restart the database from CI.
+
+set -eu
+
+COMPOSE_DIR="${WAWPTN_COMPOSE_DIR:-/opt/wawptn}"
+
+echo "[deploy] Pulling latest images..."
+docker compose -f "$COMPOSE_DIR/compose.yml" pull wawptn wawptn-discord
+
+echo "[deploy] Restarting services..."
+docker compose -f "$COMPOSE_DIR/compose.yml" up -d wawptn wawptn-discord
+
+echo "[deploy] Cleaning up old images..."
+docker image prune -f
+
+echo "[deploy] Done."


### PR DESCRIPTION
## Résumé technique

### Contexte
Watchtower effectuait un polling horaire vers Docker Hub pour détecter les nouvelles images. Ce mécanisme introduit un délai de 0 à 60 minutes entre le push d'une image et sa mise en production, sans audit trail ni garantie d'absence de race condition (le pull peut commencer avant que l'image soit propagée sur le CDN du registry).

### Approche retenue
**GitHub Actions SSH deploy** avec restriction `command=` dans `authorized_keys`.

Alternatives considérées et rejetées :
- **Webhook receiver (`adnanh/webhook`)** : nécessite un conteneur supplémentaire avec accès Docker socket (root-equivalent) + Docker CLI — complexité disproportionnée pour un seul serveur
- **Docker Hub webhooks** : aucune authentification cryptographique (pas de HMAC), donc impossible de valider l'origine de la requête
- **Watchtower à intervalle réduit (30s)** : reste du polling, consomme des appels Docker Hub, aucun audit trail

La restriction `command=` dans `authorized_keys` limite le blast radius : même en cas de compromission de la clé SSH GitHub, l'attaquant ne peut exécuter que le script de déploiement, pas obtenir un shell.

### Changements implémentés
| Fichier | Modification | Justification technique |
|---------|-------------|------------------------|
| `.github/workflows/release.yml` | Ajout step `Deploy to production` via `appleboy/ssh-action@v1` | Déclenche le déploiement immédiatement après le push Docker, dans le même workflow — audit trail complet |
| `compose.yml` | Suppression du label `com.centurylinklabs.watchtower.enable=true` | Watchtower n'est plus nécessaire, deux mécanismes de mise à jour en parallèle serait un confused-deputy |
| `deploy/deploy.sh` | Nouveau script de déploiement restreint | Pull uniquement `wawptn` et `wawptn-discord` (jamais postgres), nettoyage des images orphelines |

### Configuration requise (côté serveur)

Deux secrets GitHub à configurer : `DEPLOY_HOST` et `DEPLOY_SSH_KEY`.

Sur le serveur de production, créer un utilisateur `deploy` avec clé SSH restreinte :
```bash
# Générer la clé
ssh-keygen -t ed25519 -f deploy_key -N "" -C "github-actions-deploy"

# Configurer authorized_keys avec restriction command=
echo 'command="/home/deploy/deploy-wawptn.sh",no-port-forwarding,no-agent-forwarding,no-pty ssh-ed25519 AAAA...' >> /home/deploy/.ssh/authorized_keys

# Copier le script de déploiement
cp deploy/deploy.sh /home/deploy/deploy-wawptn.sh
chmod +x /home/deploy/deploy-wawptn.sh

# Ajouter deploy au groupe docker
usermod -aG docker deploy
```

### Points d'attention pour la revue
- Le step SSH s'exécute **après** `Create GitHub Release` — si le release échoue, le deploy n'est pas déclenché
- Le script ne touche jamais postgres — seuls `wawptn` et `wawptn-discord` sont redémarrés
- `docker compose up -d` respecte le `depends_on: condition: service_healthy` existant — le bot discord attend que l'app soit healthy
- La variable `WAWPTN_COMPOSE_DIR` dans le script permet de configurer le chemin du compose.yml (défaut: `/opt/wawptn`)

### Tests
- Pas de test automatisé applicable (changements CI/CD et configuration)
- Validation manuelle requise après merge : configurer les secrets GitHub et vérifier le déclenchement du pipeline

### Prochaines étapes
- [ ] Configurer `DEPLOY_HOST` et `DEPLOY_SSH_KEY` dans les secrets GitHub
- [ ] Créer l'utilisateur `deploy` sur le serveur avec `command=` restriction
- [ ] Revue de code par l'équipe
- [ ] Merge après approbation
- [ ] Arrêter/supprimer Watchtower du serveur

---
_Implémentation générée automatiquement par IA 🤖_
_Version : fast-meeting v1.1.0_