### PR TITLE
fix(pwa): exclude /api/ from service worker navigation fallback

### DIFF
--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -54,6 +54,7 @@ export default defineConfig({
       },
       workbox: {
         globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
+        navigateFallbackDenylist: [/^\/api\//, /^\/health$/, /^\/invite\//],
         runtimeCaching: [
           {
             urlPattern: /^https:\/\/avatars\.steamstatic\.com\/.*/i,


### PR DESCRIPTION
## Résumé

Le service worker PWA interceptait les navigations vers `/api/auth/steam/login` et servait le `index.html` mis en cache au lieu de laisser le navigateur atteindre le backend. Résultat : cliquer sur « Se connecter avec Steam » ne faisait que recharger la page.

### Cause
Workbox `navigateFallback` (défaut de vite-plugin-pwa) répond à TOUTES les requêtes de navigation avec le shell SPA. Aucun `navigateFallbackDenylist` n'était configuré pour exclure les routes backend.

### Correction
```typescript
navigateFallbackDenylist: [/^\/api\//, /^\/health$/, /^\/invite\//]
```

### Impact
**Bloquant** — impossible de se connecter via Steam sur la version déployée.

Note : les utilisateurs devront peut-être vider le cache du site ou attendre que le service worker se mette à jour automatiquement (`registerType: 'autoUpdate'`).