### PR TITLE
feat(admin): add admin role and back-office for bot settings

### DIFF
--- a/packages/backend/migrations/20260321_add_admin_role.ts
+++ b/packages/backend/migrations/20260321_add_admin_role.ts
@@ -1,0 +1,30 @@
+import type { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  // Add is_admin column to users table
+  await knex.schema.alterTable('users', (table) => {
+    table.boolean('is_admin').notNullable().defaultTo(false)
+  })
+
+  // Create app_settings table for runtime-configurable settings (bot config, etc.)
+  await knex.schema.createTable('app_settings', (table) => {
+    table.string('key', 100).primary()
+    table.jsonb('value').notNullable()
+    table.timestamp('updated_at', { useTz: true }).defaultTo(knex.fn.now())
+  })
+
+  // Seed default bot settings
+  await knex('app_settings').insert([
+    { key: 'bot.persona_rotation_enabled', value: JSON.stringify(true) },
+    { key: 'bot.friday_schedule', value: JSON.stringify('0 21 * * 5') },
+    { key: 'bot.wednesday_schedule', value: JSON.stringify('0 17 * * 3') },
+    { key: 'bot.schedule_timezone', value: JSON.stringify('Europe/Paris') },
+  ])
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists('app_settings')
+  await knex.schema.alterTable('users', (table) => {
+    table.dropColumn('is_admin')
+  })
+}

--- a/packages/backend/src/config/env.ts
+++ b/packages/backend/src/config/env.ts
@@ -25,6 +25,9 @@ export const env = {
   GOG_CLIENT_SECRET: process.env['GOG_CLIENT_SECRET'] || '',
   GOG_REDIRECT_URI: process.env['GOG_REDIRECT_URI'] || '',
 
+  // Admin (optional — Steam ID of the default admin user)
+  ADMIN_STEAM_ID: process.env['ADMIN_STEAM_ID'] || '',
+
   // Discord Bot (optional — feature-flagged)
   DISCORD_BOT_API_SECRET: process.env['DISCORD_BOT_API_SECRET'] || '',
 

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -17,7 +17,9 @@ import { voteRoutes } from './presentation/routes/vote.routes.js'
 import { inviteRoutes } from './presentation/routes/invite.routes.js'
 import { requireAuth } from './presentation/middleware/auth.middleware.js'
 import { requireBotAuth } from './presentation/middleware/bot-auth.middleware.js'
+import { requireAdmin } from './presentation/middleware/admin.middleware.js'
 import { discordRoutes, discordUserRoutes } from './presentation/routes/discord.routes.js'
+import { adminRoutes } from './presentation/routes/admin.routes.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -92,6 +94,9 @@ async function main() {
   app.use('/api/auth', authRoutes)
   app.use('/api/groups', requireAuth, groupRoutes)
   app.use('/api/groups', requireAuth, voteLimiter, voteRoutes)
+
+  // Admin routes (requires authenticated admin user)
+  app.use('/api/admin', requireAuth, requireAdmin, adminRoutes)
 
   // Discord user-facing routes (session auth, no bot auth required)
   app.use('/api/discord', discordUserRoutes)

--- a/packages/backend/src/presentation/middleware/admin.middleware.ts
+++ b/packages/backend/src/presentation/middleware/admin.middleware.ts
@@ -1,0 +1,18 @@
+import type { Request, Response, NextFunction } from 'express'
+import { db } from '../../infrastructure/database/connection.js'
+import { authLogger } from '../../infrastructure/logger/logger.js'
+
+export async function requireAdmin(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const user = await db('users').where({ id: req.userId }).select('is_admin').first()
+    if (!user?.is_admin) {
+      authLogger.warn({ userId: req.userId, path: req.path }, 'admin access denied')
+      res.status(403).json({ error: 'forbidden', message: 'Admin access required' })
+      return
+    }
+    next()
+  } catch (error) {
+    authLogger.error({ error: String(error), path: req.path }, 'admin middleware: database error')
+    res.status(403).json({ error: 'forbidden', message: 'Admin access required' })
+  }
+}

--- a/packages/backend/src/presentation/routes/admin.routes.ts
+++ b/packages/backend/src/presentation/routes/admin.routes.ts
@@ -1,0 +1,91 @@
+import { Router, type Request, type Response } from 'express'
+import { db } from '../../infrastructure/database/connection.js'
+import { authLogger } from '../../infrastructure/logger/logger.js'
+
+const router = Router()
+
+// ─── Bot settings ─────────────────────────────────────────────────────────────
+
+router.get('/bot-settings', async (_req: Request, res: Response) => {
+  const rows = await db('app_settings')
+    .where('key', 'like', 'bot.%')
+    .select('key', 'value', 'updated_at')
+
+  const settings: Record<string, unknown> = {}
+  for (const row of rows) {
+    // Strip the 'bot.' prefix for cleaner API response
+    const shortKey = row.key.replace(/^bot\./, '')
+    settings[shortKey] = row.value
+  }
+
+  res.json(settings)
+})
+
+router.patch('/bot-settings', async (req: Request, res: Response) => {
+  const updates = req.body as Record<string, unknown>
+
+  if (!updates || typeof updates !== 'object' || Object.keys(updates).length === 0) {
+    res.status(400).json({ error: 'validation', message: 'Request body must be a non-empty object' })
+    return
+  }
+
+  // Allowlist of valid settings keys
+  const allowedKeys = new Set([
+    'persona_rotation_enabled',
+    'friday_schedule',
+    'wednesday_schedule',
+    'schedule_timezone',
+  ])
+
+  const invalidKeys = Object.keys(updates).filter(k => !allowedKeys.has(k))
+  if (invalidKeys.length > 0) {
+    res.status(400).json({ error: 'validation', message: `Invalid settings keys: ${invalidKeys.join(', ')}` })
+    return
+  }
+
+  for (const [key, value] of Object.entries(updates)) {
+    await db('app_settings')
+      .where({ key: `bot.${key}` })
+      .update({
+        value: JSON.stringify(value),
+        updated_at: db.fn.now(),
+      })
+  }
+
+  authLogger.info({ userId: req.userId, keys: Object.keys(updates) }, 'admin updated bot settings')
+
+  res.json({ ok: true })
+})
+
+// ─── Users management ─────────────────────────────────────────────────────────
+
+router.get('/users', async (_req: Request, res: Response) => {
+  const users = await db('users')
+    .select('id', 'steam_id', 'display_name', 'avatar_url', 'is_admin', 'created_at')
+    .orderBy('created_at', 'asc')
+
+  res.json(users.map(u => ({
+    id: u.id,
+    steamId: u.steam_id,
+    displayName: u.display_name,
+    avatarUrl: u.avatar_url,
+    isAdmin: u.is_admin,
+    createdAt: u.created_at,
+  })))
+})
+
+// ─── Stats ────────────────────────────────────────────────────────────────────
+
+router.get('/stats', async (_req: Request, res: Response) => {
+  const userCount = await db('users').count('id as count').first()
+  const groupCount = await db('groups').count('id as count').first()
+  const sessionCount = await db('voting_sessions').count('id as count').first()
+
+  res.json({
+    users: Number(userCount?.count ?? 0),
+    groups: Number(groupCount?.count ?? 0),
+    votingSessions: Number(sessionCount?.count ?? 0),
+  })
+})
+
+export { router as adminRoutes }

--- a/packages/backend/src/presentation/routes/auth.routes.ts
+++ b/packages/backend/src/presentation/routes/auth.routes.ts
@@ -148,6 +148,12 @@ router.get('/steam/callback', async (req: Request, res: Response) => {
       authLogger.info({ steamId, displayName: profile.personaname }, 'new user created')
     }
 
+    // Admin promotion: set is_admin based on ADMIN_STEAM_ID env var
+    if (env.ADMIN_STEAM_ID && steamId === env.ADMIN_STEAM_ID && !user.is_admin) {
+      await db('users').where({ id: user.id }).update({ is_admin: true })
+      authLogger.info({ steamId }, 'admin status granted on login')
+    }
+
     // Ensure account link exists (for pre-migration users)
     const existingAccount = await db('accounts')
       .where({ user_id: user.id, provider_id: 'steam' })
@@ -221,6 +227,7 @@ router.get('/me', async (req: Request, res: Response) => {
       displayName: user.display_name,
       avatarUrl: user.avatar_url,
       libraryVisible: user.library_visible ?? true,
+      isAdmin: user.is_admin ?? false,
     })
   } catch (error) {
     authLogger.error({ error: String(error) }, 'get session: database error')

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { JoinPage } from '@/pages/JoinPage'
 import { ProfilePage } from '@/pages/ProfilePage'
 import { DiscordLinkPage } from '@/pages/DiscordLinkPage'
 import { NotFoundPage } from '@/pages/NotFoundPage'
+import { AdminPage } from '@/pages/AdminPage'
 import { Skeleton } from '@/components/ui/skeleton'
 import { DialogTestPage } from '@/pages/DialogTestPage'
 
@@ -62,6 +63,7 @@ function App() {
     <Routes>
       <Route path="/" element={<GroupsPage />} />
       <Route path="/profile" element={<ProfilePage />} />
+      <Route path="/admin" element={<AdminPage />} />
       <Route path="/groups/:id" element={<GroupPage />} />
       <Route path="/groups/:id/vote" element={<VotePage />} />
       <Route path="/join/:token" element={<JoinPage />} />

--- a/packages/frontend/src/components/app-header.tsx
+++ b/packages/frontend/src/components/app-header.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { Gamepad2, LogOut, User } from 'lucide-react'
+import { Gamepad2, LogOut, User, Shield } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { cn } from '@/lib/utils'
 import { useAuthStore } from '@/stores/auth.store'
@@ -93,6 +93,15 @@ export function AppHeader({ children, className, maxWidth = 'narrow' }: AppHeade
                   <User className="w-4 h-4" />
                   {t('profile.title')}
                 </button>
+                {user?.isAdmin && (
+                  <button
+                    className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground transition-colors"
+                    onClick={() => { setShowMenu(false); navigate('/admin') }}
+                  >
+                    <Shield className="w-4 h-4" />
+                    Administration
+                  </button>
+                )}
                 <button
                   className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-destructive hover:bg-destructive/10 transition-colors"
                   onClick={() => { setShowMenu(false); setShowLogoutDialog(true) }}

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -20,7 +20,7 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
 
 // Auth
 export const api = {
-  getMe: () => request<{ id: string; steamId: string; displayName: string; avatarUrl: string; libraryVisible: boolean }>('/auth/me'),
+  getMe: () => request<{ id: string; steamId: string; displayName: string; avatarUrl: string; libraryVisible: boolean; isAdmin: boolean }>('/auth/me'),
   logout: () => request('/auth/logout', { method: 'POST' }),
   getProfile: () => request<{
     id: string; steamId: string; displayName: string; avatarUrl: string; profileUrl: string | null;
@@ -116,4 +116,14 @@ export const api = {
   ),
   deleteVoteSession: (groupId: string, sessionId: string) =>
     request<{ ok: boolean }>(`/groups/${groupId}/vote/${sessionId}`, { method: 'DELETE' }),
+
+  // Admin
+  getAdminBotSettings: () => request<Record<string, unknown>>('/admin/bot-settings'),
+  updateAdminBotSettings: (settings: Record<string, unknown>) =>
+    request<{ ok: boolean }>('/admin/bot-settings', {
+      method: 'PATCH',
+      body: JSON.stringify(settings),
+    }),
+  getAdminStats: () => request<{ users: number; groups: number; votingSessions: number }>('/admin/stats'),
+  getAdminUsers: () => request<{ id: string; steamId: string; displayName: string; avatarUrl: string; isAdmin: boolean; createdAt: string }[]>('/admin/users'),
 }

--- a/packages/frontend/src/pages/AdminPage.tsx
+++ b/packages/frontend/src/pages/AdminPage.tsx
@@ -1,0 +1,252 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { ArrowLeft, Bot, Users, BarChart3, Save, RefreshCw } from 'lucide-react'
+import { toast } from 'sonner'
+import { AppHeader } from '@/components/app-header'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
+import { Badge } from '@/components/ui/badge'
+import { useAuthStore } from '@/stores/auth.store'
+import { api } from '@/lib/api'
+
+interface BotSettings {
+  persona_rotation_enabled: boolean
+  friday_schedule: string
+  wednesday_schedule: string
+  schedule_timezone: string
+}
+
+interface AdminStats {
+  users: number
+  groups: number
+  votingSessions: number
+}
+
+interface AdminUser {
+  id: string
+  steamId: string
+  displayName: string
+  avatarUrl: string
+  isAdmin: boolean
+  createdAt: string
+}
+
+export function AdminPage() {
+  const navigate = useNavigate()
+  const { user } = useAuthStore()
+  const [settings, setSettings] = useState<BotSettings | null>(null)
+  const [stats, setStats] = useState<AdminStats | null>(null)
+  const [users, setUsers] = useState<AdminUser[]>([])
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    if (user && !user.isAdmin) {
+      navigate('/')
+      return
+    }
+    loadData()
+  }, [user, navigate])
+
+  async function loadData() {
+    try {
+      const [settingsData, statsData, usersData] = await Promise.all([
+        api.getAdminBotSettings(),
+        api.getAdminStats(),
+        api.getAdminUsers(),
+      ])
+      setSettings(settingsData as unknown as BotSettings)
+      setStats(statsData)
+      setUsers(usersData)
+    } catch {
+      toast.error('Erreur lors du chargement des données admin')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function handleSave() {
+    if (!settings) return
+    setSaving(true)
+    try {
+      await api.updateAdminBotSettings(settings as unknown as Record<string, unknown>)
+      toast.success('Paramètres sauvegardés')
+    } catch {
+      toast.error('Erreur lors de la sauvegarde')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (!user?.isAdmin) return null
+
+  return (
+    <div className="min-h-screen bg-background">
+      <AppHeader>
+        <Button variant="ghost" size="icon" onClick={() => navigate('/')}>
+          <ArrowLeft className="h-5 w-5" />
+        </Button>
+      </AppHeader>
+
+      <main id="main-content" className="mx-auto max-w-2xl px-4 py-6 space-y-6" style={{ paddingLeft: 'max(1rem, env(safe-area-inset-left))', paddingRight: 'max(1rem, env(safe-area-inset-right))' }}>
+        <div className="flex items-center justify-between">
+          <h1 className="text-2xl font-bold">Administration</h1>
+          <Badge variant="outline">Admin</Badge>
+        </div>
+
+        {/* Stats */}
+        {loading ? (
+          <div className="grid grid-cols-3 gap-4">
+            {[1, 2, 3].map(i => <Skeleton key={i} className="h-24" />)}
+          </div>
+        ) : stats && (
+          <div className="grid grid-cols-3 gap-4">
+            <Card>
+              <CardContent className="pt-4 pb-4 text-center">
+                <Users className="h-5 w-5 mx-auto mb-1 text-muted-foreground" />
+                <div className="text-2xl font-bold">{stats.users}</div>
+                <div className="text-xs text-muted-foreground">Utilisateurs</div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardContent className="pt-4 pb-4 text-center">
+                <BarChart3 className="h-5 w-5 mx-auto mb-1 text-muted-foreground" />
+                <div className="text-2xl font-bold">{stats.groups}</div>
+                <div className="text-xs text-muted-foreground">Groupes</div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardContent className="pt-4 pb-4 text-center">
+                <Bot className="h-5 w-5 mx-auto mb-1 text-muted-foreground" />
+                <div className="text-2xl font-bold">{stats.votingSessions}</div>
+                <div className="text-xs text-muted-foreground">Sessions de vote</div>
+              </CardContent>
+            </Card>
+          </div>
+        )}
+
+        {/* Bot Settings */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Bot className="h-5 w-5" />
+              Paramètres du bot Discord
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {loading ? (
+              <div className="space-y-4">
+                {[1, 2, 3, 4].map(i => <Skeleton key={i} className="h-10" />)}
+              </div>
+            ) : settings && (
+              <>
+                <div className="flex items-center gap-3">
+                  <Checkbox
+                    id="persona-rotation"
+                    checked={settings.persona_rotation_enabled}
+                    onCheckedChange={(checked) =>
+                      setSettings({ ...settings, persona_rotation_enabled: checked === true })
+                    }
+                  />
+                  <label htmlFor="persona-rotation" className="text-sm font-medium cursor-pointer">
+                    Rotation des personas activée
+                  </label>
+                </div>
+
+                <div className="space-y-1.5">
+                  <label htmlFor="friday-schedule" className="text-sm font-medium">
+                    Rappel vendredi (cron)
+                  </label>
+                  <Input
+                    id="friday-schedule"
+                    value={settings.friday_schedule}
+                    onChange={(e) => setSettings({ ...settings, friday_schedule: e.target.value })}
+                    placeholder="0 21 * * 5"
+                  />
+                  <p className="text-xs text-muted-foreground">Expression cron pour le rappel du vendredi soir</p>
+                </div>
+
+                <div className="space-y-1.5">
+                  <label htmlFor="wednesday-schedule" className="text-sm font-medium">
+                    Rappel semaine (cron)
+                  </label>
+                  <Input
+                    id="wednesday-schedule"
+                    value={settings.wednesday_schedule}
+                    onChange={(e) => setSettings({ ...settings, wednesday_schedule: e.target.value })}
+                    placeholder="0 17 * * 3"
+                  />
+                  <p className="text-xs text-muted-foreground">Expression cron pour le rappel en semaine</p>
+                </div>
+
+                <div className="space-y-1.5">
+                  <label htmlFor="timezone" className="text-sm font-medium">
+                    Fuseau horaire
+                  </label>
+                  <Input
+                    id="timezone"
+                    value={settings.schedule_timezone}
+                    onChange={(e) => setSettings({ ...settings, schedule_timezone: e.target.value })}
+                    placeholder="Europe/Paris"
+                  />
+                </div>
+
+                <div className="flex gap-2 pt-2">
+                  <Button onClick={handleSave} disabled={saving} className="gap-2">
+                    <Save className="h-4 w-4" />
+                    {saving ? 'Sauvegarde...' : 'Sauvegarder'}
+                  </Button>
+                  <Button variant="outline" onClick={loadData} className="gap-2">
+                    <RefreshCw className="h-4 w-4" />
+                    Recharger
+                  </Button>
+                </div>
+              </>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Users List */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Users className="h-5 w-5" />
+              Utilisateurs ({users.length})
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {loading ? (
+              <div className="space-y-3">
+                {[1, 2, 3].map(i => <Skeleton key={i} className="h-12" />)}
+              </div>
+            ) : (
+              <div className="space-y-2">
+                {users.map((u) => (
+                  <div key={u.id} className="flex items-center gap-3 rounded-md border border-border p-3">
+                    <Avatar className="h-8 w-8">
+                      <AvatarImage src={u.avatarUrl} alt={u.displayName} />
+                      <AvatarFallback>{u.displayName.charAt(0).toUpperCase()}</AvatarFallback>
+                    </Avatar>
+                    <div className="flex-1 min-w-0">
+                      <div className="text-sm font-medium truncate">{u.displayName}</div>
+                      <div className="text-xs text-muted-foreground">
+                        Inscrit le {new Date(u.createdAt).toLocaleDateString('fr-FR')}
+                      </div>
+                    </div>
+                    {u.isAdmin && (
+                      <Badge variant="default">Admin</Badge>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </main>
+    </div>
+  )
+}

--- a/packages/frontend/src/stores/auth.store.ts
+++ b/packages/frontend/src/stores/auth.store.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand'
 import { api } from '@/lib/api'
 
 interface AuthState {
-  user: { id: string; steamId: string; displayName: string; avatarUrl: string; libraryVisible: boolean } | null
+  user: { id: string; steamId: string; displayName: string; avatarUrl: string; libraryVisible: boolean; isAdmin: boolean } | null
   loading: boolean
   fetchUser: () => Promise<void>
   logout: () => Promise<void>

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -10,6 +10,7 @@ export interface User {
   profileUrl: string | null
   email: string | null
   libraryVisible: boolean
+  isAdmin: boolean
   createdAt: string
   updatedAt: string
 }


### PR DESCRIPTION
## Résumé technique

### Contexte
L'application n'avait aucun système d'administration global. Les seuls rôles existants étaient au niveau des groupes (owner/member). Wifsimster, en tant que créateur de l'application, avait besoin d'un accès admin pour gérer les paramètres du bot Discord depuis une interface web.

### Approche retenue
Colonne `is_admin BOOLEAN DEFAULT false` sur la table `users` + variable d'environnement `ADMIN_STEAM_ID` pour promouvoir automatiquement l'admin au login Steam. Pas de système RBAC complet — un boolean suffit pour une application à admin unique.

Alternatives rejetées :
- Table roles/permissions RBAC : over-engineering pour un seul admin
- JWT claims pour le rôle admin : incompatible avec le système de sessions DB existant, pas de révocation instantanée
- Hardcoding du Steam ID dans le code : fuite d'identité dans git history, nécessite un redeploy pour changer

### Changements implémentés
| Fichier | Modification | Justification technique |
|---------|-------------|------------------------|
| `migrations/20260321_add_admin_role.ts` | Ajout `is_admin` + table `app_settings` | Infrastructure admin + settings configurables à chaud |
| `config/env.ts` | Ajout `ADMIN_STEAM_ID` | Promotion admin via env var, pas de hardcoding |
| `middleware/admin.middleware.ts` | **Nouveau** — requireAdmin | Vérification DB à chaque requête admin, pas de trust client |
| `routes/admin.routes.ts` | **Nouveau** — CRUD bot settings + stats + users | Routes protégées par requireAuth + requireAdmin |
| `routes/auth.routes.ts` | Promotion admin au login + isAdmin dans /me | Promotion automatique et exposition côté client |
| `index.ts` | Montage `/api/admin` avec middlewares | Toutes les routes admin derrière double auth |
| `types/index.ts` | Ajout `isAdmin` à `User` | Contrat partagé backend/frontend |
| `stores/auth.store.ts` | Ajout `isAdmin` au user | State frontend pour le guard UI |
| `lib/api.ts` | Ajout méthodes admin API | Client API typé pour les endpoints admin |
| `pages/AdminPage.tsx` | **Nouveau** — Dashboard admin | Stats, paramètres bot, liste utilisateurs |
| `App.tsx` | Route `/admin` | Navigation admin |
| `components/app-header.tsx` | Lien admin dans le menu | Visible uniquement pour les admins |

### Points d'attention pour la revue
- Le middleware `requireAdmin` re-query la DB à chaque requête — c'est intentionnel pour permettre la révocation instantanée
- La promotion admin se fait uniquement au login Steam, pas via une API — pas de surface d'attaque pour l'escalade de privilèges
- Le frontend guard (`isAdmin`) est cosmétique — la sécurité réelle est côté serveur
- Les settings bot sont stockées en JSONB avec un allowlist strict côté API (pas d'injection de clés arbitraires)
- `ADMIN_STEAM_ID` doit être configuré dans les env vars de production (compose.yml)

### Tests
- Type-check backend : OK (0 erreurs)
- Type-check frontend : OK (0 erreurs)
- Lint : OK (0 nouvelles erreurs)

### Étapes restantes
- [ ] Configurer `ADMIN_STEAM_ID` dans compose.yml / env de production
- [ ] Wiring du Discord bot aux settings DB (le bot lit actuellement des valeurs hardcodées)
- [ ] Ajout d'une page de gestion des personas (activation/désactivation individuelle)
- [ ] Possibilité d'ajouter d'autres admins depuis l'interface

_Attention : d'autres branches fast-meeting sont actives (`feat/fm-bot-game-links`, `feat/fm-daily-persona`, `refactor/fm-bot-persona`). Vérifier les conflits potentiels avant merge._

---
_Implémentation générée automatiquement par IA_