### PR TITLE
fix(backend): enforce premium tier limits on members and vote scheduling

### DIFF
--- a/packages/backend/src/presentation/middleware/tier.middleware.ts
+++ b/packages/backend/src/presentation/middleware/tier.middleware.ts
@@ -8,6 +8,11 @@ export const FREE_TIER_LIMITS = {
   maxMembersPerGroup: 8,
 } as const
 
+/** Tier limits for premium users */
+export const PREMIUM_TIER_LIMITS = {
+  maxMembersPerGroup: 20,
+} as const
+
 /** Check if a user has an active premium subscription */
 export async function isUserPremium(userId: string): Promise<boolean> {
   const subscription = await db('subscriptions')

--- a/packages/backend/src/presentation/routes/group.routes.ts
+++ b/packages/backend/src/presentation/routes/group.routes.ts
@@ -7,7 +7,7 @@ import { triggerBackgroundEnrichment } from '../../infrastructure/steam/steam-st
 import { getIO, forceLeaveRoom } from '../../infrastructure/socket/socket.js'
 import { updateGroupSchedule } from '../../infrastructure/scheduler/auto-vote-scheduler.js'
 import { logger } from '../../infrastructure/logger/logger.js'
-import { isUserPremium, FREE_TIER_LIMITS } from '../middleware/tier.middleware.js'
+import { isUserPremium, FREE_TIER_LIMITS, PREMIUM_TIER_LIMITS } from '../middleware/tier.middleware.js'
 
 const router = Router()
 
@@ -363,16 +363,19 @@ router.post('/join', async (req: Request, res: Response) => {
     return
   }
 
-  // Free tier: max members per group limit
+  // Tier-based max members per group limit
   const owner = await db('group_members').where({ group_id: group.id, role: 'owner' }).select('user_id').first()
   if (owner) {
     const ownerIsPremium = await isUserPremium(owner.user_id)
-    if (!ownerIsPremium) {
-      const memberCount = await db('group_members').where({ group_id: group.id }).count('* as count').first()
-      if (Number(memberCount?.count || 0) >= FREE_TIER_LIMITS.maxMembersPerGroup) {
-        res.status(403).json({ error: 'premium_required', message: `This group has reached the free member limit (${FREE_TIER_LIMITS.maxMembersPerGroup}). Group owner must upgrade to premium.` })
-        return
-      }
+    const memberCount = await db('group_members').where({ group_id: group.id }).count('* as count').first()
+    const currentCount = Number(memberCount?.count || 0)
+    if (!ownerIsPremium && currentCount >= FREE_TIER_LIMITS.maxMembersPerGroup) {
+      res.status(403).json({ error: 'premium_required', message: `This group has reached the free member limit (${FREE_TIER_LIMITS.maxMembersPerGroup}). Group owner must upgrade to premium.` })
+      return
+    }
+    if (ownerIsPremium && currentCount >= PREMIUM_TIER_LIMITS.maxMembersPerGroup) {
+      res.status(403).json({ error: 'member_limit', message: `This group has reached the maximum member limit (${PREMIUM_TIER_LIMITS.maxMembersPerGroup}).` })
+      return
     }
   }
 

--- a/packages/backend/src/presentation/routes/vote.routes.ts
+++ b/packages/backend/src/presentation/routes/vote.routes.ts
@@ -3,6 +3,7 @@ import { db } from '../../infrastructure/database/connection.js'
 import { getIO } from '../../infrastructure/socket/socket.js'
 import { closeSession } from '../../domain/close-session.js'
 import { createVotingSession } from '../../domain/create-session.js'
+import { isUserPremium } from '../middleware/tier.middleware.js'
 
 const router = Router()
 
@@ -132,6 +133,13 @@ router.post('/:groupId/vote', async (req: Request, res: Response) => {
   // Validate scheduledAt if provided
   let parsedScheduledAt: Date | null = null
   if (scheduledAt) {
+    // Vote scheduling is a premium feature
+    const premium = await isUserPremium(userId)
+    if (!premium) {
+      res.status(403).json({ error: 'premium_required', message: 'Vote scheduling requires a premium subscription' })
+      return
+    }
+
     parsedScheduledAt = new Date(scheduledAt)
     if (isNaN(parsedScheduledAt.getTime())) {
       res.status(400).json({ error: 'validation', message: 'Invalid scheduledAt date format' })


### PR DESCRIPTION
## Summary
- **20-member cap for premium groups**: Premium users previously had unlimited members per group despite the landing page advertising "up to 20 members". Now enforced server-side via `PREMIUM_TIER_LIMITS.maxMembersPerGroup`.
- **Vote scheduling gated behind premium**: The `scheduledAt` parameter in vote creation was available to all users. Now returns `403 premium_required` for free users.
- **Discord bot**: Already properly gated (verified `/setup`, `/vote/start`, `/chat`, `/webhook` all check premium status). No change needed.

Closes gaps identified in #86.

## Test plan
- [ ] Free user trying to join a group with 8+ members gets `premium_required` error
- [ ] Premium user trying to join a group with 20+ members gets `member_limit` error
- [ ] Free user trying to create a vote with `scheduledAt` gets `premium_required` error
- [ ] Premium user can create scheduled votes as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)