### PR TITLE
feat(playtime): store Steam playtime for ranking and profile display

### DIFF
--- a/packages/backend/migrations/20260322_add_playtime_to_user_games.ts
+++ b/packages/backend/migrations/20260322_add_playtime_to_user_games.ts
@@ -1,0 +1,15 @@
+import type { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('user_games', (table) => {
+    table.integer('playtime_forever').nullable().defaultTo(null)
+    table.integer('playtime_2weeks').nullable().defaultTo(null)
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('user_games', (table) => {
+    table.dropColumn('playtime_forever')
+    table.dropColumn('playtime_2weeks')
+  })
+}

--- a/packages/backend/src/domain/create-session.ts
+++ b/packages/backend/src/domain/create-session.ts
@@ -114,6 +114,10 @@ export async function createVotingSession(params: CreateSessionParams): Promise<
     const countA = voteCountMap.get(a.steamAppId) || 0
     const countB = voteCountMap.get(b.steamAppId) || 0
     if (countA !== countB) return countB - countA
+    // Tiebreaker: aggregate playtime across group members (most played first)
+    const playtimeA = a.totalPlaytime ?? 0
+    const playtimeB = b.totalPlaytime ?? 0
+    if (playtimeA !== playtimeB) return playtimeB - playtimeA
     return a.gameName.localeCompare(b.gameName)
   })
 

--- a/packages/backend/src/infrastructure/database/common-games.ts
+++ b/packages/backend/src/infrastructure/database/common-games.ts
@@ -6,6 +6,8 @@ interface CommonGameRow {
   gameName: string
   headerImageUrl: string | null
   ownerCount: number
+  totalPlaytime: number | null
+  avgPlaytime: number | null
   isMultiplayer: boolean | null
   isCoop: boolean | null
   genres: string | null
@@ -84,6 +86,8 @@ export async function computeCommonGames(
       'user_games.game_name as gameName',
       'user_games.header_image_url as headerImageUrl',
       db.raw('COUNT(DISTINCT user_games.user_id) as "ownerCount"'),
+      db.raw('COALESCE(SUM(user_games.playtime_forever), 0) as "totalPlaytime"'),
+      db.raw('COALESCE(AVG(user_games.playtime_forever), 0) as "avgPlaytime"'),
       db.raw('bool_or(game_metadata.is_multiplayer) as "isMultiplayer"'),
       db.raw('bool_or(game_metadata.is_coop) as "isCoop"'),
       db.raw('MAX(game_metadata.genres::text) as "genres"'),
@@ -106,6 +110,8 @@ export async function computeCommonGames(
     gameName: g.gameName as string,
     headerImageUrl: g.headerImageUrl as string | null,
     ownerCount: Number(g.ownerCount),
+    totalPlaytime: g.totalPlaytime != null ? Number(g.totalPlaytime) : null,
+    avgPlaytime: g.avgPlaytime != null ? Math.round(Number(g.avgPlaytime)) : null,
     isMultiplayer: (g.isMultiplayer as boolean | null) ?? null,
     isCoop: (g.isCoop as boolean | null) ?? null,
     genres: (g.genres as string | null) ?? null,

--- a/packages/backend/src/infrastructure/steam/steam-client.ts
+++ b/packages/backend/src/infrastructure/steam/steam-client.ts
@@ -66,6 +66,7 @@ export interface SteamOwnedGame {
   appid: number
   name: string
   playtime_forever: number
+  playtime_2weeks?: number
   img_icon_url: string
 }
 

--- a/packages/backend/src/presentation/routes/auth.routes.ts
+++ b/packages/backend/src/presentation/routes/auth.routes.ts
@@ -250,11 +250,16 @@ router.get('/profile', requireAuth, async (req: Request, res: Response) => {
       return
     }
 
-    // Get game counts per platform
+    // Get game counts and playtime stats per platform
     const gameCounts = await db('user_games')
       .where({ user_id: userId })
       .groupBy('platform')
-      .select('platform', db.raw('COUNT(*) as count'), db.raw('MAX(synced_at) as "lastSyncedAt"'))
+      .select(
+        'platform',
+        db.raw('COUNT(*) as count'),
+        db.raw('MAX(synced_at) as "lastSyncedAt"'),
+        db.raw('COALESCE(SUM(playtime_forever), 0) as "totalPlaytimeMinutes"')
+      )
 
     const steamStats = gameCounts.find((g: { platform: string }) => g.platform === 'steam')
     const epicStats = gameCounts.find((g: { platform: string }) => g.platform === 'epic')
@@ -278,6 +283,7 @@ router.get('/profile', requireAuth, async (req: Request, res: Response) => {
         syncable: true,
         accountId: user.steam_id || null,
         gameCount: Number(steamStats?.count || 0),
+        totalPlaytimeMinutes: Number(steamStats?.totalPlaytimeMinutes || 0),
         lastSyncedAt: steamStats?.lastSyncedAt || null,
         profileUrl: user.profile_url || null,
       },
@@ -314,6 +320,15 @@ router.get('/profile', requireAuth, async (req: Request, res: Response) => {
       { id: 'ubisoft', name: 'Ubisoft Connect', connected: false, comingSoon: true },
     ]
 
+    // Get top 5 most-played games for profile display
+    const topGames = await db('user_games')
+      .where({ user_id: userId, platform: 'steam' })
+      .whereNotNull('playtime_forever')
+      .where('playtime_forever', '>', 0)
+      .orderBy('playtime_forever', 'desc')
+      .limit(5)
+      .select('game_name as gameName', 'steam_app_id as steamAppId', 'header_image_url as headerImageUrl', 'playtime_forever as playtimeForever')
+
     res.json({
       id: user.id,
       steamId: user.steam_id,
@@ -323,6 +338,12 @@ router.get('/profile', requireAuth, async (req: Request, res: Response) => {
       libraryVisible: user.library_visible,
       createdAt: user.created_at,
       platforms,
+      topGames: topGames.map((g: { gameName: string; steamAppId: number; headerImageUrl: string | null; playtimeForever: number }) => ({
+        gameName: g.gameName,
+        steamAppId: g.steamAppId,
+        headerImageUrl: g.headerImageUrl,
+        playtimeForever: Number(g.playtimeForever),
+      })),
     })
   } catch (error) {
     authLogger.error({ error: String(error) }, 'get profile failed')
@@ -846,6 +867,8 @@ async function syncUserLibrary(userId: string, steamId: string): Promise<number>
         platform: 'steam',
         game_name: game.name,
         header_image_url: getHeaderImageUrl(game.appid),
+        playtime_forever: game.playtime_forever ?? null,
+        playtime_2weeks: game.playtime_2weeks ?? null,
         synced_at: now,
       })
       .onConflict(['user_id', 'steam_app_id'])
@@ -853,6 +876,8 @@ async function syncUserLibrary(userId: string, steamId: string): Promise<number>
         game_name: game.name,
         game_id: gameId,
         header_image_url: getHeaderImageUrl(game.appid),
+        playtime_forever: db.raw('GREATEST(EXCLUDED.playtime_forever, user_games.playtime_forever)'),
+        playtime_2weeks: game.playtime_2weeks ?? null,
         synced_at: now,
       })
   }

--- a/packages/frontend/src/i18n/locales/en.json
+++ b/packages/frontend/src/i18n/locales/en.json
@@ -286,7 +286,8 @@
     "unlinkError": "Unable to disconnect the account.",
     "memberSince": "Member since {{date}}",
     "steamProfile": "View Steam profile",
-    "noLibraryApi": "This platform does not provide an API to sync the game library."
+    "noLibraryApi": "This platform does not provide an API to sync the game library.",
+    "topGames": "Most played games"
   },
   "recommendations": {
     "title": "Suggestions",

--- a/packages/frontend/src/i18n/locales/fr.json
+++ b/packages/frontend/src/i18n/locales/fr.json
@@ -295,7 +295,8 @@
     "unlinkError": "Impossible de déconnecter le compte.",
     "memberSince": "Membre depuis {{date}}",
     "steamProfile": "Voir le profil Steam",
-    "noLibraryApi": "Cette plateforme ne propose pas d'API pour synchroniser la bibliothèque de jeux."
+    "noLibraryApi": "Cette plateforme ne propose pas d'API pour synchroniser la bibliothèque de jeux.",
+    "topGames": "Jeux les plus joués"
   },
   "recommendations": {
     "title": "Suggestions",

--- a/packages/frontend/src/pages/ProfilePage.tsx
+++ b/packages/frontend/src/pages/ProfilePage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
-import { ArrowLeft, RefreshCw, ExternalLink, Check, Clock, Gamepad2, Link, Unlink, AlertTriangle } from 'lucide-react'
+import { ArrowLeft, RefreshCw, ExternalLink, Check, Clock, Gamepad2, Link, Unlink, AlertTriangle, Timer } from 'lucide-react'
 import { PlatformIcon } from '@/components/icons/platforms'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
@@ -22,8 +22,16 @@ interface Platform {
   needsRelink?: boolean
   accountId?: string | null
   gameCount?: number
+  totalPlaytimeMinutes?: number
   lastSyncedAt?: string | null
   profileUrl?: string | null
+}
+
+interface TopGame {
+  gameName: string
+  steamAppId: number
+  headerImageUrl: string | null
+  playtimeForever: number
 }
 
 interface Profile {
@@ -35,6 +43,14 @@ interface Profile {
   libraryVisible: boolean
   createdAt: string
   platforms: Platform[]
+  topGames?: TopGame[]
+}
+
+function formatPlaytime(minutes: number): string {
+  if (minutes < 60) return `${minutes}min`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 1000) return `${hours}h`
+  return `${(hours / 1000).toFixed(1)}kh`
 }
 
 const PLATFORM_NAMES: Record<string, string> = {
@@ -262,6 +278,12 @@ export function ProfilePage() {
                           {platform.gameCount !== undefined && (
                             <span>{t('profile.gameCount', { count: platform.gameCount })}</span>
                           )}
+                          {platform.totalPlaytimeMinutes != null && platform.totalPlaytimeMinutes > 0 && (
+                            <span className="flex items-center gap-1">
+                              <Timer className="w-3 h-3" />
+                              {formatPlaytime(platform.totalPlaytimeMinutes)}
+                            </span>
+                          )}
                           {platform.lastSyncedAt ? (
                             <span className="flex items-center gap-1">
                               <Clock className="w-3 h-3" />
@@ -329,6 +351,40 @@ export function ProfilePage() {
             ))}
           </CardContent>
         </Card>
+
+        {/* Top played games */}
+        {profile.topGames && profile.topGames.length > 0 && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Timer className="w-5 h-5" />
+                {t('profile.topGames')}
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              {profile.topGames.map((game) => (
+                <div
+                  key={game.steamAppId}
+                  className="flex items-center gap-3 p-2 rounded-lg border border-border bg-card"
+                >
+                  {game.headerImageUrl && (
+                    <img
+                      src={game.headerImageUrl}
+                      alt={game.gameName}
+                      className="w-16 h-8 object-cover rounded shrink-0"
+                    />
+                  )}
+                  <span className="flex-1 min-w-0 text-sm font-medium truncate">
+                    {game.gameName}
+                  </span>
+                  <Badge variant="secondary" className="shrink-0 text-xs">
+                    {formatPlaytime(game.playtimeForever)}
+                  </Badge>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+        )}
       </main>
     </div>
   )

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -54,6 +54,8 @@ export interface UserGame {
   gameName: string
   headerImageUrl: string | null
   platform?: string
+  playtimeForever?: number | null
+  playtime2weeks?: number | null
   syncedAt: string
 }
 
@@ -64,6 +66,8 @@ export interface CommonGame {
   headerImageUrl: string | null
   ownerCount: number
   totalMembers: number
+  totalPlaytime?: number | null
+  avgPlaytime?: number | null
   isMultiplayer: boolean | null
   isCoop: boolean | null
   genres: { id: string; description: string }[] | null


### PR DESCRIPTION
## Résumé technique

### Contexte
Les données de temps de jeu Steam (`playtime_forever`) sont déjà récupérées par l'API Steam lors de la synchronisation des bibliothèques, mais elles étaient ignorées lors de l'insertion en base. Ce temps de jeu représente un signal précieux pour améliorer le classement des jeux lors des sessions de vote et enrichir le profil utilisateur.

### Approche retenue
Stocker `playtime_forever` et `playtime_2weeks` directement dans la table `user_games` (données per-user-per-game), sans créer de table supplémentaire. Utiliser le temps de jeu agrégé comme critère de tri secondaire (tiebreaker) dans les sessions de vote, après le nombre de votes historiques. Afficher les jeux les plus joués sur le profil utilisateur.

**Décision de réunion rapide :** Sprint Zero Sarah (PO), SOLID Alex (Backend), Whiteboard Damien (Architecte) — consensus unanime sur l'approche.

### Changements implémentés
| Fichier | Modification | Justification technique |
|---------|-------------|------------------------|
| `migrations/20260322_add_playtime_to_user_games.ts` | Ajout colonnes `playtime_forever` et `playtime_2weeks` (nullable) | Données per-user-per-game, appartiennent à `user_games` |
| `steam-client.ts` | Ajout `playtime_2weeks` à l'interface `SteamOwnedGame` | L'API Steam retourne déjà ce champ |
| `auth.routes.ts` | Stockage playtime dans le sync avec guard `GREATEST` | Empêche la régression si Steam retourne 0 temporairement |
| `common-games.ts` | Ajout `SUM(playtime_forever)` et `AVG(playtime_forever)` | Signal de classement pour les sessions de vote |
| `create-session.ts` | Playtime comme tiebreaker dans le tri des jeux | Après votes historiques, avant alphabétique |
| `auth.routes.ts` (profile) | Expose `totalPlaytimeMinutes` et top 5 jeux | Enrichissement du profil utilisateur |
| `ProfilePage.tsx` | Affichage temps de jeu total et top games | Section dédiée sur le profil |
| `types/index.ts` | Ajout champs playtime aux interfaces | Cohérence des types partagés |
| `fr.json` / `en.json` | Clé i18n `profile.topGames` | Traduction FR/EN |

### Points d'attention pour la revue
- Le guard `GREATEST(EXCLUDED.playtime_forever, user_games.playtime_forever)` dans le merge empêche la régression de playtime (profil Steam temporairement privé)
- Le playtime est un **tiebreaker** uniquement — les votes historiques restent le signal principal pour éviter le biais "Spotify algorithm"
- Les colonnes sont nullable car Epic/GOG ne fournissent pas de données de playtime
- Pas de backfill nécessaire — les valeurs se remplissent au prochain sync

### Tests
- Compilation TypeScript : 0 erreur sur types, backend et frontend
- Lint : 0 erreur (3 warnings pré-existants)

### Prochaines étapes
- [ ] Revue de code par l'équipe
- [ ] Validation des tests
- [ ] Merge après approbation

> **Attention :** d'autres branches fast-meeting sont actives (`fm-add-tooltips`, `fm-admin-backoffice`, `fm-design-identity`, etc.). Vérifier les conflits potentiels avant merge.

---
_Implémentation générée automatiquement par IA_