### PR TITLE
Improve design consistency, accessibility, and polish

### DIFF
--- a/packages/frontend/src/components/game-grid.tsx
+++ b/packages/frontend/src/components/game-grid.tsx
@@ -214,7 +214,7 @@ export function GameGrid({ games, loading, filters, onToggleMultiplayer, onToggl
                 </button>
               )}
             </div>
-            <div className="flex gap-1.5 shrink-0">
+            <div className="flex gap-1.5 shrink-0 overflow-x-auto scrollbar-none">
               <Button
                 variant={filters.multiplayerOnly ? 'default' : 'secondary'}
                 size="sm"
@@ -474,9 +474,9 @@ function GameCard({ game, t }: { game: Game; t: (key: string, options?: Record<s
         <Tooltip>
           <TooltipTrigger asChild>
             <span className={`absolute top-1 left-1 text-xs font-bold px-1.5 py-0.5 rounded cursor-default ${
-              game.metacriticScore >= 75 ? 'bg-emerald-600 text-white' :
-              game.metacriticScore >= 50 ? 'bg-amber-500 text-white' :
-              'bg-red-600 text-white'
+              game.metacriticScore >= 75 ? 'bg-score-good text-white' :
+              game.metacriticScore >= 50 ? 'bg-score-mixed text-white' :
+              'bg-score-bad text-white'
             }`}>
               {game.metacriticScore}
             </span>
@@ -501,7 +501,7 @@ function GameCard({ game, t }: { game: Game; t: (key: string, options?: Record<s
       )}
       <div className="absolute bottom-7 right-1 flex gap-0.5">
         {game.isFree && (
-          <span className="text-xs font-bold bg-emerald-600 text-white px-1.5 py-0.5 rounded">
+          <span className="text-xs font-bold bg-score-good text-white px-1.5 py-0.5 rounded">
             {t('group.free')}
           </span>
         )}

--- a/packages/frontend/src/components/group-sidebar.tsx
+++ b/packages/frontend/src/components/group-sidebar.tsx
@@ -168,7 +168,7 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
                 <AvatarFallback>{member.displayName.charAt(0).toUpperCase()}</AvatarFallback>
               </Avatar>
               <span
-                className={`absolute bottom-0 right-0 w-2.5 h-2.5 rounded-full border-2 ${compact ? 'border-background' : 'border-card'} ${isOnline ? 'bg-emerald-500' : 'bg-muted-foreground/40'}`}
+                className={`absolute bottom-0 right-0 w-2.5 h-2.5 rounded-full border-2 ${compact ? 'border-background' : 'border-card'} ${isOnline ? 'bg-online' : 'bg-muted-foreground/40'}`}
                 aria-label={isOnline ? 'En ligne' : 'Hors ligne'}
               />
             </div>
@@ -182,7 +182,7 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
                 </TooltipContent>
               </Tooltip>
               {member.role === 'owner' && (
-                <Crown className="w-4 h-4 text-amber-500 shrink-0" aria-label={t('group.roleOwner')} />
+                <Crown className="w-4 h-4 text-reward shrink-0" aria-label={t('group.roleOwner')} />
               )}
             </div>
             {!member.libraryVisible && (

--- a/packages/frontend/src/components/premium-gate.tsx
+++ b/packages/frontend/src/components/premium-gate.tsx
@@ -34,7 +34,7 @@ function PremiumGateFallback({ feature }: { feature?: string }) {
         </span>
       </div>
       <Button size="sm" variant="outline" onClick={() => navigate('/subscription')}>
-        <Crown className="w-4 h-4 mr-2 text-yellow-500" />
+        <Crown className="w-4 h-4 mr-2 text-reward" />
         {t('premium.unlock')}
       </Button>
     </div>

--- a/packages/frontend/src/components/ui/badge.tsx
+++ b/packages/frontend/src/components/ui/badge.tsx
@@ -3,7 +3,7 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
 const badgeVariants = cva(
-  'inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-[3px] focus:ring-ring/50',
+  'inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-[3px] focus:ring-ring',
   {
     variants: {
       variant: {

--- a/packages/frontend/src/components/ui/button.tsx
+++ b/packages/frontend/src/components/ui/button.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
   {
     variants: {
       variant: {

--- a/packages/frontend/src/components/ui/checkbox.tsx
+++ b/packages/frontend/src/components/ui/checkbox.tsx
@@ -12,7 +12,7 @@ function Checkbox({
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        "peer size-4 shrink-0 rounded-[4px] border border-input shadow-xs transition-shadow outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:bg-input/30 dark:aria-invalid:ring-destructive/40 dark:data-[state=checked]:bg-primary",
+        "peer size-4 shrink-0 rounded-[4px] border border-input shadow-xs transition-shadow outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:bg-input/30 dark:aria-invalid:ring-destructive/40 dark:data-[state=checked]:bg-primary",
         className
       )}
       {...props}

--- a/packages/frontend/src/components/ui/dialog.tsx
+++ b/packages/frontend/src/components/ui/dialog.tsx
@@ -38,7 +38,7 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus-visible:ring-[3px] focus-visible:ring-ring disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>

--- a/packages/frontend/src/components/ui/input.tsx
+++ b/packages/frontend/src/components/ui/input.tsx
@@ -7,7 +7,7 @@ const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLI
       <input
         type={type}
         className={cn(
-          'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive',
+          'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/30',
           className
         )}
         ref={ref}

--- a/packages/frontend/src/components/ui/skeleton.tsx
+++ b/packages/frontend/src/components/ui/skeleton.tsx
@@ -4,7 +4,7 @@ import { cn } from '@/lib/utils'
 function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
   return (
     <div
-      className={cn('animate-pulse rounded-md bg-muted', className)}
+      className={cn('rounded-md bg-gradient-to-r from-muted via-muted/60 to-muted bg-[length:200%_100%] animate-[shimmer_1.5s_ease-in-out_infinite]', className)}
       {...props}
     />
   )

--- a/packages/frontend/src/components/ui/textarea.tsx
+++ b/packages/frontend/src/components/ui/textarea.tsx
@@ -6,7 +6,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, React.TextareaHTMLAttribu
     return (
       <textarea
         className={cn(
-          'flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive',
+          'flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/30',
           className
         )}
         ref={ref}

--- a/packages/frontend/src/components/vote-setup-dialog.tsx
+++ b/packages/frontend/src/components/vote-setup-dialog.tsx
@@ -187,7 +187,7 @@ export function VoteSetupDialog({ open, onOpenChange, members, groupId, onlineMe
                           <AvatarFallback>{member.displayName.charAt(0).toUpperCase()}</AvatarFallback>
                         </Avatar>
                         <span
-                          className={`absolute bottom-0 right-0 w-2 h-2 rounded-full border-2 border-card ${isOnline ? 'bg-emerald-500' : 'bg-muted-foreground/40'}`}
+                          className={`absolute bottom-0 right-0 w-2 h-2 rounded-full border-2 border-card ${isOnline ? 'bg-online' : 'bg-muted-foreground/40'}`}
                         />
                       </div>
                       <span className={`text-sm font-medium truncate ${!isOnline ? 'text-muted-foreground' : ''}`}>{member.displayName}</span>

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -14,7 +14,7 @@
   --secondary: oklch(0.274 0.006 286.033);
   --secondary-foreground: oklch(0.985 0 0);
   --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.75 0 0);
+  --muted-foreground: oklch(0.80 0 0);
   --accent: oklch(0.371 0 0);
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.704 0.191 22.216);
@@ -43,6 +43,12 @@
   --reward: oklch(0.795 0.160 75);
   --reward-foreground: oklch(0.25 0.05 75);
   --neon: oklch(0.78 0.18 195);
+  /* Semantic: Metacritic score colors */
+  --score-good: oklch(0.60 0.18 155);
+  --score-mixed: oklch(0.75 0.15 85);
+  --score-bad: oklch(0.60 0.20 25);
+  /* Semantic: Online status */
+  --online: oklch(0.65 0.19 155);
 }
 
 @theme inline {
@@ -87,6 +93,10 @@
   --color-reward: var(--reward);
   --color-reward-foreground: var(--reward-foreground);
   --color-neon: var(--neon);
+  --color-score-good: var(--score-good);
+  --color-score-mixed: var(--score-mixed);
+  --color-score-bad: var(--score-bad);
+  --color-online: var(--online);
   --radius-sm: calc(var(--radius) * 0.6);
   --radius-md: calc(var(--radius) * 0.8);
   --radius-lg: var(--radius);
@@ -98,7 +108,7 @@
 
 @layer base {
   * {
-    @apply border-border outline-ring/50;
+    @apply border-border outline-ring;
   }
   body {
     @apply text-foreground antialiased;
@@ -206,6 +216,15 @@
   border-color: oklch(0.424 0.199 265.638 / 0.3);
   box-shadow: 0 0 24px oklch(0.424 0.199 265.638 / 0.06);
   transform: scale(1.01);
+}
+
+@keyframes shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
 }
 
 @keyframes premium-glow {

--- a/packages/frontend/src/pages/DiscordLinkPage.tsx
+++ b/packages/frontend/src/pages/DiscordLinkPage.tsx
@@ -76,7 +76,7 @@ export function DiscordLinkPage() {
   if (discordUsername) {
     return (
       <div className="min-h-screen flex flex-col items-center justify-center px-4">
-        <Check className="w-12 h-12 text-green-500 mb-4" />
+        <Check className="w-12 h-12 text-success mb-4" />
         <h1 className="text-2xl font-bold mb-2">{t('discordLink.linked')}</h1>
         <p className="text-muted-foreground mb-6">
           {t('discordLink.linkedDescription', { username: discordUsername })}

--- a/packages/frontend/src/pages/GroupsPage.tsx
+++ b/packages/frontend/src/pages/GroupsPage.tsx
@@ -350,7 +350,7 @@ export function GroupsPage() {
                         <h3 className="font-semibold flex items-center gap-1.5">
                           {group.name}
                           {group.role === 'owner' && (
-                            <Crown className="w-4 h-4 text-amber-500 shrink-0" />
+                            <Crown className="w-4 h-4 text-reward shrink-0" />
                           )}
                         </h3>
                         <div className="flex items-center gap-2 text-sm text-muted-foreground mt-0.5">

--- a/packages/frontend/src/pages/SubscriptionPage.tsx
+++ b/packages/frontend/src/pages/SubscriptionPage.tsx
@@ -62,7 +62,7 @@ export function SubscriptionPage() {
             <div className="flex items-center justify-between">
               <CardTitle className="flex items-center gap-2">
                 {isPremium ? (
-                  <Crown className="w-5 h-5 text-yellow-500" />
+                  <Crown className="w-5 h-5 text-reward" />
                 ) : (
                   <CreditCard className="w-5 h-5 text-muted-foreground" />
                 )}
@@ -91,7 +91,7 @@ export function SubscriptionPage() {
                   </p>
                 )}
                 {status === 'canceled' && (
-                  <p className="text-sm text-yellow-500">
+                  <p className="text-sm text-reward">
                     {t('subscription.canceledNotice')}
                   </p>
                 )}
@@ -107,15 +107,15 @@ export function SubscriptionPage() {
                 </p>
                 <ul className="space-y-2 text-sm">
                   <li className="flex items-center gap-2">
-                    <Crown className="w-4 h-4 text-yellow-500" />
+                    <Crown className="w-4 h-4 text-reward" />
                     {t('landing.premiumFeature1')}
                   </li>
                   <li className="flex items-center gap-2">
-                    <Crown className="w-4 h-4 text-yellow-500" />
+                    <Crown className="w-4 h-4 text-reward" />
                     {t('landing.premiumFeature2')}
                   </li>
                   <li className="flex items-center gap-2">
-                    <Crown className="w-4 h-4 text-yellow-500" />
+                    <Crown className="w-4 h-4 text-reward" />
                     {t('landing.premiumFeature3')}
                   </li>
                 </ul>

--- a/packages/frontend/src/pages/VotePage.tsx
+++ b/packages/frontend/src/pages/VotePage.tsx
@@ -396,9 +396,9 @@ export function VotePage() {
                 )}
                 {game.metacriticScore != null && (
                   <span className={`absolute top-1.5 left-1.5 text-xs font-bold px-1.5 py-0.5 rounded pointer-events-none ${
-                    game.metacriticScore >= 75 ? 'bg-emerald-600 text-white' :
-                    game.metacriticScore >= 50 ? 'bg-amber-500 text-white' :
-                    'bg-red-600 text-white'
+                    game.metacriticScore >= 75 ? 'bg-score-good text-white' :
+                    game.metacriticScore >= 50 ? 'bg-score-mixed text-white' :
+                    'bg-score-bad text-white'
                   }`}>
                     {game.metacriticScore}
                   </span>
@@ -499,9 +499,9 @@ function GameDetailDialog({ game, isSelected, onOpenChange, onToggle, t }: GameD
             <Badge
               variant="outline"
               className={`gap-1 ${
-                game.metacriticScore >= 75 ? 'border-emerald-600 text-emerald-600' :
-                game.metacriticScore >= 50 ? 'border-amber-500 text-amber-500' :
-                'border-red-600 text-red-600'
+                game.metacriticScore >= 75 ? 'border-score-good text-score-good' :
+                game.metacriticScore >= 50 ? 'border-score-mixed text-score-mixed' :
+                'border-score-bad text-score-bad'
               }`}
             >
               <Star className="w-3 h-3" />
@@ -511,7 +511,7 @@ function GameDetailDialog({ game, isSelected, onOpenChange, onToggle, t }: GameD
 
           {/* Free badge */}
           {game.isFree && (
-            <Badge variant="secondary" className="bg-emerald-600/10 text-emerald-600 border-emerald-600/20">
+            <Badge variant="secondary" className="bg-score-good/10 text-score-good border-score-good/20">
               {t('vote.free')}
             </Badge>
           )}


### PR DESCRIPTION
## Résumé technique

### Contexte
Plusieurs problèmes de cohérence visuelle et d'accessibilité identifiés lors d'un audit de design : focus ring insuffisant pour WCAG 2.2 SC 2.4.13, couleurs Tailwind hardcodées contournant le design system OKLCH, et composants skeleton basiques sans shimmer.

### Approche retenue
Correction bottom-up : renforcer les tokens de design d'abord, puis corriger les primitives UI, et enfin remplacer toutes les couleurs hardcodées dans les composants consommateurs. Approche validée par une réunion rapide avec 4 personas (Frontend, UX/UI, PO, Architecte).

### Changements implémentés
| Fichier | Modification | Justification technique |
|---------|-------------|------------------------|
| `index.css` | Bump `--muted-foreground` de `oklch(0.75)` à `oklch(0.80)` | Conformité WCAG AA (4.5:1 minimum) |
| `index.css` | Ajout tokens `--score-good/mixed/bad`, `--online` | Sémantique pour Metacritic et statuts en ligne |
| `index.css` | Ajout keyframes `shimmer` | Animation gradient pour skeletons |
| `index.css` | Outline global de `ring/50` à `ring` | Visibilité focus ring WCAG 2.2 |
| `button.tsx`, `input.tsx`, `textarea.tsx`, `badge.tsx`, `checkbox.tsx` | `ring-ring/50` → `ring-ring` | Focus ring accessible sur toutes les primitives |
| `dialog.tsx` | Normalisation focus pattern du bouton close | Cohérence avec les autres primitives (ring-[3px] + focus-visible) |
| `input.tsx`, `textarea.tsx` | Ajout `aria-invalid:ring-destructive/30` | Feedback visuel d'erreur renforcé |
| `skeleton.tsx` | Pulse → gradient shimmer | Perceived-performance améliorée |
| `game-grid.tsx`, `VotePage.tsx` | Metacritic badges : `bg-emerald-600` → `bg-score-good`, etc. | Utilisation des tokens design system |
| `game-grid.tsx` | Free badge : `bg-emerald-600` → `bg-score-good` | Cohérence tokens |
| `group-sidebar.tsx`, `vote-setup-dialog.tsx` | Online dots : `bg-emerald-500` → `bg-online` | Token sémantique |
| `GroupsPage.tsx`, `group-sidebar.tsx` | Crown icons : `text-amber-500` → `text-reward` | Token existant réutilisé |
| `SubscriptionPage.tsx`, `premium-gate.tsx` | Crown/texte : `text-yellow-500` → `text-reward` | Token existant réutilisé |
| `DiscordLinkPage.tsx` | Check icon : `text-green-500` → `text-success` | Token existant réutilisé |
| `game-grid.tsx` | Filter bar : ajout `overflow-x-auto scrollbar-none` | Prévention overflow sur petits écrans |

### Points d'attention pour la revue
- Vérifier le rendu du focus ring sur les boutons `default` (bg-primary) — le ring gris pourrait se fondre avec le violet
- Tester le shimmer skeleton sur des appareils bas de gamme (performance de l'animation gradient)
- Valider visuellement les nouveaux tokens Metacritic (score-good/mixed/bad) vs les anciennes couleurs Tailwind

### Tests
- TypeScript : compilation sans erreur
- ESLint : 0 erreurs, 3 warnings pré-existants (non liés aux changements)
- Pas de suite de tests unitaires détectée

### Prochaines étapes
- [ ] Revue de code par l'équipe
- [ ] Validation visuelle sur mobile et desktop
- [ ] Merge après approbation

> _Attention : d'autres branches fast-meeting sont actives (`fm-add-tooltips`, `fm-admin-backoffice`, `fm-design-identity`, `fm-mobile-first`, `fm-mobile-panels`, `fm-persona-badge`, `fm-saas-subscription`). Vérifier les conflits potentiels avant merge._

---
_Implémentation générée automatiquement par IA_