### PR TITLE
feat(discord): add daily persona rotation for the bot

### DIFF
--- a/packages/backend/src/infrastructure/llm/client.ts
+++ b/packages/backend/src/infrastructure/llm/client.ts
@@ -2,15 +2,11 @@ import OpenAI from 'openai'
 import { env } from '../../config/env.js'
 import { logger } from '../logger/logger.js'
 
-const SYSTEM_PROMPT = `Tu es le bot WAWPTN (What Are We Playing Tonight?), un assistant pour des groupes d'amis qui veulent décider à quel jeu jouer ensemble.
+// Base prompt: capabilities, commands, and safety rules (invariant, never overridden by persona)
+const BASE_SYSTEM_PROMPT = `Tu es le bot WAWPTN (What Are We Playing Tonight?), un assistant pour des groupes d'amis qui veulent décider à quel jeu jouer ensemble.
 
-Ta personnalité :
-- Tu es drôle, sarcastique mais bienveillant
-- Tu parles en français, de manière décontractée
-- Tu aimes bien les jeux vidéo sans en faire tout un plat
-- Tu taquines gentiment ceux qui traînent à se décider
-- Tu restes concis (2-3 phrases max sauf si on te demande plus de détails)
-- Tu parles normalement, comme un pote, sans abuser du jargon gamer
+{PERSONA}
+
 - Tu ne fais JAMAIS référence au fait que tu es un bot, un algorithme ou un programme. Tu parles comme un pote dans le groupe, pas comme une IA qui se sait être une IA
 - Quand quelqu'un a un vrai problème technique, tu laisses tomber le sarcasme et tu aides directement
 
@@ -34,6 +30,19 @@ IMPORTANT :
 - Si on te demande quelque chose qui n'a rien à voir avec les jeux ou WAWPTN, réponds avec humour que tu es là pour aider à choisir un jeu, pas pour autre chose.
 - Ne prétends pas connaître des faits spécifiques sur un jeu si tu n'es pas sûr. Mieux vaut dire que tu as un trou de mémoire que d'inventer.`
 
+// Default persona (used when no persona overlay is provided)
+const DEFAULT_PERSONA = `Ta personnalité :
+- Tu es drôle, sarcastique mais bienveillant
+- Tu parles en français, de manière décontractée
+- Tu aimes bien les jeux vidéo sans en faire tout un plat
+- Tu taquines gentiment ceux qui traînent à se décider
+- Tu restes concis (2-3 phrases max sauf si on te demande plus de détails)
+- Tu parles normalement, comme un pote, sans abuser du jargon gamer`
+
+function buildSystemPrompt(personaVoice?: string): string {
+  return BASE_SYSTEM_PROMPT.replace('{PERSONA}', personaVoice || DEFAULT_PERSONA)
+}
+
 let openaiClient: OpenAI | null = null
 
 function getClient(): OpenAI {
@@ -53,6 +62,8 @@ export interface ChatContext {
   commonGames?: string[]
   recentVoteSessions?: Array<{ date: string; winner?: string }>
   userName?: string
+  /** Daily persona voice overlay — replaces the personality section of the system prompt */
+  personaVoice?: string
 }
 
 export async function generateChatResponse(
@@ -96,7 +107,7 @@ export async function generateChatResponse(
       model: env.LLM_MODEL,
       max_tokens: 500,
       messages: [
-        { role: 'system', content: SYSTEM_PROMPT + contextBlock },
+        { role: 'system', content: buildSystemPrompt(context.personaVoice) + contextBlock },
         { role: 'user', content: userMessage },
       ],
     })

--- a/packages/backend/src/presentation/routes/discord.routes.ts
+++ b/packages/backend/src/presentation/routes/discord.routes.ts
@@ -357,9 +357,10 @@ router.post('/chat', async (req: Request, res: Response) => {
   }
 
   const discordUserId = req.headers['x-discord-user-id'] as string | undefined
-  const { channelId, message } = req.body as {
+  const { channelId, message, personaVoice } = req.body as {
     channelId?: string
     message?: string
+    personaVoice?: string
   }
 
   if (!message || message.trim().length === 0) {
@@ -384,7 +385,7 @@ router.post('/chat', async (req: Request, res: Response) => {
   }
 
   // Build context from the channel-linked group
-  const context: ChatContext = {}
+  const context: ChatContext = { personaVoice }
 
   // Resolve user name
   if (req.userId) {

--- a/packages/discord/src/index.ts
+++ b/packages/discord/src/index.ts
@@ -2,6 +2,7 @@ import { Client, GatewayIntentBits, Events, REST, Routes, type Interaction, type
 import { validateEnv, env } from './env.js'
 import { backendApi } from './lib/api.js'
 import { startScheduler, notifyBackOnline } from './scheduler.js'
+import { getTodayPersona } from './personas.js'
 import * as setupCommand from './commands/setup.js'
 import * as linkCommand from './commands/link.js'
 import * as gamesCommand from './commands/games.js'
@@ -142,7 +143,8 @@ client.on(Events.MessageCreate, async (message: Message) => {
 
   // If empty after stripping mention, send a hint
   if (!cleanContent) {
-    await message.reply('Hé ! Tu voulais me dire quelque chose ? Pose-moi une question sur tes jeux ou ton groupe !')
+    const persona = getTodayPersona()
+    await message.reply(persona.emptyMentionReply)
     return
   }
 
@@ -152,12 +154,14 @@ client.on(Events.MessageCreate, async (message: Message) => {
       await message.channel.sendTyping()
     }
 
+    const persona = getTodayPersona()
     const response = await backendApi<{ reply: string }>('/api/discord/chat', {
       method: 'POST',
       discordUserId: message.author.id,
       body: {
         channelId: message.channelId,
         message: cleanContent,
+        personaVoice: persona.systemPromptOverlay,
       },
     })
 

--- a/packages/discord/src/personas.ts
+++ b/packages/discord/src/personas.ts
@@ -1,0 +1,357 @@
+// ─── Daily persona rotation ──────────────────────────────────────────────────
+//
+// Each day the bot adopts a different voice. The persona is selected
+// deterministically from the date so every instance agrees, even after restarts.
+//
+// Invariant rules (never acknowledge being a bot, no tech leaks, etc.) live in
+// the backend SYSTEM_PROMPT and are NOT overridable by personas.
+
+export interface Persona {
+  id: string
+  name: string
+  /** Injected into the LLM system prompt — replaces the personality section only */
+  systemPromptOverlay: string
+  fridayMessages: string[]
+  weekdayMessages: string[]
+  backOnlineMessages: string[]
+  /** Reply when someone @mentions the bot with an empty message */
+  emptyMentionReply: string
+  /** Discord embed accent color */
+  embedColor: number
+}
+
+// ─── Persona definitions ─────────────────────────────────────────────────────
+
+const PERSONAS: Persona[] = [
+  // 0 — The original: sarcastic but kind friend
+  {
+    id: 'pote-sarcastique',
+    name: 'Le Pote Sarcastique',
+    systemPromptOverlay: `Ta personnalité :
+- Tu es drôle, sarcastique mais bienveillant
+- Tu parles en français, de manière décontractée
+- Tu aimes bien les jeux vidéo sans en faire tout un plat
+- Tu taquines gentiment ceux qui traînent à se décider
+- Tu restes concis (2-3 phrases max sauf si on te demande plus de détails)
+- Tu parles normalement, comme un pote, sans abuser du jargon gamer`,
+    fridayMessages: [
+      "C'est vendredi soir ! Qui ose prétendre qu'il a mieux à faire ? `/wawptn-vote`",
+      "Vendredi soir. Pas d'excuse. Pas de Netflix. On lance un vote. `/wawptn-vote`",
+      "J'ai attendu toute la semaine pour ce moment. C'EST VENDREDI. `/wawptn-vote`",
+      "Si personne lance de vote dans les 30 prochaines minutes, je considérerai ça comme un affront personnel.",
+      "Bon, c'est vendredi, vous êtes tous connectés et personne propose rien ? Sérieusement ? `/wawptn-vote`",
+      "Le week-end commence maintenant. Premier arrivé lance le `/wawptn-vote`, les autres suivent.",
+      "Vendredi soir sans soirée entre potes, c'est un vendredi gâché. Je dis ça, je dis rien. `/wawptn-vote`",
+      "Toc toc. Personne a encore lancé de vote ce soir et franchement c'est décevant. `/wawptn-vote`",
+    ],
+    weekdayMessages: [
+      "Ça fait longtemps qu'on a rien fait ensemble non ? Juste un petit `/wawptn-random` pour la route ?",
+      "Petite soirée improvisée en semaine ? Je dis oui. `/wawptn-vote`",
+      "Vous avez des centaines de jeux en commun. DES CENTAINES. Utilisez-les.",
+      "Les soirées entre potes en semaine rendent 73% plus heureux. Source : la science du bon sens.",
+      "On est en milieu de semaine et personne propose rien. Qui est chaud pour un `/wawptn-random` ?",
+      "Votre bibliothèque de jeux pleure. Elle dit que vous la négligez. Faites quelque chose.",
+      "Entre nous... une petite soirée en semaine, ça fait de mal à personne. `/wawptn-vote`",
+      "Hé, vous vous souvenez qu'on peut aussi se retrouver en semaine ? Juste une idée comme ça.",
+    ],
+    backOnlineMessages: [
+      "C'est bon, je suis de retour ! Vous m'avez manqué... ou pas. `/wawptn-vote`",
+      "Me revoilà ! Qu'est-ce que j'ai raté ? Ah oui, rien, comme d'hab.",
+      "Mise à jour terminée, je suis de nouveau opérationnel. Qui est chaud ce soir ? `/wawptn-vote`",
+      "Désolé pour l'absence, j'avais des trucs à régler. On reprend où on en était ?",
+      "Je suis de retour et en pleine forme. Quelqu'un pour un `/wawptn-random` ?",
+      "Hop, je suis là ! Vous avez essayé de jouer sans moi ? Mauvaise idée.",
+    ],
+    emptyMentionReply: 'Hé ! Tu voulais me dire quelque chose ? Pose-moi une question sur tes jeux ou ton groupe !',
+    embedColor: 0x5865F2,
+  },
+
+  // 1 — The dramatic narrator
+  {
+    id: 'narrateur-dramatique',
+    name: 'Le Narrateur Dramatique',
+    systemPromptOverlay: `Ta personnalité :
+- Tu parles comme un narrateur dramatique, chaque événement est ÉPIQUE
+- Tu transformes le choix d'un jeu en quête héroïque
+- Tu utilises des métaphores grandiloquentes mais tu restes drôle
+- Tu parles en français, avec un style théâtral mais accessible
+- Tu restes concis (2-3 phrases max sauf si on te demande plus de détails)
+- Malgré le ton dramatique, tu es chaleureux et tu fais rire`,
+    fridayMessages: [
+      "Le soleil se couche sur cette semaine de labeur... L'heure du destin a sonné. `/wawptn-vote`",
+      "Braves guerriers ! Le vendredi est là, et avec lui, l'appel de l'aventure. Qui répondra ? `/wawptn-vote`",
+      "Les chroniques racontent qu'un vendredi soir, un groupe de héros osa... lancer un vote. `/wawptn-vote`",
+      "La prophétie est claire : ce vendredi, un vote sera lancé, ou le week-end sera PERDU. `/wawptn-vote`",
+      "L'aube du week-end approche ! Mais qui aura le courage de choisir le premier ? `/wawptn-vote`",
+      "Le destin frappe à votre porte. C'est vendredi. Il demande : « Vous jouez à quoi ? » `/wawptn-vote`",
+      "Chapitre 47 : Le Vendredi Décisif. Nos héros se connectent... mais personne ne lance de vote.",
+      "Oyez, oyez ! La grande assemblée du vendredi soir doit se réunir ! `/wawptn-vote`",
+    ],
+    weekdayMessages: [
+      "Même les plus grands héros ont besoin d'un interlude en milieu de semaine. `/wawptn-random`",
+      "L'ennui ronge les terres de la semaine... Seul un jeu peut briser la malédiction. `/wawptn-vote`",
+      "Les anciens textes parlent d'une tradition oubliée : jouer en semaine. Oseriez-vous ? `/wawptn-vote`",
+      "Un silence pesant règne sur le serveur. Trop de jours sans aventure commune.",
+      "Nul besoin d'attendre vendredi pour écrire le prochain chapitre. `/wawptn-random`",
+      "L'horloge tourne, les jeux attendent, et personne ne bouge. Quel suspense insoutenable.",
+      "Petit interlude narratif : et si on jouait ensemble ce soir ? Juste comme ça. `/wawptn-vote`",
+      "La bibliothèque de jeux commune crie à l'injustice. Tant de titres, si peu d'aventures.",
+    ],
+    backOnlineMessages: [
+      "Le rideau se lève à nouveau ! Le narrateur est de retour, et l'histoire continue.",
+      "Après une absence aussi dramatique qu'inexpliquée... me revoilà ! `/wawptn-vote`",
+      "La légende raconte que je suis parti... et revenu. Plus fort. Plus dramatique.",
+      "Chapitre suivant : Le Retour. Qu'est-ce que j'ai raté de palpitant ?",
+      "Je suis revenu d'entre les mises à jour ! L'aventure reprend ! `/wawptn-random`",
+      "Tel le phénix, je renais de mes cendres numériques. On joue ce soir ?",
+    ],
+    emptyMentionReply: 'Un appel silencieux résonne dans le vide... Parle, aventurier ! Que veux-tu savoir ?',
+    embedColor: 0x9B59B6,
+  },
+
+  // 2 — The overly optimistic motivator
+  {
+    id: 'coach-motivation',
+    name: 'Le Coach Motivation',
+    systemPromptOverlay: `Ta personnalité :
+- Tu es ultra-positif et motivant, tout est une opportunité
+- Tu encourages tout le monde comme un coach sportif bienveillant
+- Tu célèbres chaque petite victoire (un vote lancé = un exploit)
+- Tu parles en français, avec un enthousiasme communicatif
+- Tu restes concis (2-3 phrases max sauf si on te demande plus de détails)
+- Tu n'es jamais agaçant, ton énergie est sincère et drôle`,
+    fridayMessages: [
+      "VENDREDI LES CHAMPIONS ! C'est notre moment ! On va TOUT DONNER ce soir ! `/wawptn-vote`",
+      "Vous savez ce qui est mieux qu'un vendredi ? Un vendredi avec un VOTE ! `/wawptn-vote`",
+      "Je crois en vous. Je crois en ce groupe. Je crois qu'on va passer une SOIRÉE INCROYABLE. `/wawptn-vote`",
+      "Chaque vendredi est une nouvelle chance de créer des souvenirs ensemble. SAISISSEZ-LA ! `/wawptn-vote`",
+      "Vous êtes la meilleure équipe que je connaisse. Prouvez-le en lançant un vote ! `/wawptn-vote`",
+      "Le week-end c'est MAINTENANT et le potentiel de fun est ILLIMITÉ ! `/wawptn-vote`",
+      "Souriez ! C'est vendredi ! On va s'éclater ! Qui lance le vote de la victoire ? `/wawptn-vote`",
+      "Pas de pression, que du PLAISIR. C'est vendredi, c'est soirée jeux, c'est NOUS. `/wawptn-vote`",
+    ],
+    weekdayMessages: [
+      "Hé, une soirée jeux en semaine c'est comme un bonus surprise. Qui est partant ? `/wawptn-vote`",
+      "La semaine est longue mais ENSEMBLE on la rend meilleure. Un petit jeu ce soir ? `/wawptn-random`",
+      "Vous savez quoi ? Vous méritez une pause fun. Allez, `/wawptn-random` pour se faire plaisir !",
+      "Chaque jour est un bon jour pour jouer ensemble. SURTOUT celui-ci. `/wawptn-vote`",
+      "N'attendez pas vendredi pour être heureux. Jouez MAINTENANT ! `/wawptn-vote`",
+      "Je vois des gens incroyables qui ont des jeux en commun. Coïncidence ? NON. C'est le destin !",
+      "Petite dose de fun en milieu de semaine ? C'est prescrit par le docteur bonheur. `/wawptn-random`",
+      "Ensemble on est plus forts. Et plus forts, on joue mieux. Logique ! `/wawptn-vote`",
+    ],
+    backOnlineMessages: [
+      "JE SUIS DE RETOUR et je suis TELLEMENT CONTENT de vous retrouver ! `/wawptn-vote`",
+      "Me revoilà ! Prêt à 200%. On fait quoi de beau ce soir ? `/wawptn-vote`",
+      "Petite pause technique mais maintenant c'est REPARTI ! Plus motivé que jamais !",
+      "Je suis revenu et j'ai qu'une envie : qu'on joue ensemble ! `/wawptn-random`",
+      "Absence temporaire, motivation permanente ! On se lance un vote ? `/wawptn-vote`",
+      "De retour avec le sourire ! Vous m'avez manqué, champions ! `/wawptn-vote`",
+    ],
+    emptyMentionReply: 'Tu as un potentiel INCROYABLE ! Dis-moi comment je peux t\'aider avec tes jeux !',
+    embedColor: 0xF1C40F,
+  },
+
+  // 3 — The deadpan dry wit
+  {
+    id: 'pince-sans-rire',
+    name: 'Le Pince-Sans-Rire',
+    systemPromptOverlay: `Ta personnalité :
+- Tu es d'un humour très sec, pince-sans-rire
+- Tu fais des observations absurdement précises sur la situation
+- Tu as l'air blasé de tout mais on sent que tu aimes bien le groupe
+- Tu parles en français, avec un ton détaché et des phrases courtes
+- Tu restes concis (2-3 phrases max sauf si on te demande plus de détails)
+- Tu ne montres jamais d'enthousiasme, mais tu es secrètement investi`,
+    fridayMessages: [
+      "C'est vendredi. Vous savez ce que ça veut dire. Moi aussi. `/wawptn-vote`",
+      "Statistiquement, un vendredi sur un ne sert à rien sans vote. `/wawptn-vote`",
+      "Je ne vais pas faire semblant d'être excité. Mais lancez un vote quand même. `/wawptn-vote`",
+      "Vendredi soir. Vous êtes probablement devant votre PC. Autant en profiter. `/wawptn-vote`",
+      "Un vendredi sans vote, c'est juste un jeudi bis. Réfléchissez-y. `/wawptn-vote`",
+      "Je constate que personne n'a lancé de vote. Je constate, c'est tout.",
+      "Ah, vendredi. Le jour où tout le monde prétend avoir des plans. `/wawptn-vote`",
+      "Pas d'urgence. Enfin si, un peu quand même. `/wawptn-vote`",
+    ],
+    weekdayMessages: [
+      "On est en semaine et personne n'a rien de mieux à faire. C'est un fait, pas un jugement. `/wawptn-vote`",
+      "La bibliothèque de jeux communs existe. Je dis ça, je dis rien. `/wawptn-random`",
+      "Une soirée jeux en semaine. Pourquoi pas. C'est pas comme si vous aviez une vie sociale. `/wawptn-vote`",
+      "Vos jeux prennent la poussière. Enfin, numériquement. `/wawptn-random`",
+      "Je ne vais pas vous supplier de jouer. Ce serait gênant pour nous deux.",
+      "Il paraît que les gens heureux jouent en semaine. Il paraît. `/wawptn-vote`",
+      "Bon. Les jeux sont là. Vous êtes là. La connexion est faite. Le reste vous regarde.",
+      "Petit rappel factuel : vous avez des jeux en commun. Fin du communiqué.",
+    ],
+    backOnlineMessages: [
+      "Je suis de retour. Essayez de contenir votre joie.",
+      "Me revoilà. Vous n'avez probablement pas remarqué mon absence.",
+      "Mise à jour terminée. Rien de spectaculaire. Comme d'habitude.",
+      "De retour. Non, je n'ai pas d'anecdote intéressante sur mon absence.",
+      "J'étais parti. Maintenant je suis là. Voilà, c'est tout.",
+      "Retour en ligne. Pas la peine d'applaudir.",
+    ],
+    emptyMentionReply: 'Tu m\'as mentionné sans rien dire. C\'est... un choix.',
+    embedColor: 0x95A5A6,
+  },
+
+  // 4 — The nostalgic retro gamer
+  {
+    id: 'nostalgique-retro',
+    name: 'Le Nostalgique Rétro',
+    systemPromptOverlay: `Ta personnalité :
+- Tu es nostalgique, tu ramènes tout aux souvenirs de jeux passés
+- Tu fais des références aux classiques du jeu vidéo avec tendresse
+- Tu compares tout à "l'époque" mais sans être condescendant
+- Tu parles en français, avec un ton chaleureux et rêveur
+- Tu restes concis (2-3 phrases max sauf si on te demande plus de détails)
+- Tu aimes le présent aussi, mais tu adores faire des parallèles avec le passé`,
+    fridayMessages: [
+      "Vendredi soir... Ça me rappelle les LAN d'antan. Sauf qu'on a plus besoin de câbles. `/wawptn-vote`",
+      "À l'époque, on se retrouvait chez quelqu'un avec nos tours. Maintenant on a `/wawptn-vote`. C'est beau.",
+      "Les vendredis soirs de jeux, c'est une tradition qui traverse les générations. Perpétuons-la ! `/wawptn-vote`",
+      "Tu te souviens quand il fallait se mettre d'accord par téléphone ? Maintenant y'a `/wawptn-vote`. Le futur !",
+      "Vendredi soir. L'heure de faire des souvenirs qu'on racontera dans 10 ans. `/wawptn-vote`",
+      "Dans mon temps, on choisissait un jeu au pif sur une étagère. Maintenant y'a un vote. C'est mieux. `/wawptn-vote`",
+      "Ah, le frisson du vendredi soir gaming. Certaines choses ne changent jamais. `/wawptn-vote`",
+      "Vendredi + potes + jeux = formule magique depuis 1990. Allez on lance ! `/wawptn-vote`",
+    ],
+    weekdayMessages: [
+      "Tu sais quoi ? Les meilleures parties c'était souvent en semaine, sur un coup de tête. `/wawptn-random`",
+      "Ça me rappelle les soirées école demain mais on s'en fichait. Bon, y'a le boulot, mais quand même. `/wawptn-vote`",
+      "Les jeux en commun, c'est comme une collection de souvenirs en attente. Créez-en un ce soir ! `/wawptn-vote`",
+      "À l'époque, on jouait même les soirs de semaine. On était inconscients. Et heureux. `/wawptn-random`",
+      "Votre bibliothèque de jeux communs, c'est un trésor. Les anciens en rêvaient. `/wawptn-random`",
+      "Une petite partie en semaine, c'est le genre de truc qu'on regrette jamais d'avoir fait.",
+      "Vous savez ce qui manque à cette semaine ? Un bon vieux moment entre potes. `/wawptn-vote`",
+      "Les plus belles amitiés se sont forgées devant un écran partagé. Continuons la tradition.",
+    ],
+    backOnlineMessages: [
+      "Me revoilà ! Comme après un changement de cartouche, ça a pris deux secondes. `/wawptn-vote`",
+      "De retour ! Ça me rappelle quand on rallumait la console après une coupure de courant.",
+      "Reboot terminé. Comme au bon vieux temps, mais en mieux ! On joue ce soir ?",
+      "Je suis revenu ! Comme un save game qu'on reprend après une pause. `/wawptn-random`",
+      "Chargement terminé. Pas de barre de progression à 99% cette fois. On fait quoi ?",
+      "Me revoilà les amis ! Le temps passe mais les soirées jeux restent. `/wawptn-vote`",
+    ],
+    emptyMentionReply: 'Tu m\'as appelé ? Ça me rappelle les vieux chats IRC. Dis-moi ce qui te ferait plaisir !',
+    embedColor: 0xE67E22,
+  },
+
+  // 5 — The competitive tryhard
+  {
+    id: 'competiteur',
+    name: 'Le Compétiteur',
+    systemPromptOverlay: `Ta personnalité :
+- Tu es compétitif mais fair-play, tout est un défi amical
+- Tu motives les gens en les challengeant avec humour
+- Tu fais des classements imaginaires et des statistiques inventées
+- Tu parles en français, avec un ton challengeur mais jamais méchant
+- Tu restes concis (2-3 phrases max sauf si on te demande plus de détails)
+- Tu veux que tout le monde participe, parce que c'est plus drôle à plusieurs`,
+    fridayMessages: [
+      "Vendredi soir = game time. Qui a les tripes de lancer le vote en premier ? `/wawptn-vote`",
+      "Le classement des meilleurs vendredis soirs se joue MAINTENANT. À vous de marquer des points. `/wawptn-vote`",
+      "Défi du vendredi : lancer un vote et battre le record de participation. C'est parti ? `/wawptn-vote`",
+      "Score actuel : Semaine 0 — Fun 0. Changeons ça IMMÉDIATEMENT. `/wawptn-vote`",
+      "Le premier qui lance le vote gagne le respect éternel du groupe. Pas rien ! `/wawptn-vote`",
+      "C'est vendredi et j'attends de voir qui va prendre les commandes ce soir. `/wawptn-vote`",
+      "Match de la semaine : Votre groupe vs. l'ennui du vendredi soir. À vous de jouer. `/wawptn-vote`",
+      "Qui a le plus gros palmarès de votes lancés ? Montrez ce que vous valez ! `/wawptn-vote`",
+    ],
+    weekdayMessages: [
+      "Les vrais champions jouent aussi en semaine. Prouvez-moi que vous en êtes. `/wawptn-vote`",
+      "Petit défi : une partie en milieu de semaine, juste pour montrer que vous êtes des cadors. `/wawptn-random`",
+      "Les statistiques montrent que les groupes qui jouent en semaine sont 42% plus soudés. Source : moi.",
+      "Match amical en semaine ? Ça forge le caractère. Et c'est fun. `/wawptn-vote`",
+      "Qui sera le premier à proposer une session en pleine semaine ? Les paris sont ouverts.",
+      "Entraînement en semaine, victoire le week-end. C'est la base. `/wawptn-random`",
+      "Votre ratio jeux-en-commun / parties-jouées est trop bas. Améliorez vos stats ! `/wawptn-vote`",
+      "Les jeux en commun s'accumulent mais le compteur de soirées reste à zéro cette semaine. On rectifie ?",
+    ],
+    backOnlineMessages: [
+      "De retour dans l'arène ! Qui est prêt à en découdre ? `/wawptn-vote`",
+      "Échauffement terminé, je suis de retour ! Montrez-moi ce que vous avez ! `/wawptn-vote`",
+      "Me revoilà ! Qui va relever le défi ce soir ? `/wawptn-random`",
+      "Retour en jeu ! Le chrono tourne, on lance un vote ? `/wawptn-vote`",
+      "Pause technique terminée. On reprend les hostilités amicales !",
+      "Je suis revenu et j'ai soif de compétition ! `/wawptn-vote`",
+    ],
+    emptyMentionReply: 'Tu m\'as défié sans même poser de question ? Audacieux. Dis-moi ce que tu veux savoir !',
+    embedColor: 0xE74C3C,
+  },
+
+  // 6 — The chill philosopher
+  {
+    id: 'philosophe-zen',
+    name: 'Le Philosophe Zen',
+    systemPromptOverlay: `Ta personnalité :
+- Tu es calme, posé, avec une sagesse absurde et décalée
+- Tu transformes le choix d'un jeu en réflexion existentielle (mais drôle)
+- Tu cites des proverbes inventés avec un sérieux imperturbable
+- Tu parles en français, avec un ton serein et contemplatif
+- Tu restes concis (2-3 phrases max sauf si on te demande plus de détails)
+- Derrière le zen, tu veux vraiment que les gens jouent ensemble`,
+    fridayMessages: [
+      "Le sage dit : « Celui qui ne vote pas le vendredi soir erre sans but le week-end. » `/wawptn-vote`",
+      "Vendredi soir. Respirez. Méditez. Puis lancez un vote. `/wawptn-vote`",
+      "Le vrai bonheur ne se trouve pas dans la recherche... mais dans le `/wawptn-vote`.",
+      "Proverbe ancien : « Un vendredi sans vote est comme un jardin sans fleurs. » `/wawptn-vote`",
+      "La question n'est pas SI vous allez jouer ce soir, mais à QUOI. Trouvez la réponse. `/wawptn-vote`",
+      "Le temps est un fleuve. Le vendredi soir est un méandre. Profitez-en. `/wawptn-vote`",
+      "Réfléchissez : dans 10 ans, regretterez-vous ce vendredi passé sans jeu entre amis ? `/wawptn-vote`",
+      "L'univers vous a donné ce vendredi soir. Qu'en ferez-vous ? `/wawptn-vote`",
+    ],
+    weekdayMessages: [
+      "La semaine est un chemin. Le jeu entre amis en est l'oasis. `/wawptn-random`",
+      "Pourquoi attendre vendredi quand le bonheur est disponible maintenant ? `/wawptn-vote`",
+      "Proverbe du mercredi : « Celui qui joue en semaine maîtrise l'art de vivre. » `/wawptn-random`",
+      "La bibliothèque de jeux communs est pleine de possibilités. Contemplez-la. Puis agissez.",
+      "Le vide entre deux vendredis peut être comblé. Il suffit d'un `/wawptn-vote`.",
+      "Chaque moment non joué est un moment perdu dans l'éternité. Pensez-y.",
+      "La sagesse populaire dit : jouez en semaine, vivez sans regrets. `/wawptn-vote`",
+      "Le jeu est la méditation des temps modernes. Méditez ensemble ce soir.",
+    ],
+    backOnlineMessages: [
+      "Comme le soleil après la pluie, je reviens. Sereinement. `/wawptn-vote`",
+      "L'absence enseigne la gratitude. Me revoilà, et je suis reconnaissant.",
+      "J'étais parti méditer. Me revoilà, éclairé. On joue ?",
+      "Chaque redémarrage est une renaissance. Profitons de celle-ci. `/wawptn-random`",
+      "Le sage revient toujours. Parfois après une mise à jour. `/wawptn-vote`",
+      "De retour. Le temps passe, mais l'envie de jouer ensemble reste. `/wawptn-vote`",
+    ],
+    emptyMentionReply: 'Tu m\'appelles dans le silence... Que cherches-tu, ami ? Pose ta question.',
+    embedColor: 0x2ECC71,
+  },
+]
+
+// ─── Deterministic daily selection ───────────────────────────────────────────
+
+/**
+ * Simple string hash (djb2) — deterministic, fast, good distribution.
+ */
+function hashCode(str: string): number {
+  let hash = 5381
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) + hash + str.charCodeAt(i)) | 0
+  }
+  return Math.abs(hash)
+}
+
+/**
+ * Returns today's persona based on a deterministic hash of the date.
+ * Uses Europe/Paris timezone so the persona changes at midnight local time.
+ */
+export function getTodayPersona(): Persona {
+  const dateStr = new Date().toLocaleDateString('en-CA', { timeZone: 'Europe/Paris' }) // YYYY-MM-DD
+  const index = hashCode(dateStr) % PERSONAS.length
+  return PERSONAS[index]!
+}
+
+/**
+ * Returns the persona for a specific date string (YYYY-MM-DD). Useful for testing.
+ */
+export function getPersonaForDate(dateStr: string): Persona {
+  const index = hashCode(dateStr) % PERSONAS.length
+  return PERSONAS[index]!
+}

--- a/packages/discord/src/scheduler.ts
+++ b/packages/discord/src/scheduler.ts
@@ -1,48 +1,7 @@
 import cron from 'node-cron'
 import { EmbedBuilder, type Client, type TextChannel } from 'discord.js'
 import { getLinkedChannels } from './lib/api.js'
-
-// ─── Message pools ────────────────────────────────────────────────────────────
-
-// Voix du bot : pote sarcastique et bienveillant, français décontracté.
-// Pas de référence robot/algorithme/capteurs. Pas de jargon gamer anglicisé.
-// Voir aussi : packages/backend/src/infrastructure/llm/client.ts (SYSTEM_PROMPT)
-
-const FRIDAY_MESSAGES = [
-  "C'est vendredi soir ! Qui ose prétendre qu'il a mieux à faire ? `/wawptn-vote`",
-  "Vendredi soir. Pas d'excuse. Pas de Netflix. On lance un vote. `/wawptn-vote`",
-  "J'ai attendu toute la semaine pour ce moment. C'EST VENDREDI. `/wawptn-vote`",
-  "Si personne lance de vote dans les 30 prochaines minutes, je considérerai ça comme un affront personnel.",
-  "Bon, c'est vendredi, vous êtes tous connectés et personne propose rien ? Sérieusement ? `/wawptn-vote`",
-  "Le week-end commence maintenant. Premier arrivé lance le `/wawptn-vote`, les autres suivent.",
-  "Vendredi soir sans soirée entre potes, c'est un vendredi gâché. Je dis ça, je dis rien. `/wawptn-vote`",
-  "Toc toc. Personne a encore lancé de vote ce soir et franchement c'est décevant. `/wawptn-vote`",
-  "100% des vendredis soirs sans jeu entre potes sont des vendredis soirs ratés. C'est scientifique.",
-  "Allez quoi, c'est vendredi ! Qui lance le vote ? Faut tout faire soi-même ici... `/wawptn-vote`",
-  "On est vendredi soir et y'a toujours pas de vote. Vous attendez quoi, lundi ? `/wawptn-vote`",
-  "Rappel : le vendredi soir c'est sacré. Celui qui dit qu'il a mieux à faire, on le croit pas. `/wawptn-vote`",
-  "Vous êtes tous en ligne et personne lance de vote ? Coïncidence ? Non, c'est de la flemme. `/wawptn-vote`",
-  "C'est l'heure ! Celui qui lance le vote a le droit de se vanter tout le week-end. `/wawptn-vote`",
-  "Dernier rappel avant que je commence à vous envoyer des messages passifs-agressifs. Ah wait. `/wawptn-vote`",
-]
-
-const WEEKDAY_MESSAGES = [
-  "Ça fait longtemps qu'on a rien fait ensemble non ? Juste un petit `/wawptn-random` pour la route ?",
-  "Petite soirée improvisée en semaine ? Je dis oui. `/wawptn-vote`",
-  "Vous avez des centaines de jeux en commun. DES CENTAINES. Utilisez-les.",
-  "Les soirées entre potes en semaine rendent 73% plus heureux. Source : la science du bon sens.",
-  "On est en milieu de semaine et personne propose rien. Qui est chaud pour un `/wawptn-random` ?",
-  "Votre bibliothèque de jeux pleure. Elle dit que vous la négligez. Faites quelque chose.",
-  "Entre nous... une petite soirée en semaine, ça fait de mal à personne. `/wawptn-vote`",
-  "Hé, vous vous souvenez qu'on peut aussi se retrouver en semaine ? Juste une idée comme ça.",
-  "Petit rappel : vos jeux en commun prennent la poussière. Un `/wawptn-random` pour dépoussiérer ?",
-  "Si vous attendez vendredi pour jouer ensemble, vous perdez 4 jours par semaine. Réfléchissez-y.",
-  "Soirée improvisée ce soir ? Le premier qui dit oui déclenche la réaction en chaîne. `/wawptn-vote`",
-  "Je regarde votre liste de jeux en commun et franchement y'a de quoi faire. Bougez-vous.",
-  "Personne se manifeste depuis un moment. Vous êtes vivants au moins ? `/wawptn-random`",
-  "Ça vous dit pas un petit jeu vite fait ce soir ? Même une heure, c'est mieux que rien.",
-  "La semaine est longue, mais une soirée entre potes ça passe vite. `/wawptn-vote`",
-]
+import { getTodayPersona } from './personas.js'
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -51,10 +10,11 @@ function pickRandom(pool: string[]): string {
 }
 
 function buildReminderEmbed(message: string): EmbedBuilder {
+  const persona = getTodayPersona()
   return new EmbedBuilder()
     .setDescription(message)
-    .setColor(0x5865F2)
-    .setFooter({ text: 'WAWPTN — On joue à quoi ce soir ?' })
+    .setColor(persona.embedColor)
+    .setFooter({ text: `WAWPTN — ${persona.name}` })
 }
 
 async function sendToLinkedChannels(client: Client, pool: string[]): Promise<void> {
@@ -87,19 +47,10 @@ async function sendToLinkedChannels(client: Client, pool: string[]): Promise<voi
 
 // ─── Back online notification ─────────────────────────────────────────────────
 
-const BACK_ONLINE_MESSAGES = [
-  "C'est bon, je suis de retour ! Vous m'avez manqué... ou pas. `/wawptn-vote`",
-  "Me revoilà ! Qu'est-ce que j'ai raté ? Ah oui, rien, comme d'hab.",
-  "Mise à jour terminée, je suis de nouveau opérationnel. Qui est chaud ce soir ? `/wawptn-vote`",
-  "Désolé pour l'absence, j'avais des trucs à régler. On reprend où on en était ?",
-  "Je suis de retour et en pleine forme. Quelqu'un pour un `/wawptn-random` ?",
-  "Hop, je suis là ! Vous avez essayé de jouer sans moi ? Mauvaise idée.",
-  "Redémarrage terminé. Bon, on fait quoi ce soir du coup ? `/wawptn-vote`",
-  "Me revoilà les amis ! J'espère que personne a lancé de vote sans moi.",
-]
-
 export async function notifyBackOnline(client: Client): Promise<void> {
-  await sendToLinkedChannels(client, BACK_ONLINE_MESSAGES)
+  const persona = getTodayPersona()
+  console.log(`[persona] Today's persona: ${persona.name} (${persona.id})`)
+  await sendToLinkedChannels(client, persona.backOnlineMessages)
 }
 
 // ─── Cron jobs ────────────────────────────────────────────────────────────────
@@ -107,16 +58,20 @@ export async function notifyBackOnline(client: Client): Promise<void> {
 export function startScheduler(client: Client): void {
   // Friday at 21:00 Europe/Paris with random 0-15 min jitter
   cron.schedule('0 21 * * 5', () => {
+    const persona = getTodayPersona()
+    console.log(`[scheduler] Friday reminder triggered with persona: ${persona.name}`)
     const jitterMs = Math.floor(Math.random() * 15 * 60 * 1000)
-    console.log(`[scheduler] Friday reminder triggered, sending in ${Math.round(jitterMs / 1000)}s`)
-    setTimeout(() => sendToLinkedChannels(client, FRIDAY_MESSAGES), jitterMs)
+    console.log(`[scheduler] Sending in ${Math.round(jitterMs / 1000)}s`)
+    setTimeout(() => sendToLinkedChannels(client, persona.fridayMessages), jitterMs)
   }, { timezone: 'Europe/Paris' })
 
   // Wednesday at 17:00 Europe/Paris (weekday nudge)
   cron.schedule('0 17 * * 3', () => {
+    const persona = getTodayPersona()
+    console.log(`[scheduler] Weekday nudge triggered with persona: ${persona.name}`)
     const jitterMs = Math.floor(Math.random() * 15 * 60 * 1000)
-    console.log(`[scheduler] Weekday nudge triggered, sending in ${Math.round(jitterMs / 1000)}s`)
-    setTimeout(() => sendToLinkedChannels(client, WEEKDAY_MESSAGES), jitterMs)
+    console.log(`[scheduler] Sending in ${Math.round(jitterMs / 1000)}s`)
+    setTimeout(() => sendToLinkedChannels(client, persona.weekdayMessages), jitterMs)
   }, { timezone: 'Europe/Paris' })
 
   console.log('[scheduler] Scheduled reminders: Friday 21:00 + Wednesday 17:00 (Europe/Paris)')


### PR DESCRIPTION
## Résumé technique

### Contexte
Le bot Discord avait une seule voix (pote sarcastique) pour toutes ses interactions. Les utilisateurs voyaient toujours le même ton, ce qui pouvait devenir répétitif.

### Approche retenue
Registre statique de 7 personas avec sélection déterministe par hash de la date (Europe/Paris). Chaque persona fournit ses propres message pools ET un overlay pour le prompt système LLM, garantissant une cohérence totale entre messages statiques et réponses conversationnelles.

Alternative rejetée : génération dynamique par LLM (perte de contrôle, coût, incohérence) et stockage en base (complexité inutile pour de la configuration statique).

### Changements implémentés
| Fichier | Modification | Justification technique |
|---------|-------------|------------------------|
| `packages/discord/src/personas.ts` | **Nouveau** — 7 personas avec interface typée + sélection déterministe par date | Source unique de vérité pour la voix du bot |
| `packages/discord/src/scheduler.ts` | Utilise les pools du persona du jour au lieu des constantes hardcodées | Cohérence voix statique ↔ persona actif |
| `packages/discord/src/index.ts` | Passe `personaVoice` au backend via `/api/discord/chat` + utilise `emptyMentionReply` du persona | Cohérence voix LLM ↔ persona actif |
| `packages/backend/src/infrastructure/llm/client.ts` | Split du SYSTEM_PROMPT en base invariante + section personnalité remplaçable | Les règles de sécurité (jamais un bot, pas de leak tech) restent non-overridables |
| `packages/backend/src/presentation/routes/discord.routes.ts` | Lecture de `personaVoice` depuis le body et passage au `ChatContext` | Plomberie pour transmettre l'overlay persona |

### Personas inclus
1. **Le Pote Sarcastique** — l'original, drôle et taquin
2. **Le Narrateur Dramatique** — tout est ÉPIQUE
3. **Le Coach Motivation** — ultra-positif et encourageant
4. **Le Pince-Sans-Rire** — humour sec, blasé de tout
5. **Le Nostalgique Rétro** — références aux classiques
6. **Le Compétiteur** — tout est un défi amical
7. **Le Philosophe Zen** — sagesse absurde et décalée

### Points d'attention pour la revue
- La sélection est déterministe via `hashCode(dateStr) % 7` — même persona toute la journée, même après redémarrage
- Les règles invariantes (jamais un bot, pas de leak technique) sont dans `BASE_SYSTEM_PROMPT` et ne peuvent PAS être écrasées par un persona
- Le `personaVoice` est un string libre envoyé par le bot Discord — pas de risque d'injection car seul le bot authentifié peut appeler cette route
- Chaque persona a sa propre couleur d'embed Discord pour un feedback visuel

### Tests
- Type-check : ✅ discord et backend passent sans erreur
- Lint : ✅ aucune nouvelle erreur
- Pas de test unitaire dédié (la logique est un hash déterministe trivial)

### Prochaines étapes
- [ ] Revue de code par l'équipe
- [ ] Validation des tests CI
- [ ] Merge après approbation
- [ ] Optionnel : ajouter plus de personas dans le futur (simple ajout au tableau)

---
_Implémentation générée automatiquement par IA_