### PR TITLE
fix(backend): race condition on invite join, expired link codes, and gameCount

### DIFF
--- a/packages/backend/src/infrastructure/scheduler/vote-scheduler.ts
+++ b/packages/backend/src/infrastructure/scheduler/vote-scheduler.ts
@@ -24,5 +24,17 @@ export function startVoteScheduler(): void {
     }
   })
 
+  // Clean up expired Discord link codes every 5 minutes
+  cron.schedule('*/5 * * * *', async () => {
+    try {
+      const deleted = await db('discord_link_codes').where('expires_at', '<', db.fn.now()).del()
+      if (deleted > 0) {
+        schedulerLogger.info({ deleted }, 'cleaned up expired Discord link codes')
+      }
+    } catch (err) {
+      schedulerLogger.error({ error: String(err) }, 'Discord link code cleanup failed')
+    }
+  })
+
   schedulerLogger.info('vote scheduler started (polling every 15s)')
 }

--- a/packages/backend/src/presentation/routes/auth.routes.ts
+++ b/packages/backend/src/presentation/routes/auth.routes.ts
@@ -723,11 +723,11 @@ router.post('/gog/sync', requireAuth, async (req: Request, res: Response) => {
 // ─── Background Library Sync ────────────────────────────────────────
 
 // Background Epic library sync
-async function syncEpicLibrary(userId: string): Promise<void> {
+async function syncEpicLibrary(userId: string): Promise<number> {
   const games = await getEpicOwnedGames(userId)
   if (!games || games.length === 0) {
     epicLogger.warn({ userId }, 'no Epic games returned or token issue')
-    return
+    return 0
   }
 
   const now = new Date()
@@ -780,20 +780,21 @@ async function syncEpicLibrary(userId: string): Promise<void> {
   }
 
   epicLogger.info({ userId, gameCount: games.length }, 'Epic library synced')
+  return games.length
 }
 
 // Background Steam library sync
-async function syncUserLibrary(userId: string, steamId: string): Promise<void> {
+async function syncUserLibrary(userId: string, steamId: string): Promise<number> {
   const games = await getOwnedGames(steamId)
   if (!games) {
     await db('users').where({ id: userId }).update({ library_visible: false })
-    return
+    return 0
   }
 
   if (games.length === 0) {
     steamLogger.warn({ steamId }, 'no games returned — profile may be private')
     await db('users').where({ id: userId }).update({ library_visible: false })
-    return
+    return 0
   }
 
   // Upsert all games
@@ -844,14 +845,15 @@ async function syncUserLibrary(userId: string, steamId: string): Promise<void> {
 
   await db('users').where({ id: userId }).update({ library_visible: true, updated_at: now })
   steamLogger.info({ userId, steamId, gameCount: games.length }, 'library synced')
+  return games.length
 }
 
 // Background GOG library sync
-async function syncGogLibrary(userId: string): Promise<void> {
+async function syncGogLibrary(userId: string): Promise<number> {
   const games = await getGogOwnedGames(userId)
   if (!games || games.length === 0) {
     gogLogger.warn({ userId }, 'no GOG games returned or token issue')
-    return
+    return 0
   }
 
   const now = new Date()
@@ -902,6 +904,7 @@ async function syncGogLibrary(userId: string): Promise<void> {
   }
 
   gogLogger.info({ userId, gameCount: games.length }, 'GOG library synced')
+  return games.length
 }
 
 export { router as authRoutes, syncUserLibrary, syncEpicLibrary, syncGogLibrary }

--- a/packages/backend/src/presentation/routes/group.routes.ts
+++ b/packages/backend/src/presentation/routes/group.routes.ts
@@ -255,12 +255,7 @@ router.post('/join', async (req: Request, res: Response) => {
     return
   }
 
-  if (group.invite_use_count >= group.invite_max_uses) {
-    res.status(410).json({ error: 'expired', message: 'This invite link has reached its maximum uses' })
-    return
-  }
-
-  // Check if already a member
+  // Check if already a member (before claiming an invite use)
   const existing = await db('group_members')
     .where({ group_id: group.id, user_id: userId })
     .first()
@@ -270,15 +265,28 @@ router.post('/join', async (req: Request, res: Response) => {
     return
   }
 
-  // Add member
-  await db('group_members').insert({
-    group_id: group.id,
-    user_id: userId,
-    role: 'member',
+  // Atomic: claim an invite use and add member in a single transaction (race-safe)
+  const joined = await db.transaction(async (trx) => {
+    const claimed = await trx('groups')
+      .where({ id: group.id })
+      .whereRaw('invite_use_count < invite_max_uses')
+      .increment('invite_use_count', 1)
+
+    if (claimed === 0) return false
+
+    await trx('group_members').insert({
+      group_id: group.id,
+      user_id: userId,
+      role: 'member',
+    })
+
+    return true
   })
 
-  // Increment use count
-  await db('groups').where({ id: group.id }).increment('invite_use_count', 1)
+  if (!joined) {
+    res.status(410).json({ error: 'expired', message: 'This invite link has reached its maximum uses' })
+    return
+  }
 
   // Notify group via Socket.io
   const user = await db('users').where({ id: userId }).first()
@@ -524,20 +532,20 @@ router.post('/:id/sync', async (req: Request, res: Response) => {
     .where('status', 'active')
     .select('user_id', 'provider_id')
 
-  const emitSynced = (memberId: string) => {
+  const emitSynced = (memberId: string, gameCount: number) => {
     const io = getIO()
     io.to(`group:${groupId}`).emit('library:synced', {
       groupId,
       userId: memberId,
-      gameCount: 0, // will be updated
+      gameCount,
     })
   }
 
   // Sync in background, one at a time (rate limited)
   for (const member of members) {
     // Steam sync
-    syncUserLibrary(member.id, member.steam_id).then(() => {
-      emitSynced(member.id)
+    syncUserLibrary(member.id, member.steam_id).then((count) => {
+      emitSynced(member.id, count)
     }).catch(err => {
       logger.error({ error: String(err), userId: member.id }, 'Steam sync failed for member')
     })
@@ -545,8 +553,8 @@ router.post('/:id/sync', async (req: Request, res: Response) => {
     // Epic sync (if linked)
     const hasEpic = linkedAccounts.some((a: { user_id: string; provider_id: string }) => a.user_id === member.id && a.provider_id === 'epic')
     if (hasEpic) {
-      syncEpicLibrary(member.id).then(() => {
-        emitSynced(member.id)
+      syncEpicLibrary(member.id).then((count) => {
+        emitSynced(member.id, count)
       }).catch(err => {
         logger.error({ error: String(err), userId: member.id }, 'Epic sync failed for member')
       })
@@ -555,8 +563,8 @@ router.post('/:id/sync', async (req: Request, res: Response) => {
     // GOG sync (if linked)
     const hasGog = linkedAccounts.some((a: { user_id: string; provider_id: string }) => a.user_id === member.id && a.provider_id === 'gog')
     if (hasGog) {
-      syncGogLibrary(member.id).then(() => {
-        emitSynced(member.id)
+      syncGogLibrary(member.id).then((count) => {
+        emitSynced(member.id, count)
       }).catch(err => {
         logger.error({ error: String(err), userId: member.id }, 'GOG sync failed for member')
       })


### PR DESCRIPTION
## Résumé technique

### Contexte
Audit de code approfondi ayant identifié 3 bugs vérifiés dans le backend. La plupart des "bugs" détectés par l'analyse initiale étaient des faux positifs — seuls les bugs confirmés par lecture du code source sont corrigés ici.

### Approche retenue
Corrections chirurgicales sur 3 fichiers, sans changement d'architecture. Chaque fix est isolé et testable indépendamment.

### Changements implémentés
| Fichier | Modification | Justification technique |
|---------|-------------|------------------------|
| `packages/backend/src/presentation/routes/group.routes.ts` | Race condition invite join : remplacement du check-then-increment par un UPDATE atomique dans une transaction | TOCTOU classique — deux joins concurrents pouvaient dépasser `invite_max_uses`. L'UPDATE conditionnel `WHERE invite_use_count < invite_max_uses` + INSERT dans une transaction élimine la fenêtre de race |
| `packages/backend/src/presentation/routes/group.routes.ts` | `emitSynced` accepte maintenant le vrai `gameCount` au lieu de `0` hardcodé | Le type `library:synced` déclare `gameCount: number` — le contrat était violé. Le frontend ignore la valeur mais le Discord bot ou futurs consumers pourraient l'utiliser |
| `packages/backend/src/presentation/routes/auth.routes.ts` | `syncUserLibrary`, `syncEpicLibrary`, `syncGogLibrary` retournent `Promise<number>` (nombre de jeux synchronisés) | Permet à `emitSynced` de transmettre la vraie valeur. Changement rétrocompatible — les appelants existants utilisent `.catch()` sans `.then()` |
| `packages/backend/src/infrastructure/scheduler/vote-scheduler.ts` | Ajout d'un cron job toutes les 5 minutes pour supprimer les `discord_link_codes` expirés | La table accumulait des lignes expirées indéfiniment. DELETE idempotent avec WHERE sur `expires_at` |

### Points d'attention pour la revue
- L'UPDATE atomique utilise `whereRaw('invite_use_count < invite_max_uses')` — vérifier que Knex retourne bien le nombre de lignes affectées (confirmé pour Knex 3.x + PostgreSQL)
- Le check "already a member" est déplacé AVANT la transaction pour éviter de brûler un usage d'invite pour un membre existant
- Le changement de return type `Promise<void>` → `Promise<number>` est rétrocompatible — les `.catch()` existants ne sont pas affectés
- Le cron de cleanup tourne toutes les 5 minutes (pas toutes les 15 secondes comme le vote scheduler) pour ne pas surcharger la DB

### Tests
- Pas de suite de tests automatisée détectée
- Validation manuelle recommandée : tester le join concurrent avec deux requêtes simultanées sur un invite avec `max_uses = 1`

### Prochaines étapes
- [ ] Revue de code par l'équipe
- [ ] Test du join concurrent en staging
- [ ] Vérifier le log de cleanup des link codes après déploiement
- [ ] Merge après approbation

---
_Implémentation générée automatiquement par IA 🤖_
_Version : fast-meeting v1.1.0_