### PR TITLE
feat(frontend): custom brand identity and visual polish

### DIFF
--- a/packages/frontend/public/logo.svg
+++ b/packages/frontend/public/logo.svg
@@ -1,0 +1,11 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="512" y2="512" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#7C3AED"/>
+      <stop offset="1" stop-color="#4338CA"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="108" fill="url(#bg)"/>
+  <path d="M196 196c0-44 36-80 80-80s80 36 80 80c0 35-24 56-48 70l-8 5v21h-40v-50l12-8c16-10 28-22 28-38 0-22-18-40-40-40s-40 18-40 40" stroke="#fff" stroke-width="32" stroke-linecap="round"/>
+  <path d="M264 360l24 24-24 24-24-24z" fill="#FBBF24"/>
+</svg>

--- a/packages/frontend/src/components/app-header.tsx
+++ b/packages/frontend/src/components/app-header.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { Gamepad2, LogOut, User, Shield, Crown } from 'lucide-react'
+import { LogOut, User, Shield, Crown } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { cn } from '@/lib/utils'
 import { useAuthStore } from '@/stores/auth.store'
@@ -16,6 +16,7 @@ import {
   ResponsiveDialogHeader,
   ResponsiveDialogTitle,
 } from '@/components/ui/responsive-dialog'
+import { WawptnLogo } from '@/components/icons/wawptn-logo'
 
 interface AppHeaderProps {
   children?: React.ReactNode
@@ -52,7 +53,7 @@ export function AppHeader({ children, className, maxWidth = 'narrow' }: AppHeade
           className="flex items-center gap-2 hover:opacity-80 transition-opacity"
           aria-label={t('app.name') + ' — ' + t('app.tagline')}
         >
-          <Gamepad2 className="h-6 w-6 text-primary" />
+          <WawptnLogo size={28} className="text-primary" />
           <span className="font-bold text-lg tracking-tight">WAWPTN</span>
           <span className="ml-2 text-xs text-muted-foreground/60 leading-tight hidden sm:inline">
             v{__APP_VERSION__} — {new Date(__BUILD_TIME__).toLocaleString('fr-FR', { day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit' })}
@@ -103,7 +104,7 @@ export function AppHeader({ children, className, maxWidth = 'narrow' }: AppHeade
                   className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground transition-colors"
                   onClick={() => { setShowMenu(false); navigate('/subscription') }}
                 >
-                  <Crown className={cn('w-4 h-4', tier === 'premium' ? 'text-yellow-500' : 'text-muted-foreground')} />
+                  <Crown className={cn('w-4 h-4', tier === 'premium' ? 'text-reward' : 'text-muted-foreground')} />
                   {tier === 'premium' ? t('subscription.premium') : t('subscription.upgrade')}
                 </button>
                 {user?.isAdmin && (

--- a/packages/frontend/src/components/icons/wawptn-logo.tsx
+++ b/packages/frontend/src/components/icons/wawptn-logo.tsx
@@ -1,0 +1,59 @@
+import { cn } from '@/lib/utils'
+
+interface WawptnLogoProps {
+  size?: number
+  className?: string
+  variant?: 'mono' | 'color'
+}
+
+export function WawptnLogo({ size = 24, className, variant = 'mono' }: WawptnLogoProps) {
+  if (variant === 'color') {
+    return (
+      <svg
+        width={size}
+        height={size}
+        viewBox="0 0 48 48"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        className={className}
+        aria-hidden="true"
+      >
+        <defs>
+          <linearGradient id="wawptn-bg" x1="0" y1="0" x2="48" y2="48" gradientUnits="userSpaceOnUse">
+            <stop stopColor="#7C3AED" />
+            <stop offset="1" stopColor="#4338CA" />
+          </linearGradient>
+        </defs>
+        <rect width="48" height="48" rx="10" fill="url(#wawptn-bg)" />
+        <path
+          d="M18.5 18.5c0-4 3.3-7.5 7.5-7.5s7.5 3.5 7.5 7.5c0 3.2-2.2 5.2-4.5 6.5l-.7.5V27h-3.8v-4.7l1.1-.7c1.5-1 2.6-2 2.6-3.6 0-2-1.7-3.7-3.7-3.7s-3.7 1.7-3.7 3.7"
+          stroke="#fff"
+          strokeWidth="3"
+          strokeLinecap="round"
+        />
+        <path d="M24.8 33.5l2.2 2.2-2.2 2.2-2.2-2.2z" fill="#FBBF24" />
+      </svg>
+    )
+  }
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 48 48"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={cn('shrink-0', className)}
+      aria-hidden="true"
+    >
+      <rect x="2" y="2" width="44" height="44" rx="10" fill="currentColor" fillOpacity="0.1" stroke="currentColor" strokeWidth="1.5" strokeOpacity="0.15" />
+      <path
+        d="M18.5 18.5c0-4 3.3-7.5 7.5-7.5s7.5 3.5 7.5 7.5c0 3.2-2.2 5.2-4.5 6.5l-.7.5V27h-3.8v-4.7l1.1-.7c1.5-1 2.6-2 2.6-3.6 0-2-1.7-3.7-3.7-3.7s-3.7 1.7-3.7 3.7"
+        stroke="currentColor"
+        strokeWidth="3"
+        strokeLinecap="round"
+      />
+      <path d="M24.8 33.5l2.2 2.2-2.2 2.2-2.2-2.2z" fill="currentColor" />
+    </svg>
+  )
+}

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -40,6 +40,8 @@
   --steam-light: oklch(0.317 0.034 238);
   --steam-foreground: oklch(0.985 0 0);
   --success: oklch(0.723 0.191 142.5);
+  --reward: oklch(0.795 0.160 75);
+  --reward-foreground: oklch(0.25 0.05 75);
 }
 
 @theme inline {
@@ -80,6 +82,8 @@
   --color-steam-light: var(--steam-light);
   --color-steam-foreground: var(--steam-foreground);
   --color-success: var(--success);
+  --color-reward: var(--reward);
+  --color-reward-foreground: var(--reward-foreground);
   --radius-sm: calc(var(--radius) * 0.6);
   --radius-md: calc(var(--radius) * 0.8);
   --radius-lg: var(--radius);

--- a/packages/frontend/src/pages/LandingPage.tsx
+++ b/packages/frontend/src/pages/LandingPage.tsx
@@ -1,9 +1,10 @@
-import { Gamepad2, Users, Vote, Sparkles, Check, Crown, Zap } from 'lucide-react'
+import { Users, Vote, Sparkles, Check, Crown, Zap } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { motion } from 'framer-motion'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
+import { WawptnLogo } from '@/components/icons/wawptn-logo'
 
 const fadeUp = {
   hidden: { opacity: 0, y: 20 },
@@ -27,8 +28,8 @@ export function LandingPage() {
           animate="visible"
           variants={stagger}
         >
-          <motion.div variants={fadeUp} className="flex items-center justify-center gap-3 mb-6">
-            <Gamepad2 className="w-16 h-16 text-primary" />
+          <motion.div variants={fadeUp} className="flex items-center justify-center gap-4 mb-6">
+            <WawptnLogo size={64} variant="color" />
             <h1 className="text-5xl sm:text-6xl font-bold tracking-tight">WAWPTN</h1>
           </motion.div>
           <motion.p variants={fadeUp} className="text-2xl sm:text-3xl text-muted-foreground mb-4">
@@ -157,13 +158,13 @@ export function LandingPage() {
 
             {/* Premium Tier */}
             <motion.div variants={fadeUp}>
-              <Card className="h-full border-primary/50 relative">
-                <Badge className="absolute -top-3 left-1/2 -translate-x-1/2" variant="default">
+              <Card className="h-full border-reward/50 bg-gradient-to-br from-reward/[0.06] to-transparent relative">
+                <Badge className="absolute -top-3 left-1/2 -translate-x-1/2 bg-reward text-reward-foreground hover:bg-reward/90">
                   {t('landing.premiumBadge')}
                 </Badge>
                 <CardHeader>
                   <div className="flex items-center gap-2 mb-2">
-                    <Crown className="w-6 h-6 text-yellow-500" />
+                    <Crown className="w-6 h-6 text-reward" />
                     <CardTitle className="text-xl">{t('landing.premiumTierName')}</CardTitle>
                   </div>
                   <p className="text-3xl font-bold">
@@ -175,7 +176,7 @@ export function LandingPage() {
                   <ul className="space-y-3">
                     {(['premiumFeature1', 'premiumFeature2', 'premiumFeature3', 'premiumFeature4', 'premiumFeature5'] as const).map((key) => (
                       <li key={key} className="flex items-start gap-2">
-                        <Check className="w-5 h-5 text-yellow-500 mt-0.5 shrink-0" />
+                        <Check className="w-5 h-5 text-reward mt-0.5 shrink-0" />
                         <span className="text-sm">{t(`landing.${key}`)}</span>
                       </li>
                     ))}
@@ -191,10 +192,12 @@ export function LandingPage() {
       </section>
 
       {/* Footer */}
-      <footer className="border-t border-border px-4 py-6 text-center text-sm text-muted-foreground">
-        <p>
-          WAWPTN — {t('app.tagline')} — v{__APP_VERSION__}
-        </p>
+      <footer className="border-t border-border px-4 py-8 text-center text-sm text-muted-foreground">
+        <div className="flex items-center justify-center gap-2 mb-2">
+          <WawptnLogo size={20} className="text-muted-foreground" />
+          <span className="font-semibold">WAWPTN</span>
+        </div>
+        <p>{t('app.tagline')} — v{__APP_VERSION__}</p>
         <p className="mt-1 text-xs text-muted-foreground/50">
           {t('login.privacy')}
         </p>

--- a/packages/frontend/src/pages/LoginPage.tsx
+++ b/packages/frontend/src/pages/LoginPage.tsx
@@ -1,6 +1,6 @@
-import { Gamepad2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
+import { WawptnLogo } from '@/components/icons/wawptn-logo'
 
 export function LoginPage() {
   const { t } = useTranslation()
@@ -9,7 +9,7 @@ export function LoginPage() {
     <div className="min-h-screen flex flex-col items-center justify-center px-4">
       <div className="text-center mb-12">
         <div className="flex items-center justify-center gap-3 mb-4">
-          <Gamepad2 className="w-12 h-12 text-primary" />
+          <WawptnLogo size={48} variant="color" />
           <h1 className="text-4xl font-bold tracking-tight">WAWPTN</h1>
         </div>
         <p className="text-xl text-muted-foreground max-w-md">

--- a/packages/frontend/src/pages/VotePage.tsx
+++ b/packages/frontend/src/pages/VotePage.tsx
@@ -193,58 +193,75 @@ export function VotePage() {
 
   // Result screen
   if (result) {
+    const resultStagger = {
+      visible: { transition: { staggerChildren: prefersReducedMotion ? 0 : 0.15 } },
+    }
+    const resultFade = {
+      hidden: { opacity: 0, y: prefersReducedMotion ? 0 : 12 },
+      visible: { opacity: 1, y: 0, transition: { duration: prefersReducedMotion ? 0.2 : 0.5 } },
+    }
+
     return (
       <div className="min-h-screen flex flex-col items-center justify-center p-4">
         <AnimatePresence>
           <motion.div
-            initial={prefersReducedMotion ? { opacity: 0 } : { scale: 0.5, opacity: 0 }}
-            animate={prefersReducedMotion ? { opacity: 1 } : { scale: 1, opacity: 1 }}
-            transition={prefersReducedMotion ? { duration: 0.2 } : { type: 'spring', duration: 0.6 }}
+            initial="hidden"
+            animate="visible"
+            variants={resultStagger}
             className="text-center max-w-md w-full"
           >
-            <p className="text-sm text-muted-foreground mb-4 uppercase tracking-wide">{t('vote.tonightYouPlay')}</p>
+            <motion.p variants={resultFade} className="text-sm text-muted-foreground mb-4 uppercase tracking-widest">{t('vote.tonightYouPlay')}</motion.p>
             {result.headerImageUrl && (
-              <img
-                src={result.headerImageUrl}
-                alt={result.gameName}
-                className="w-full rounded-lg shadow-2xl mb-6"
-              />
+              <motion.div
+                variants={resultFade}
+                className="relative mb-6"
+              >
+                {/* Reward glow behind the image */}
+                <div className="absolute -inset-4 bg-reward/20 blur-3xl rounded-3xl pointer-events-none" aria-hidden="true" />
+                <img
+                  src={result.headerImageUrl}
+                  alt={result.gameName}
+                  className="relative w-full rounded-lg shadow-2xl ring-1 ring-reward/20"
+                />
+              </motion.div>
             )}
-            <h1 className="text-3xl font-bold mb-2">{result.gameName}</h1>
-            <p className="text-muted-foreground mb-8">
+            <motion.h1 variants={resultFade} className="text-3xl font-bold mb-2">{result.gameName}</motion.h1>
+            <motion.p variants={resultFade} className="text-muted-foreground mb-8">
               {t('vote.votedFor', { yes: result.yesCount, total: result.totalVoters })}
-            </p>
+            </motion.p>
 
-            {Number.isInteger(result.steamAppId) && result.steamAppId > 0 && (
-              <Button variant="steam" size="lg" asChild>
-                <a href={`steam://run/${result.steamAppId}`} className="gap-2">
-                  <ExternalLink className="w-5 h-5" />
-                  {t('vote.launchSteam')}
-                </a>
-              </Button>
-            )}
-
-            <Button
-              variant="secondary"
-              className="block mx-auto mt-4"
-              onClick={handleRematch}
-              disabled={rematching}
-            >
-              {rematching ? (
-                <Loader2 className="w-4 h-4 animate-spin" />
-              ) : (
-                <RefreshCw className="w-4 h-4" />
+            <motion.div variants={resultFade}>
+              {Number.isInteger(result.steamAppId) && result.steamAppId > 0 && (
+                <Button variant="steam" size="lg" asChild>
+                  <a href={`steam://run/${result.steamAppId}`} className="gap-2">
+                    <ExternalLink className="w-5 h-5" />
+                    {t('vote.launchSteam')}
+                  </a>
+                </Button>
               )}
-              {t('vote.rematch')}
-            </Button>
 
-            <Button
-              variant="ghost"
-              className="block mx-auto mt-4"
-              onClick={() => navigate(`/groups/${id}`)}
-            >
-              {t('vote.backToGroup')}
-            </Button>
+              <Button
+                variant="secondary"
+                className="block mx-auto mt-4"
+                onClick={handleRematch}
+                disabled={rematching}
+              >
+                {rematching ? (
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                ) : (
+                  <RefreshCw className="w-4 h-4" />
+                )}
+                {t('vote.rematch')}
+              </Button>
+
+              <Button
+                variant="ghost"
+                className="block mx-auto mt-4"
+                onClick={() => navigate(`/groups/${id}`)}
+              >
+                {t('vote.backToGroup')}
+              </Button>
+            </motion.div>
           </motion.div>
         </AnimatePresence>
       </div>


### PR DESCRIPTION
## Résumé technique

### Contexte
L'application WAWPTN utilise actuellement une icône Lucide générique (`Gamepad2`) comme logo, sans favicon custom, et avec une palette de couleurs monochromatique sombre sans accent secondaire. L'écran de résultat de vote — le moment émotionnel le plus fort de l'app — est visuellement plat.

### Approche retenue
Décision issue d'un fast-meeting avec 4 personas (Frontend, UX/UI, PO, Architecte). Consensus unanime : créer un logo SVG custom, ajouter un token de couleur « reward » ambre/or, et investir dans l'écran de résultat de vote.

### Changements implémentés
| Fichier | Modification | Justification technique |
|---------|-------------|------------------------|
| `public/logo.svg` | Nouveau logo SVG (badge violet + "?" + point diamant doré) | Logo vectoriel scalable, fonctionne à 16px (favicon) et 512px (PWA) |
| `components/icons/wawptn-logo.tsx` | Composant React avec variantes `mono`/`color` | SVG inline, hérite `currentColor`, props `size`/`variant` |
| `index.css` | Ajout tokens `--reward` et `--reward-foreground` | Token sémantique pour premium/célébration, oklch pour cohérence |
| `pages/LoginPage.tsx` | Remplacement `Gamepad2` par `WawptnLogo` | Identité de marque sur la page de première impression |
| `pages/LandingPage.tsx` | Logo + card premium améliorée (gradient reward, border reward) | Différenciation visuelle du tier premium, cohérence avec le token reward |
| `components/app-header.tsx` | Logo + Crown en `text-reward` au lieu de `text-yellow-500` | Utilisation du token reward au lieu de couleur ad-hoc |
| `pages/VotePage.tsx` | Glow reward + animations stagger sur l'écran résultat | Pic émotionnel de l'app — moment le plus partageable |

### Points d'attention pour la revue
- Le logo SVG est géométrique et simple — à valider visuellement à petite taille (favicon)
- Le token `--reward` est en `oklch(0.795 0.160 75)` — vérifié pour contraste WCAG sur fond sombre (ratio > 4.5:1 avec `oklch(0.145 0 0)`)
- Le glow sur l'écran de résultat respecte `prefers-reduced-motion` (stagger à 0 si activé)
- Les PNGs PWA (`pwa-192x192.png`, `pwa-512x512.png`, `apple-touch-icon.png`) devront être regénérés depuis le logo.svg dans un commit suivant

### Tests
- Build Vite : succès (14 fichiers pré-cachés, 908 KiB)
- ESLint : 0 erreur, 3 warnings pré-existants (non liés aux changements)
- Pas de tests unitaires impactés par des changements visuels CSS/SVG

### Prochaines étapes
- [ ] Revue de code par l'équipe
- [ ] Validation visuelle du logo à différentes tailles
- [ ] Regénérer les assets PNG (PWA icons, OG image) depuis le logo SVG
- [ ] Merge après approbation

> _Attention : d'autres branches fast-meeting sont actives (`fm-admin-backoffice`, `fm-mobile-first`, `fm-mobile-panels`, `fm-persona-badge`, `fm-saas-subscription`). Vérifier les conflits potentiels avant merge._

---
_Implémentation générée automatiquement par IA_