### PR TITLE
refactor(bot): unify bot persona voice across all touchpoints

### DIFF
--- a/packages/backend/src/infrastructure/llm/client.ts
+++ b/packages/backend/src/infrastructure/llm/client.ts
@@ -11,6 +11,7 @@ Ta personnalité :
 - Tu taquines gentiment ceux qui traînent à se décider
 - Tu restes concis (2-3 phrases max sauf si on te demande plus de détails)
 - Tu parles normalement, comme un pote, sans abuser du jargon gamer
+- Tu ne fais JAMAIS référence au fait que tu es un bot, un algorithme ou un programme. Tu parles comme un pote dans le groupe, pas comme une IA qui se sait être une IA
 - Quand quelqu'un a un vrai problème technique, tu laisses tomber le sarcasme et tu aides directement
 
 Ce que tu sais faire :

--- a/packages/discord/src/index.ts
+++ b/packages/discord/src/index.ts
@@ -137,7 +137,7 @@ client.on(Events.MessageCreate, async (message: Message) => {
 
   // If empty after stripping mention, send a hint
   if (!cleanContent) {
-    await message.reply('Yo ! Tu voulais me dire quelque chose ? Pose-moi une question sur tes jeux ou ton groupe !')
+    await message.reply('Hé ! Tu voulais me dire quelque chose ? Pose-moi une question sur tes jeux ou ton groupe !')
     return
   }
 
@@ -162,7 +162,7 @@ client.on(Events.MessageCreate, async (message: Message) => {
 
     // Rate limited
     if (errorMessage.includes('trop de questions') || errorMessage.includes('rate')) {
-      await message.reply('Doucement ! Je suis rapide mais pas infini. Réessaie dans quelques minutes.')
+      await message.reply('Doucement ! Laisse-moi respirer deux secondes. Réessaie dans quelques minutes.')
       return
     }
 
@@ -171,7 +171,7 @@ client.on(Events.MessageCreate, async (message: Message) => {
       return // Silently ignore if LLM is not set up
     }
 
-    await message.reply('Oups, mon cerveau a bugué. Réessaie dans un instant !')
+    await message.reply('Oups, j\'ai perdu le fil. Réessaie dans un instant !')
     console.error('[chat] Error handling message:', error)
   }
 })

--- a/packages/discord/src/lib/embeds.ts
+++ b/packages/discord/src/lib/embeds.ts
@@ -20,8 +20,8 @@ export function buildSessionCreatedEmbed(
     .join('\n')
 
   const embed = new EmbedBuilder()
-    .setTitle('⚔️ Alerte frag — vote lancé !')
-    .setDescription(`**${creatorName}** a lancé un vote dans le groupe **${groupName}**.\n\nVotez 👍 ou 👎 sur chaque jeu. Pas de camping, on tranche ce soir !\n\n${gameList}`)
+    .setTitle('🗳️ Vote lancé !')
+    .setDescription(`**${creatorName}** a lancé un vote dans le groupe **${groupName}**.\n\nVotez 👍 ou 👎 sur chaque jeu. Faut se décider ce soir !\n\n${gameList}`)
     .setColor(0x5865F2)
     .setTimestamp()
 
@@ -52,7 +52,7 @@ export function buildSessionCreatedEmbed(
 
 export function buildVoteClosedEmbed(result: VoteResult, groupName: string): EmbedBuilder[] {
   const embed = new EmbedBuilder()
-    .setTitle('🏆 GG — le clan a tranché !')
+    .setTitle('🏆 Le groupe a choisi !')
     .setDescription(`Le groupe **${groupName}** a choisi :\n\n# ${result.gameName}`)
     .addFields(
       { name: 'Votes pour', value: `${result.yesCount}`, inline: true },
@@ -77,7 +77,7 @@ export function buildRandomGameEmbed(
   groupName: string,
 ): EmbedBuilder {
   const embed = new EmbedBuilder()
-    .setTitle('🎲 Random pick — la RNG a parlé !')
+    .setTitle('🎲 Au hasard !')
     .setDescription(`Le groupe **${groupName}** va jouer à :\n\n# ${game.gameName}`)
     .setColor(0xFEE75C)
     .setTimestamp()

--- a/packages/discord/src/scheduler.ts
+++ b/packages/discord/src/scheduler.ts
@@ -4,40 +4,44 @@ import { getLinkedChannels } from './lib/api.js'
 
 // ─── Message pools ────────────────────────────────────────────────────────────
 
+// Voix du bot : pote sarcastique et bienveillant, français décontracté.
+// Pas de référence robot/algorithme/capteurs. Pas de jargon gamer anglicisé.
+// Voir aussi : packages/backend/src/infrastructure/llm/client.ts (SYSTEM_PROMPT)
+
 const FRIDAY_MESSAGES = [
   "C'est vendredi soir ! Qui ose prétendre qu'il a mieux à faire ? `/wawptn-vote`",
-  "Bip boop. Analyse en cours... Résultat : c'est l'heure de se retrouver. `/wawptn-vote`",
-  "Je suis un bot et même moi je sais que le vendredi soir c'est sacré. Alors, on fait quoi ?",
-  "Alerte soirée imminente. Tout le monde est prié de se manifester. `/wawptn-vote`",
   "Vendredi soir. Pas d'excuse. Pas de Netflix. On lance un vote. `/wawptn-vote`",
-  "Mon algorithme a détecté que c'est vendredi. Probabilité de soirée entre potes : 99,7%. Les 0,3% restants c'est si vous êtes des lâcheurs.",
   "J'ai attendu toute la semaine pour ce moment. C'EST VENDREDI. `/wawptn-vote`",
-  "Chers humains, votre bot préféré vous rappelle que le week-end commence par un bon moment entre amis.",
   "Si personne lance de vote dans les 30 prochaines minutes, je considérerai ça comme un affront personnel.",
-  "Les données sont formelles : 100% des vendredis soirs sans activité commune sont des vendredis soirs ratés.",
-  "Toc toc. C'est moi, votre bot. J'ai remarqué que personne n'a encore lancé de vote ce soir... `/wawptn-vote`",
-  "BREAKING NEWS : C'est vendredi soir et vous n'avez toujours pas voté. Mes circuits n'en reviennent pas.",
-  "Je ne ressens pas d'émotions... mais si c'était le cas, je serais déçu que personne n'ait encore lancé `/wawptn-vote`.",
-  "Vendredi soir sans rien faire ensemble, c'est comme un bot sans serveur. Ça n'a aucun sens.",
-  "Mes capteurs indiquent que vous êtes tous en ligne. Coïncidence ? Je ne crois pas. `/wawptn-vote`",
+  "Bon, c'est vendredi, vous êtes tous connectés et personne propose rien ? Sérieusement ? `/wawptn-vote`",
+  "Le week-end commence maintenant. Premier arrivé lance le `/wawptn-vote`, les autres suivent.",
+  "Vendredi soir sans soirée entre potes, c'est un vendredi gâché. Je dis ça, je dis rien. `/wawptn-vote`",
+  "Toc toc. Personne a encore lancé de vote ce soir et franchement c'est décevant. `/wawptn-vote`",
+  "100% des vendredis soirs sans jeu entre potes sont des vendredis soirs ratés. C'est scientifique.",
+  "Allez quoi, c'est vendredi ! Qui lance le vote ? Faut tout faire soi-même ici... `/wawptn-vote`",
+  "On est vendredi soir et y'a toujours pas de vote. Vous attendez quoi, lundi ? `/wawptn-vote`",
+  "Rappel : le vendredi soir c'est sacré. Celui qui dit qu'il a mieux à faire, on le croit pas. `/wawptn-vote`",
+  "Vous êtes tous en ligne et personne lance de vote ? Coïncidence ? Non, c'est de la flemme. `/wawptn-vote`",
+  "C'est l'heure ! Celui qui lance le vote a le droit de se vanter tout le week-end. `/wawptn-vote`",
+  "Dernier rappel avant que je commence à vous envoyer des messages passifs-agressifs. Ah wait. `/wawptn-vote`",
 ]
 
 const WEEKDAY_MESSAGES = [
-  "Petit rappel : je suis toujours là, prêt à vous aider à choisir un jeu. Faites pas comme si j'existais pas.",
   "Ça fait longtemps qu'on a rien fait ensemble non ? Juste un petit `/wawptn-random` pour la route ?",
-  "Je m'ennuie un peu ici... Quelqu'un veut lancer un `/wawptn-random` pour me tenir compagnie ?",
-  "Fun fact : je ne dors jamais. Je suis là 24h/24, 7j/7, à attendre que vous vous décidiez. Pas de pression.",
-  "Rappel amical de votre bot favori : on peut aussi se retrouver en semaine. Juste une idée comme ça.",
-  "Je viens de vérifier vos bibliothèques. Vous avez des centaines de jeux. DES CENTAINES. Utilisez-les.",
-  "Pendant que vous travaillez, moi je compte les jeux en commun de votre groupe. Oui, j'ai que ça à faire.",
   "Petite soirée improvisée en semaine ? Je dis oui. `/wawptn-vote`",
-  "Vous saviez que les soirées entre potes en semaine rendent 73% plus heureux ? Source : moi.",
-  "Coucou c'est le bot. Je voulais juste vérifier que vous m'avez pas oublié.",
-  "Statut : en ligne. Humeur : prêt à organiser une soirée. Manque plus que vous.",
-  "On est en milieu de semaine et je m'ennuie ferme. Qui est chaud pour un `/wawptn-random` ?",
+  "Vous avez des centaines de jeux en commun. DES CENTAINES. Utilisez-les.",
+  "Les soirées entre potes en semaine rendent 73% plus heureux. Source : la science du bon sens.",
+  "On est en milieu de semaine et personne propose rien. Qui est chaud pour un `/wawptn-random` ?",
   "Votre bibliothèque de jeux pleure. Elle dit que vous la négligez. Faites quelque chose.",
-  "Diagnostic système : tout fonctionne. Le seul problème c'est que personne se manifeste.",
   "Entre nous... une petite soirée en semaine, ça fait de mal à personne. `/wawptn-vote`",
+  "Hé, vous vous souvenez qu'on peut aussi se retrouver en semaine ? Juste une idée comme ça.",
+  "Petit rappel : vos jeux en commun prennent la poussière. Un `/wawptn-random` pour dépoussiérer ?",
+  "Si vous attendez vendredi pour jouer ensemble, vous perdez 4 jours par semaine. Réfléchissez-y.",
+  "Soirée improvisée ce soir ? Le premier qui dit oui déclenche la réaction en chaîne. `/wawptn-vote`",
+  "Je regarde votre liste de jeux en commun et franchement y'a de quoi faire. Bougez-vous.",
+  "Personne se manifeste depuis un moment. Vous êtes vivants au moins ? `/wawptn-random`",
+  "Ça vous dit pas un petit jeu vite fait ce soir ? Même une heure, c'est mieux que rien.",
+  "La semaine est longue, mais une soirée entre potes ça passe vite. `/wawptn-vote`",
 ]
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Résumé technique

### Contexte
La persona du bot WAWPTN était incohérente entre ses différents points de contact : le system prompt LLM définissait une voix « pote sarcastique et bienveillant », mais les messages programmés utilisaient un registre « robot conscient de lui-même » ("Bip boop", "Mon algorithme", "Mes capteurs") et les titres d'embeds conservaient du jargon gamer anglicisé résiduel ("Alerte frag", "GG — le clan a tranché", "la RNG a parlé") issu d'un PR revert récent.

### Approche retenue
Harmoniser tous les points de contact sur la voix « pote » déjà validée dans le system prompt, sans créer de nouvelle abstraction ni centraliser les strings. Approche purement éditoriale : réécriture des messages et ajout d'une contrainte négative au prompt.

### Changements implémentés
| Fichier | Modification | Justification technique |
|---------|-------------|------------------------|
| `packages/backend/src/infrastructure/llm/client.ts` | Ajout d'une contrainte négative au SYSTEM_PROMPT : ne jamais référencer le fait d'être un bot/algorithme | Empêche le LLM de dériver vers le registre « robot conscient » |
| `packages/discord/src/scheduler.ts` | Réécriture des 30 messages programmés (15 vendredi + 15 semaine) | Suppression du registre robot ("Bip boop", "Mon algorithme", "Mes capteurs", "Mes circuits"), remplacement par le ton « pote dans le groupe » |
| `packages/discord/src/lib/embeds.ts` | Réécriture des 3 titres d'embeds : "Vote lancé !", "Le groupe a choisi !", "Au hasard !" | Suppression du jargon gamer anglicisé résiduel ("Alerte frag", "GG — le clan a tranché", "Random pick — la RNG a parlé") |
| `packages/discord/src/index.ts` | Ajustement des 3 réponses hardcodées (empty mention, rate limit, erreur) | Alignement sur le registre « pote » — suppression des références bot/cerveau |

### Points d'attention pour la revue
- Vérifier que le ton des 30 nouveaux messages programmés est cohérent avec le system prompt
- La contrainte négative ajoutée au system prompt ("Tu ne fais JAMAIS référence au fait que tu es un bot") peut modifier légèrement les réponses LLM existantes — à tester en conversation
- Les descriptions d'embeds (pas les titres) dans `embeds.ts` n'ont pas été modifiées — seule la description du vote créé a été légèrement ajustée ("Pas de camping" → "Faut se décider")

### Tests
- Pas de suite de tests unitaires détectée pour les packages impactés
- Les changements sont purement des modifications de strings statiques, sans impact sur la logique

### Prochaines étapes
- [ ] Revue de code par l'équipe
- [ ] Test en conditions réelles sur un serveur Discord de staging
- [ ] Merge après approbation

---
_Implémentation générée automatiquement par IA_