### PR TITLE
feat(persona): show current bot persona in app header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -86,6 +86,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -7822,6 +7823,7 @@
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -7860,6 +7862,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.5.tgz",
       "integrity": "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -7903,6 +7906,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -7913,6 +7917,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -8029,6 +8034,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -8332,6 +8338,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8376,6 +8383,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -8718,6 +8726,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -9130,6 +9139,7 @@
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -9573,6 +9583,7 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -9970,6 +9981,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -10262,6 +10274,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -11236,6 +11249,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.4.tgz",
       "integrity": "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -11326,6 +11340,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4"
       },
@@ -14245,6 +14260,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14254,6 +14270,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -15724,6 +15741,7 @@
       "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -16103,6 +16121,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16431,6 +16450,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -16900,6 +16920,7 @@
       "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -17104,6 +17125,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -17247,6 +17269,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -24,6 +24,7 @@ import { discordRoutes, discordUserRoutes } from './presentation/routes/discord.
 import { adminRoutes } from './presentation/routes/admin.routes.js'
 import { subscriptionRoutes, subscriptionWebhookRouter } from './presentation/routes/subscription.routes.js'
 import { isStripeEnabled } from './infrastructure/stripe/stripe-client.js'
+import { personaRoutes } from './presentation/routes/persona.routes.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -112,6 +113,9 @@ async function main() {
   app.use('/api/auth', authRoutes)
   app.use('/api/groups', requireAuth, groupRoutes)
   app.use('/api/groups', requireAuth, voteLimiter, voteRoutes)
+
+  // Persona route (public, read-only — shows today's bot personality)
+  app.use('/api/persona', personaRoutes)
 
   // Admin routes (requires authenticated admin user)
   app.use('/api/admin', requireAuth, requireAdmin, adminRoutes)

--- a/packages/backend/src/presentation/routes/persona.routes.ts
+++ b/packages/backend/src/presentation/routes/persona.routes.ts
@@ -1,0 +1,90 @@
+import { Router, type Request, type Response } from 'express'
+import { db } from '../../infrastructure/database/connection.js'
+import { logger } from '../../infrastructure/logger/logger.js'
+
+const router = Router()
+
+// In-memory cache (persona changes at most once per day)
+let cachedPersona: { id: string; name: string; embedColor: number; introMessage: string } | null = null
+let cacheExpiry = 0
+
+/**
+ * djb2 string hash — deterministic, same as packages/discord/src/personas.ts.
+ * Keep in sync with the Discord bot's hashCode function.
+ */
+function hashCode(str: string): number {
+  let hash = 5381
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) + hash + str.charCodeAt(i)) | 0
+  }
+  return Math.abs(hash)
+}
+
+// GET /api/persona/current — public, returns today's active persona
+router.get('/current', async (_req: Request, res: Response) => {
+  try {
+    const now = Date.now()
+    if (cachedPersona && now < cacheExpiry) {
+      res.json(cachedPersona)
+      return
+    }
+
+    // Check if rotation is enabled
+    const rotationSetting = await db('app_settings')
+      .where({ key: 'bot.persona_rotation_enabled' })
+      .select('value')
+      .first()
+    const rotationEnabled = rotationSetting?.value === true
+
+    // Get disabled personas list
+    const disabledSetting = await db('app_settings')
+      .where({ key: 'bot.disabled_personas' })
+      .select('value')
+      .first()
+    const disabledIds: string[] = Array.isArray(disabledSetting?.value) ? disabledSetting.value : []
+
+    // Fetch active personas
+    const personas = await db('personas')
+      .where({ is_active: true })
+      .orderBy('created_at', 'asc')
+      .select('id', 'name', 'embed_color', 'intro_message')
+
+    if (personas.length === 0) {
+      res.status(404).json({ error: 'not_found', message: 'No active personas' })
+      return
+    }
+
+    let selected
+
+    if (!rotationEnabled) {
+      // No rotation: use first active persona (default)
+      selected = personas[0]
+    } else {
+      // Filter out disabled personas
+      const available = disabledIds.length > 0
+        ? personas.filter((p: { id: string }) => !disabledIds.includes(p.id))
+        : personas
+      const pool = available.length > 0 ? available : personas
+
+      // Deterministic selection based on date (Europe/Paris timezone)
+      const dateStr = new Date().toLocaleDateString('en-CA', { timeZone: 'Europe/Paris' })
+      const index = hashCode(dateStr) % pool.length
+      selected = pool[index]
+    }
+
+    cachedPersona = {
+      id: selected.id,
+      name: selected.name,
+      embedColor: selected.embed_color,
+      introMessage: selected.intro_message,
+    }
+    cacheExpiry = now + 5 * 60 * 1000 // 5 minutes
+
+    res.json(cachedPersona)
+  } catch (error) {
+    logger.error({ error: String(error) }, 'persona: failed to get current')
+    res.status(500).json({ error: 'internal', message: 'Failed to get current persona' })
+  }
+})
+
+export { router as personaRoutes }

--- a/packages/frontend/src/components/app-header.tsx
+++ b/packages/frontend/src/components/app-header.tsx
@@ -7,6 +7,7 @@ import { useAuthStore } from '@/stores/auth.store'
 import { useSubscriptionStore } from '@/stores/subscription.store'
 import { Button } from '@/components/ui/button'
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
+import { PersonaBadge } from '@/components/persona-badge'
 import {
   ResponsiveDialog,
   ResponsiveDialogContent,
@@ -58,6 +59,9 @@ export function AppHeader({ children, className, maxWidth = 'narrow' }: AppHeade
           </span>
         </button>
         <div className="flex-1" />
+
+        {/* Today's bot persona */}
+        {user && <PersonaBadge />}
 
         {/* User menu */}
         <div className="relative">

--- a/packages/frontend/src/components/persona-badge.tsx
+++ b/packages/frontend/src/components/persona-badge.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { motion } from 'framer-motion'
+import { Badge } from '@/components/ui/badge'
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
+import { api } from '@/lib/api'
+
+interface PersonaData {
+  name: string
+  embedColor: number
+  introMessage: string
+}
+
+function colorIntToHex(color: number): string {
+  return `#${color.toString(16).padStart(6, '0')}`
+}
+
+export function PersonaBadge() {
+  const { t } = useTranslation()
+  const [persona, setPersona] = useState<PersonaData | null>(null)
+
+  useEffect(() => {
+    api.getCurrentPersona()
+      .then(setPersona)
+      .catch(() => {})
+  }, [])
+
+  if (!persona) return null
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, scale: 0.9 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={{ duration: 0.3 }}
+    >
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Badge variant="outline" className="gap-1.5 cursor-default text-xs">
+            <span
+              className="w-2.5 h-2.5 rounded-full shrink-0"
+              style={{ backgroundColor: colorIntToHex(persona.embedColor) }}
+            />
+            <span className="hidden sm:inline truncate max-w-[120px]">
+              {persona.name}
+            </span>
+          </Badge>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" className="max-w-[250px]">
+          <p className="font-medium text-xs">{t('persona.today')}</p>
+          <p className="text-xs text-muted-foreground mt-0.5">{persona.introMessage}</p>
+        </TooltipContent>
+      </Tooltip>
+    </motion.div>
+  )
+}

--- a/packages/frontend/src/i18n/locales/fr.json
+++ b/packages/frontend/src/i18n/locales/fr.json
@@ -356,5 +356,8 @@
     "autoVote": "Vote automatique",
     "groupLimitReached": "Limite de groupes atteinte ({{max}}). Passe en Premium pour des groupes illimités.",
     "memberLimitReached": "Ce groupe a atteint la limite de membres gratuite ({{max}})."
+  },
+  "persona": {
+    "today": "Persona du jour"
   }
 }

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -162,6 +162,9 @@ export const api = {
   deleteVoteSession: (groupId: string, sessionId: string) =>
     request<{ ok: boolean }>(`/groups/${groupId}/vote/${sessionId}`, { method: 'DELETE' }),
 
+  // Persona
+  getCurrentPersona: () => request<{ id: string; name: string; embedColor: number; introMessage: string }>('/persona/current'),
+
   // Admin
   getAdminBotSettings: () => request<Record<string, unknown>>('/admin/bot-settings'),
   updateAdminBotSettings: (settings: Record<string, unknown>) =>


### PR DESCRIPTION
## Résumé technique

### Contexte
Les utilisateurs n'ont aucun moyen de savoir quelle personnalité le bot Discord utilise aujourd'hui. L'information n'est visible que dans Discord (footer des messages) et dans le panneau admin.

### Approche retenue
Badge coloré dans le **header** (visible sur toutes les pages authentifiées) avec Tooltip montrant l'intro_message de la persona. Endpoint backend public dédié — pas de leak du `system_prompt_overlay`.

Décision issue d'un fast meeting : Sprint Zero Sarah (PO), Pixel-Perfect Hugo (Frontend), Whiteboard Damien (Architecte).

### Changements implémentés
| Fichier | Modification | Justification |
|---------|-------------|---------------|
| `persona.routes.ts` (nouveau) | `GET /api/persona/current` — public, read-only | Endpoint dédié évite de leaker le system prompt |
| `index.ts` | Enregistrement route `/api/persona` | Public, pas d'auth nécessaire |
| `persona-badge.tsx` (nouveau) | Badge avec dot coloré + nom + Tooltip intro | Framer Motion animation, responsive (dot seul sur mobile) |
| `app-header.tsx` | Intégration du `<PersonaBadge />` | Visible sur toutes les pages authentifiées |
| `api.ts` | `getCurrentPersona()` method | Retourne { id, name, embedColor, introMessage } |
| `fr.json` | Clé `persona.today` | "Persona du jour" |

### Architecture
- La logique de sélection (djb2 hash + date Europe/Paris) est **dupliquée** depuis `packages/discord/src/personas.ts`
- Commentaire "keep in sync" ajouté — refactor vers `@wawptn/types` planifié
- Cache mémoire 5 min côté backend (même fréquence que le bot Discord)
- Dégradation gracieuse : si l'endpoint échoue, le badge ne s'affiche pas

### Points d'attention
- Le hash djb2 doit rester identique à celui du package Discord
- L'endpoint ne retourne pas le `system_prompt_overlay` (sécurité)
- Le badge est conditionnel à `{user && <PersonaBadge />}` (pas visible sur la landing page)

### Tests
- Backend type-check : ✅ clean
- Frontend lint : ✅ 0 erreur

> _Attention : d'autres branches fast-meeting sont actives (`feat/fm-admin-backoffice`, `feat/fm-saas-subscription`). Vérifier les conflits potentiels avant merge._

---
_Implémentation générée automatiquement par IA suite à un fast meeting_