### PR TITLE
fix(discord): redirect bare /discord/link URL and add 404 page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wawptn",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wawptn",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "workspaces": [
         "packages/*"
       ],
@@ -13538,7 +13538,7 @@
     },
     "packages/backend": {
       "name": "@wawptn/backend",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "dependencies": {
         "@wawptn/types": "*",
         "cookie-parser": "^1.4.7",
@@ -13574,7 +13574,7 @@
     },
     "packages/discord": {
       "name": "@wawptn/discord",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "dependencies": {
         "@wawptn/types": "*",
         "discord.js": "^14.18.0",
@@ -13588,7 +13588,7 @@
     },
     "packages/frontend": {
       "name": "@wawptn/frontend",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "dependencies": {
         "@radix-ui/react-avatar": "^1.1.11",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -13659,7 +13659,7 @@
     },
     "packages/types": {
       "name": "@wawptn/types",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "devDependencies": {
         "typescript": "^5.9.3"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wawptn",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "private": true,
   "description": "What Are We Playing Tonight? — Help your friend group decide what game to play together.",
   "workspaces": [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wawptn/backend",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Backend API for WAWPTN",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -101,6 +101,12 @@ async function main() {
     app.use('/api/discord', requireBotAuth, discordRoutes)
   }
 
+  // Redirect bare /discord/link to SPA hash route (for Discord bot URLs without /#/)
+  app.get('/discord/link', (req, res) => {
+    const qs = new URLSearchParams(req.query as Record<string, string>).toString()
+    res.redirect(302, `${env.CORS_ORIGIN}/#/discord/link${qs ? `?${qs}` : ''}`)
+  })
+
   // Invite preview route (public, no auth) — serves OG meta tags for Discord/social embeds
   // Must be registered BEFORE the SPA catch-all so it is matched first
   const inviteLimiter = rateLimit({

--- a/packages/discord/package.json
+++ b/packages/discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wawptn/discord",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Discord bot for WAWPTN — vote on games directly in Discord",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wawptn/frontend",
   "private": true,
-  "version": "0.10.2",
+  "version": "0.10.3",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { Routes, Route, Navigate } from 'react-router-dom'
+import { Routes, Route } from 'react-router-dom'
 import { useAuthStore } from '@/stores/auth.store'
 import { connectSocket, disconnectSocket } from '@/lib/socket'
 import { LoginPage } from '@/pages/LoginPage'
@@ -9,6 +9,7 @@ import { VotePage } from '@/pages/VotePage'
 import { JoinPage } from '@/pages/JoinPage'
 import { ProfilePage } from '@/pages/ProfilePage'
 import { DiscordLinkPage } from '@/pages/DiscordLinkPage'
+import { NotFoundPage } from '@/pages/NotFoundPage'
 import { Skeleton } from '@/components/ui/skeleton'
 import { DialogTestPage } from '@/pages/DialogTestPage'
 
@@ -52,7 +53,7 @@ function App() {
         <Route path="/login" element={<LoginPage />} />
         <Route path="/join/:token" element={<JoinPage />} />
         <Route path="/discord/link" element={<DiscordLinkPage />} />
-        <Route path="*" element={<Navigate to="/login" replace />} />
+        <Route path="*" element={<NotFoundPage />} />
       </Routes>
     )
   }
@@ -65,7 +66,7 @@ function App() {
       <Route path="/groups/:id/vote" element={<VotePage />} />
       <Route path="/join/:token" element={<JoinPage />} />
       <Route path="/discord/link" element={<DiscordLinkPage />} />
-      <Route path="*" element={<Navigate to="/" replace />} />
+      <Route path="*" element={<NotFoundPage />} />
     </Routes>
   )
 }

--- a/packages/frontend/src/i18n/locales/en.json
+++ b/packages/frontend/src/i18n/locales/en.json
@@ -210,6 +210,11 @@
     "noCode": "No link code found in the URL.",
     "goHome": "Back to home"
   },
+  "notFound": {
+    "title": "Page not found",
+    "description": "The page you are looking for does not exist or has been moved.",
+    "backHome": "Back to home"
+  },
   "profile": {
     "title": "My Profile",
     "platforms": "Connected Platforms",

--- a/packages/frontend/src/i18n/locales/fr.json
+++ b/packages/frontend/src/i18n/locales/fr.json
@@ -210,6 +210,11 @@
     "noCode": "Aucun code de liaison trouvé dans l'URL.",
     "goHome": "Retour à l'accueil"
   },
+  "notFound": {
+    "title": "Page introuvable",
+    "description": "La page que tu cherches n'existe pas ou a été déplacée.",
+    "backHome": "Retour à l'accueil"
+  },
   "profile": {
     "title": "Mon Profil",
     "platforms": "Plateformes connectées",

--- a/packages/frontend/src/pages/NotFoundPage.tsx
+++ b/packages/frontend/src/pages/NotFoundPage.tsx
@@ -1,0 +1,18 @@
+import { useNavigate } from 'react-router-dom'
+import { SearchX } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { Button } from '@/components/ui/button'
+
+export function NotFoundPage() {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center px-4">
+      <SearchX className="w-12 h-12 text-muted-foreground mb-4" />
+      <h1 className="text-2xl font-bold mb-2">{t('notFound.title')}</h1>
+      <p className="text-muted-foreground mb-6">{t('notFound.description')}</p>
+      <Button onClick={() => navigate('/')}>{t('notFound.backHome')}</Button>
+    </div>
+  )
+}

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wawptn/types",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Shared TypeScript types for WAWPTN",
   "main": "./dist/index.js",
   "module": "./dist/index.js",


### PR DESCRIPTION
## Résumé technique

### Contexte
L'URL `/discord/link?code=XXXX` envoyée par le bot Discord retourne une page blanche (redirect silencieux) car le frontend utilise `HashRouter` — les routes nécessitent le préfixe `/#/`. De plus, aucune page 404 dédiée n'existe : les routes inconnues redirigent silencieusement vers `/login` ou `/`.

### Approche retenue
Ajout d'un redirect serveur 302 ciblé plutôt qu'une migration vers `BrowserRouter`. Cette approche a été préférée car :
- Blast radius minimal (0 modification des 20+ redirects auth Steam/Epic/GOG)
- Pattern cohérent avec la route `/invite/:token` déjà existante côté serveur
- Changements additifs et déployables indépendamment
- La migration BrowserRouter reste une option future mais mérite son propre ticket avec QA dédiée

### Changements implémentés
| Fichier | Modification | Justification technique |
|---------|-------------|------------------------|
| `packages/backend/src/index.ts` | Ajout d'un `app.get('/discord/link')` qui 302-redirige vers `/#/discord/link` avec query params | Adapter pattern : les URLs externes (bot Discord) sont traduites vers le format HashRouter |
| `packages/frontend/src/pages/NotFoundPage.tsx` | Nouveau composant 404 avec i18n (FR/EN) | Feedback utilisateur explicite au lieu d'une redirection silencieuse |
| `packages/frontend/src/App.tsx` | Remplacement des `<Navigate>` catch-all par `<NotFoundPage />` | Les routes inconnues affichent désormais une page 404 propre |
| `packages/frontend/src/i18n/locales/fr.json` | Ajout des clés `notFound.*` | Traductions françaises pour la page 404 |
| `packages/frontend/src/i18n/locales/en.json` | Ajout des clés `notFound.*` | Traductions anglaises pour la page 404 |

### Points d'attention pour la revue
- Le redirect utilise `URLSearchParams` pour sérialiser les query params proprement (pas de risque d'encoding)
- Le redirect est un 302 (pas 301) pour pouvoir le retirer sans cache stale si migration BrowserRouter future
- L'import `Navigate` a été retiré de `App.tsx` car il n'est plus utilisé

### Tests
- Type-check frontend : OK (0 erreurs)
- Lint : OK (2 warnings pré-existants non liés)
- Pas de suite de tests E2E automatisée disponible localement

### Prochaines étapes
- [ ] Revue de code par l'équipe
- [ ] Validation manuelle : naviguer vers `/discord/link?code=TEST` sans `/#/` et vérifier le redirect
- [ ] Validation manuelle : naviguer vers une URL inexistante et vérifier la page 404
- [ ] Merge après approbation

---
_Implémentation générée automatiquement par IA 🤖_
_Version : fast-meeting v1.1.0_