### PR TITLE
Add tooltips on Metacritic badges, truncated text, and icon buttons

### DIFF
--- a/packages/frontend/src/components/game-grid.tsx
+++ b/packages/frontend/src/components/game-grid.tsx
@@ -471,13 +471,20 @@ function GameCard({ game, t }: { game: Game; t: (key: string, options?: Record<s
         )}
       </Tooltip>
       {game.metacriticScore !== null && (
-        <span className={`absolute top-1 left-1 text-xs font-bold px-1.5 py-0.5 rounded ${
-          game.metacriticScore >= 75 ? 'bg-emerald-600 text-white' :
-          game.metacriticScore >= 50 ? 'bg-amber-500 text-white' :
-          'bg-red-600 text-white'
-        }`}>
-          {game.metacriticScore}
-        </span>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className={`absolute top-1 left-1 text-xs font-bold px-1.5 py-0.5 rounded cursor-default ${
+              game.metacriticScore >= 75 ? 'bg-emerald-600 text-white' :
+              game.metacriticScore >= 50 ? 'bg-amber-500 text-white' :
+              'bg-red-600 text-white'
+            }`}>
+              {game.metacriticScore}
+            </span>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" className="text-xs">
+            {t('group.metacriticTooltip', { score: game.metacriticScore })}
+          </TooltipContent>
+        </Tooltip>
       )}
       {game.ownerCount < game.totalMembers && (
         <Tooltip>

--- a/packages/frontend/src/components/group-sidebar.tsx
+++ b/packages/frontend/src/components/group-sidebar.tsx
@@ -101,7 +101,14 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
             loading="lazy"
           />
           <div className="flex-1 min-w-0">
-            <p className={`text-sm font-medium truncate ${index === 0 ? 'text-primary' : ''}`}>{session.winningGameName}</p>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <p className={`text-sm font-medium truncate ${index === 0 ? 'text-primary' : ''}`}>{session.winningGameName}</p>
+              </TooltipTrigger>
+              <TooltipContent side="top" className="text-xs">
+                {session.winningGameName}
+              </TooltipContent>
+            </Tooltip>
             <p className="text-xs text-muted-foreground">
               {new Intl.DateTimeFormat(i18n.language, { weekday: 'short', day: 'numeric', month: 'short' }).format(new Date(session.closedAt))}
             </p>
@@ -166,7 +173,14 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
               />
             </div>
             <div className="flex-1 min-w-0 flex items-center gap-1.5">
-              <span className={`text-sm font-medium truncate ${!isOnline ? 'text-muted-foreground' : ''}`}>{member.displayName}</span>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className={`text-sm font-medium truncate ${!isOnline ? 'text-muted-foreground' : ''}`}>{member.displayName}</span>
+                </TooltipTrigger>
+                <TooltipContent side="top" className="text-xs">
+                  {member.displayName}
+                </TooltipContent>
+              </Tooltip>
               {member.role === 'owner' && (
                 <Crown className="w-4 h-4 text-amber-500 shrink-0" aria-label={t('group.roleOwner')} />
               )}
@@ -175,15 +189,22 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
               <span className="text-xs text-destructive">{t('group.privateLibrary')}</span>
             )}
             {isOwner && !isSelf && (
-              <Button
-                variant="ghost"
-                size="icon"
-                className={`h-7 w-7 text-muted-foreground hover:text-destructive ${compact ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'} transition-opacity`}
-                onClick={() => setConfirmKick(member)}
-                aria-label={t('group.kickMember', { name: member.displayName })}
-              >
-                <UserMinus className="w-3.5 h-3.5" />
-              </Button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className={`h-7 w-7 text-muted-foreground hover:text-destructive ${compact ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'} transition-opacity`}
+                    onClick={() => setConfirmKick(member)}
+                    aria-label={t('group.kickMember', { name: member.displayName })}
+                  >
+                    <UserMinus className="w-3.5 h-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="left" className="text-xs">
+                  {t('group.kickMember', { name: member.displayName })}
+                </TooltipContent>
+              </Tooltip>
             )}
           </div>
         )

--- a/packages/frontend/src/components/group-stats.tsx
+++ b/packages/frontend/src/components/group-stats.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { Card, CardHeader, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { api } from '@/lib/api'
 
 interface GroupStatsData {
@@ -79,7 +80,14 @@ export function GroupStats({ groupId, compact = false }: GroupStatsProps) {
                   className="w-12 h-[22px] rounded object-cover shrink-0"
                   loading="lazy"
                 />
-                <span className="text-sm truncate flex-1">{game.gameName}</span>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="text-sm truncate flex-1">{game.gameName}</span>
+                  </TooltipTrigger>
+                  <TooltipContent side="top" className="text-xs">
+                    {game.gameName}
+                  </TooltipContent>
+                </Tooltip>
                 <Badge variant="secondary" className="shrink-0 text-xs">
                   {game.winCount} {game.winCount > 1 ? t('stats.wins') : t('stats.win')}
                 </Badge>
@@ -103,7 +111,14 @@ export function GroupStats({ groupId, compact = false }: GroupStatsProps) {
                   <AvatarImage src={member.avatarUrl} alt={member.displayName} />
                   <AvatarFallback className="text-xs">{member.displayName.charAt(0).toUpperCase()}</AvatarFallback>
                 </Avatar>
-                <span className="text-sm truncate flex-1">{member.displayName}</span>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="text-sm truncate flex-1">{member.displayName}</span>
+                  </TooltipTrigger>
+                  <TooltipContent side="top" className="text-xs">
+                    {member.displayName}
+                  </TooltipContent>
+                </Tooltip>
                 <span className="text-xs text-muted-foreground shrink-0">
                   {t('stats.memberVotes', { count: member.voteCount })}
                 </span>
@@ -129,7 +144,14 @@ export function GroupStats({ groupId, compact = false }: GroupStatsProps) {
                   className="w-12 h-[22px] rounded object-cover shrink-0"
                   loading="lazy"
                 />
-                <span className="text-sm truncate flex-1">{winner.gameName}</span>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="text-sm truncate flex-1">{winner.gameName}</span>
+                  </TooltipTrigger>
+                  <TooltipContent side="top" className="text-xs">
+                    {winner.gameName}
+                  </TooltipContent>
+                </Tooltip>
                 <span className="text-xs text-muted-foreground shrink-0">
                   {new Intl.DateTimeFormat(i18n.language, { day: 'numeric', month: 'short' }).format(new Date(winner.closedAt))}
                 </span>

--- a/packages/frontend/src/i18n/locales/en.json
+++ b/packages/frontend/src/i18n/locales/en.json
@@ -65,6 +65,7 @@
     "multiplayerOnly": "Multiplayer",
     "coopOnly": "Co-op",
     "metacritic": "Metacritic",
+    "metacriticTooltip": "Metacritic score: {{score}}/100",
     "allScores": "All",
     "genres": "Genres",
     "clearGenres": "Clear",

--- a/packages/frontend/src/i18n/locales/fr.json
+++ b/packages/frontend/src/i18n/locales/fr.json
@@ -68,6 +68,7 @@
     "multiplayerOnly": "Multijoueur",
     "coopOnly": "Coopératif",
     "metacritic": "Metacritic",
+    "metacriticTooltip": "Score Metacritic : {{score}}/100",
     "allScores": "Tous",
     "genres": "Genres",
     "clearGenres": "Effacer",

--- a/packages/frontend/src/pages/VotePage.tsx
+++ b/packages/frontend/src/pages/VotePage.tsx
@@ -11,6 +11,7 @@ import { getSocket } from '@/lib/socket'
 import { useAuthStore } from '@/stores/auth.store'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { Progress } from '@/components/ui/progress'
 import {
   ResponsiveDialog,
@@ -404,16 +405,23 @@ export function VotePage() {
                 )}
                 <div className="flex items-center justify-between p-2">
                   <p className="text-xs font-medium truncate flex-1 min-w-0">{game.gameName}</p>
-                  <button
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      setDetailGame(game)
-                    }}
-                    className="ml-1 shrink-0 p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors"
-                    aria-label={t('vote.gameDetails')}
-                  >
-                    <Info className="w-3.5 h-3.5" />
-                  </button>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          setDetailGame(game)
+                        }}
+                        className="ml-1 shrink-0 p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors"
+                        aria-label={t('vote.gameDetails')}
+                      >
+                        <Info className="w-3.5 h-3.5" />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent side="top" className="text-xs">
+                      {t('vote.gameDetails')}
+                    </TooltipContent>
+                  </Tooltip>
                 </div>
               </div>
             )
@@ -530,19 +538,19 @@ function GameDetailDialog({ game, isSelected, onOpenChange, onToggle, t }: GameD
             <span className="text-xs text-muted-foreground">{t('vote.platforms')}:</span>
             <div className="flex gap-2">
               {game.platforms.windows && (
-                <span className="flex items-center gap-1 text-xs text-foreground" title="Windows">
+                <span className="flex items-center gap-1 text-xs text-foreground">
                   <Monitor className="w-3.5 h-3.5" />
                   Windows
                 </span>
               )}
               {game.platforms.mac && (
-                <span className="flex items-center gap-1 text-xs text-foreground" title="macOS">
+                <span className="flex items-center gap-1 text-xs text-foreground">
                   <Apple className="w-3.5 h-3.5" />
                   Mac
                 </span>
               )}
               {game.platforms.linux && (
-                <span className="flex items-center gap-1 text-xs text-foreground" title="Linux">
+                <span className="flex items-center gap-1 text-xs text-foreground">
                   <Monitor className="w-3.5 h-3.5" />
                   Linux
                 </span>


### PR DESCRIPTION
## Résumé technique

### Contexte
L'application manquait de tooltips sur plusieurs éléments ambigus : les badges Metacritic affichaient un nombre sans contexte, les textes tronqués ne révélaient pas le contenu complet au survol, et certains boutons icône-seuls n'avaient qu'un `aria-label` invisible pour les utilisateurs voyants.

### Approche retenue
Utilisation systématique du composant Radix Tooltip existant (`@/components/ui/tooltip`) plutôt que des attributs `title` natifs. Les attributs `title` existants sur les labels de plateformes (VotePage) ont été supprimés car le texte visible ("Windows", "Mac", "Linux") rend le tooltip redondant. Pas de tooltip ajouté sur les boutons retour (flèche) ni les boutons de recherche (X) — ces icônes sont universellement comprises par l'audience cible (joueurs Steam).

Décision issue d'une réunion rapide avec Pixel-Perfect Hugo (Frontend), Figma Fiona (UX/UI), Sprint Zero Sarah (PO).

### Changements implémentés
| Fichier | Modification | Justification technique |
|---------|-------------|------------------------|
| `game-grid.tsx` | Tooltip Radix sur badge Metacritic | Nombre coloré sans contexte — tooltip "Score Metacritic : X/100" |
| `VotePage.tsx` | Tooltip sur bouton Info (icône seule) | Bouton `<Info>` sans texte visible — action non-évidente |
| `VotePage.tsx` | Suppression `title` natifs sur plateformes | Texte visible ("Windows"...) rend le title redondant et inconsistant |
| `VotePage.tsx` | Import Tooltip ajouté | Composant non importé dans ce fichier |
| `group-sidebar.tsx` | Tooltip sur bouton kick member | Action destructrice (icône UserMinus) sans indication visuelle |
| `group-sidebar.tsx` | Tooltip sur noms de membres tronqués | `truncate` CSS masquait le nom complet |
| `group-sidebar.tsx` | Tooltip sur noms de jeux tronqués (historique) | Idem — titres longs coupés sans recours |
| `group-stats.tsx` | Tooltip sur 3 listes tronquées (top games, participation, winners) | Textes tronqués dans les statistiques |
| `group-stats.tsx` | Import Tooltip ajouté | Composant non importé dans ce fichier |
| `fr.json` / `en.json` | Clé i18n `group.metacriticTooltip` | "Score Metacritic : {{score}}/100" |

### Points d'attention pour la revue
- Les tooltips sur textes tronqués s'affichent même quand le texte n'est pas tronqué (écran large) — acceptable pour v1, un hook `useIsTruncated` pourrait conditionner l'affichage ultérieurement
- Le badge Metacritic sur VotePage conserve `pointer-events-none` (pas de tooltip) car les cartes sont des cibles de sélection — le tooltip est uniquement sur la grille de jeux
- Vérifier le comportement tactile (mobile) : Radix gère le touch via `delayDuration` du `TooltipProvider` (300ms)

### Tests
- TypeScript : compilation sans erreur
- ESLint : 0 erreur, 3 warnings pré-existants

### Prochaines étapes
- [ ] Revue de code par l'équipe
- [ ] Test mobile (Safari iOS, Steam Deck)
- [ ] Merge après approbation

---
_Attention : d'autres branches fast-meeting sont actives (`fm-admin-backoffice`, `fm-design-identity`, `fm-mobile-first`, `fm-mobile-panels`, `fm-persona-badge`, `fm-saas-subscription`). Vérifier les conflits potentiels avant merge._

_Implémentation générée automatiquement par IA_