### PR TITLE
feat(notifications): add in-app notification system

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -86,6 +86,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -7822,6 +7823,7 @@
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -7860,6 +7862,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.5.tgz",
       "integrity": "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -7903,6 +7906,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -7913,6 +7917,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -8029,6 +8034,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -8332,6 +8338,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8376,6 +8383,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -8718,6 +8726,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -9130,6 +9139,7 @@
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -9573,6 +9583,7 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -9970,6 +9981,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -10262,6 +10274,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -11236,6 +11249,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.4.tgz",
       "integrity": "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -11326,6 +11340,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4"
       },
@@ -14245,6 +14260,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14254,6 +14270,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -15724,6 +15741,7 @@
       "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -16103,6 +16121,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16431,6 +16450,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -16900,6 +16920,7 @@
       "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -17104,6 +17125,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -17247,6 +17269,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/packages/backend/migrations/20260323_add_notifications.ts
+++ b/packages/backend/migrations/20260323_add_notifications.ts
@@ -1,0 +1,39 @@
+import type { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('notifications', (table) => {
+    table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'))
+    table.string('type', 50).notNullable() // 'vote_opened', 'vote_closed', 'admin_broadcast'
+    table.string('title', 255).notNullable()
+    table.text('body').nullable()
+    table.uuid('group_id').nullable().references('id').inTable('groups').onDelete('CASCADE')
+    table.uuid('created_by').nullable().references('id').inTable('users').onDelete('SET NULL')
+    table.jsonb('metadata').nullable() // flexible payload (actionUrl, gameName, etc.)
+    table.timestamp('expires_at').nullable()
+    table.timestamp('created_at').notNullable().defaultTo(knex.fn.now())
+  })
+
+  await knex.schema.createTable('notification_recipients', (table) => {
+    table.uuid('notification_id').notNullable().references('id').inTable('notifications').onDelete('CASCADE')
+    table.uuid('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE')
+    table.timestamp('read_at').nullable()
+    table.primary(['notification_id', 'user_id'])
+  })
+
+  // Partial index for fast unread count per user
+  await knex.raw(`
+    CREATE INDEX idx_notif_recipients_user_unread
+    ON notification_recipients (user_id, read_at)
+    WHERE read_at IS NULL
+  `)
+
+  await knex.raw(`
+    CREATE INDEX idx_notifications_created
+    ON notifications (created_at DESC)
+  `)
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists('notification_recipients')
+  await knex.schema.dropTableIfExists('notifications')
+}

--- a/packages/backend/src/domain/close-session.ts
+++ b/packages/backend/src/domain/close-session.ts
@@ -2,6 +2,7 @@ import { db } from '../infrastructure/database/connection.js'
 import { getIO } from '../infrastructure/socket/socket.js'
 import { logger } from '../infrastructure/logger/logger.js'
 import { notifyVoteClosed } from '../infrastructure/discord/notifier.js'
+import { createNotification } from '../infrastructure/notifications/notification-service.js'
 import type { VoteResult } from '@wawptn/types'
 
 /**
@@ -73,6 +74,32 @@ export async function closeSession(sessionId: string, groupId: string): Promise<
   notifyVoteClosed(groupId, result).catch(err =>
     logger.warn({ error: String(err), groupId }, 'Discord notification failed')
   )
+
+  // In-app notification for group participants (non-blocking)
+  const group = await db('groups').where({ id: groupId }).first()
+  const groupName = group?.name || 'Groupe'
+  const participantIds: string[] = await db('voting_session_participants')
+    .where({ session_id: sessionId })
+    .pluck('user_id')
+
+  if (participantIds.length > 0 && winnerName) {
+    createNotification({
+      type: 'vote_closed',
+      title: `${winnerName} a gagné dans ${groupName} !`,
+      body: `${result.yesCount} sur ${result.totalVoters} ont voté pour.`,
+      groupId,
+      metadata: {
+        sessionId,
+        winnerAppId,
+        winnerName,
+        actionUrl: `/groups/${groupId}/vote`,
+      },
+      recipientUserIds: participantIds,
+      expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // 7 days
+    }).catch(err =>
+      logger.warn({ error: String(err), groupId }, 'in-app vote closed notification failed')
+    )
+  }
 
   logger.info({ sessionId, groupId, winner: winnerName, winnerAppId }, 'voting session closed')
 

--- a/packages/backend/src/domain/create-session.ts
+++ b/packages/backend/src/domain/create-session.ts
@@ -2,6 +2,7 @@ import { db } from '../infrastructure/database/connection.js'
 import { computeCommonGames, type GameFilters } from '../infrastructure/database/common-games.js'
 import { getIO } from '../infrastructure/socket/socket.js'
 import { notifySessionCreated } from '../infrastructure/discord/notifier.js'
+import { createNotification } from '../infrastructure/notifications/notification-service.js'
 import { logger } from '../infrastructure/logger/logger.js'
 
 export interface CreateSessionParams {
@@ -165,6 +166,24 @@ export async function createVotingSession(params: CreateSessionParams): Promise<
   }))).catch(err =>
     logger.warn({ error: String(err), groupId }, 'Discord session notification failed')
   )
+
+  // In-app notification for participants (non-blocking)
+  const groupName = group?.name || 'Groupe'
+  const notifRecipients = validMembers.filter(uid => uid !== createdBy)
+  if (notifRecipients.length > 0) {
+    createNotification({
+      type: 'vote_opened',
+      title: `Un vote a commencé dans ${groupName}`,
+      body: `${selectedGames.length} jeux en commun sont soumis au vote.`,
+      groupId,
+      createdBy,
+      metadata: { sessionId: session.id, actionUrl: `/groups/${groupId}/vote` },
+      recipientUserIds: notifRecipients,
+      expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // 7 days
+    }).catch(err =>
+      logger.warn({ error: String(err), groupId }, 'in-app vote notification failed')
+    )
+  }
 
   logger.info({ sessionId: session.id, groupId, gameCount: selectedGames.length, participants: validMembers.length }, 'voting session created')
 

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -25,6 +25,8 @@ import { adminRoutes } from './presentation/routes/admin.routes.js'
 import { subscriptionRoutes, subscriptionWebhookRouter } from './presentation/routes/subscription.routes.js'
 import { isStripeEnabled } from './infrastructure/stripe/stripe-client.js'
 import { personaRoutes } from './presentation/routes/persona.routes.js'
+import { notificationRoutes, adminNotificationRoutes } from './presentation/routes/notification.routes.js'
+import { startNotificationCleanup } from './infrastructure/notifications/notification-cleanup.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -118,8 +120,12 @@ async function main() {
   // Persona route (public, read-only — shows today's bot personality)
   app.use('/api/persona', personaRoutes)
 
+  // Notification routes (requires authenticated user)
+  app.use('/api/notifications', requireAuth, notificationRoutes)
+
   // Admin routes (requires authenticated admin user)
   app.use('/api/admin', requireAuth, requireAdmin, adminRoutes)
+  app.use('/api/admin/notifications', requireAuth, requireAdmin, adminNotificationRoutes)
 
   // Discord user-facing routes (session auth, no bot auth required)
   app.use('/api/discord', discordUserRoutes)
@@ -178,6 +184,9 @@ async function main() {
 
   // Subscription reconciler (daily Stripe sync + grace period enforcement)
   startSubscriptionReconciler()
+
+  // Notification cleanup (purge expired notifications weekly)
+  startNotificationCleanup()
 
   // Start server
   httpServer.listen(env.PORT, () => {

--- a/packages/backend/src/infrastructure/notifications/notification-cleanup.ts
+++ b/packages/backend/src/infrastructure/notifications/notification-cleanup.ts
@@ -1,0 +1,22 @@
+import cron from 'node-cron'
+import { cleanupExpiredNotifications } from './notification-service.js'
+import { logger } from '../logger/logger.js'
+
+const cleanupLogger = logger.child({ module: 'notification-cleanup' })
+
+/**
+ * Start a weekly cron job to clean up expired notifications.
+ * Runs every Sunday at 3:00 AM.
+ */
+export function startNotificationCleanup(): void {
+  cron.schedule('0 3 * * 0', async () => {
+    try {
+      const deleted = await cleanupExpiredNotifications()
+      cleanupLogger.info({ deleted }, 'notification cleanup completed')
+    } catch (error) {
+      cleanupLogger.error({ error: String(error) }, 'notification cleanup failed')
+    }
+  })
+
+  cleanupLogger.info('notification cleanup scheduler started (weekly, Sundays 3:00 AM)')
+}

--- a/packages/backend/src/infrastructure/notifications/notification-service.ts
+++ b/packages/backend/src/infrastructure/notifications/notification-service.ts
@@ -1,0 +1,160 @@
+import type { NotificationType } from '@wawptn/types'
+import { db } from '../database/connection.js'
+import { getIO } from '../socket/socket.js'
+import { logger } from '../logger/logger.js'
+
+const notificationLogger = logger.child({ module: 'notifications' })
+
+interface CreateNotificationParams {
+  type: NotificationType
+  title: string
+  body?: string
+  groupId?: string
+  createdBy?: string
+  metadata?: Record<string, unknown>
+  recipientUserIds: string[]
+  expiresAt?: Date
+}
+
+/**
+ * Create a notification, persist it, fan-out to recipients, and deliver via Socket.io.
+ */
+export async function createNotification(params: CreateNotificationParams): Promise<string> {
+  const { type, title, body, groupId, createdBy, metadata, recipientUserIds, expiresAt } = params
+
+  if (recipientUserIds.length === 0) return ''
+
+  const [notification] = await db('notifications')
+    .insert({
+      type,
+      title,
+      body: body || null,
+      group_id: groupId || null,
+      created_by: createdBy || null,
+      metadata: metadata ? JSON.stringify(metadata) : null,
+      expires_at: expiresAt || null,
+    })
+    .returning('*')
+
+  // Fan-out: insert recipient rows
+  const recipientRows = recipientUserIds.map((userId) => ({
+    notification_id: notification.id,
+    user_id: userId,
+  }))
+
+  await db.batchInsert('notification_recipients', recipientRows, 500)
+
+  // Deliver via Socket.io to online users
+  const io = getIO()
+  const payload = {
+    id: notification.id,
+    type: notification.type as NotificationType,
+    title: notification.title,
+    body: notification.body,
+    groupId: notification.group_id,
+    metadata: notification.metadata ? (typeof notification.metadata === 'string' ? JSON.parse(notification.metadata) : notification.metadata) : null,
+    read: false,
+    createdAt: notification.created_at,
+  }
+
+  for (const userId of recipientUserIds) {
+    io.to(`user:${userId}`).emit('notification:new', payload)
+  }
+
+  notificationLogger.info(
+    { notificationId: notification.id, type, recipientCount: recipientUserIds.length },
+    'notification created and delivered'
+  )
+
+  return notification.id
+}
+
+/**
+ * Get unread notifications for a user.
+ */
+export async function getUnreadNotifications(userId: string, limit = 20) {
+  const rows = await db('notification_recipients')
+    .join('notifications', 'notification_recipients.notification_id', 'notifications.id')
+    .where('notification_recipients.user_id', userId)
+    .where('notification_recipients.read_at', null)
+    .where(function () {
+      this.whereNull('notifications.expires_at').orWhere('notifications.expires_at', '>', new Date())
+    })
+    .orderBy('notifications.created_at', 'desc')
+    .limit(limit)
+    .select(
+      'notifications.id',
+      'notifications.type',
+      'notifications.title',
+      'notifications.body',
+      'notifications.group_id as groupId',
+      'notifications.metadata',
+      'notifications.created_at as createdAt',
+      'notification_recipients.read_at'
+    )
+
+  return rows.map((r) => ({
+    id: r.id,
+    type: r.type as NotificationType,
+    title: r.title,
+    body: r.body,
+    groupId: r.groupId,
+    metadata: r.metadata ? (typeof r.metadata === 'string' ? JSON.parse(r.metadata) : r.metadata) : null,
+    read: !!r.read_at,
+    createdAt: r.createdAt,
+  }))
+}
+
+/**
+ * Get unread notification count for a user.
+ */
+export async function getUnreadCount(userId: string): Promise<number> {
+  const result = await db('notification_recipients')
+    .join('notifications', 'notification_recipients.notification_id', 'notifications.id')
+    .where('notification_recipients.user_id', userId)
+    .where('notification_recipients.read_at', null)
+    .where(function () {
+      this.whereNull('notifications.expires_at').orWhere('notifications.expires_at', '>', new Date())
+    })
+    .count('* as count')
+    .first()
+
+  return Number(result?.count || 0)
+}
+
+/**
+ * Mark a specific notification as read for a user.
+ */
+export async function markAsRead(notificationId: string, userId: string): Promise<boolean> {
+  const updated = await db('notification_recipients')
+    .where({ notification_id: notificationId, user_id: userId })
+    .whereNull('read_at')
+    .update({ read_at: db.fn.now() })
+
+  return updated > 0
+}
+
+/**
+ * Mark all notifications as read for a user.
+ */
+export async function markAllAsRead(userId: string): Promise<number> {
+  return db('notification_recipients')
+    .where({ user_id: userId })
+    .whereNull('read_at')
+    .update({ read_at: db.fn.now() })
+}
+
+/**
+ * Cleanup expired notifications. Run periodically via cron.
+ */
+export async function cleanupExpiredNotifications(): Promise<number> {
+  const deleted = await db('notifications')
+    .where('expires_at', '<', new Date())
+    .del()
+
+  if (deleted > 0) {
+    notificationLogger.info({ deletedCount: deleted }, 'expired notifications cleaned up')
+  }
+
+  return deleted
+}

--- a/packages/backend/src/infrastructure/socket/socket.ts
+++ b/packages/backend/src/infrastructure/socket/socket.ts
@@ -96,6 +96,9 @@ export function createSocketServer(httpServer: HttpServer): TypedServer {
   io.on('connection', (socket) => {
     socketLogger.info({ userId: socket.data.userId }, 'client connected')
 
+    // Auto-join user-specific room for targeted notifications
+    socket.join(`user:${socket.data.userId}`)
+
     socket.on('group:join', async (groupId) => {
       // Verify membership before joining room
       const membership = await db('group_members')

--- a/packages/backend/src/presentation/routes/notification.routes.ts
+++ b/packages/backend/src/presentation/routes/notification.routes.ts
@@ -1,0 +1,103 @@
+import { Router, type Request, type Response } from 'express'
+import {
+  getUnreadNotifications,
+  getUnreadCount,
+  markAsRead,
+  markAllAsRead,
+  createNotification,
+} from '../../infrastructure/notifications/notification-service.js'
+import { db } from '../../infrastructure/database/connection.js'
+import { logger } from '../../infrastructure/logger/logger.js'
+
+const router = Router()
+
+// Get unread notifications for current user
+router.get('/', async (req: Request, res: Response) => {
+  const userId = req.userId!
+  const notifications = await getUnreadNotifications(userId)
+  res.json(notifications)
+})
+
+// Get unread count
+router.get('/count', async (req: Request, res: Response) => {
+  const userId = req.userId!
+  const count = await getUnreadCount(userId)
+  res.json({ count })
+})
+
+// Mark a single notification as read
+router.patch('/:id/read', async (req: Request, res: Response) => {
+  const userId = req.userId!
+  const notificationId = String(req.params['id'])
+  const updated = await markAsRead(notificationId, userId)
+
+  if (!updated) {
+    res.status(404).json({ error: 'not_found', message: 'Notification introuvable ou déjà lue' })
+    return
+  }
+
+  res.json({ ok: true })
+})
+
+// Mark all notifications as read
+router.post('/read-all', async (req: Request, res: Response) => {
+  const userId = req.userId!
+  const count = await markAllAsRead(userId)
+  res.json({ ok: true, count })
+})
+
+export { router as notificationRoutes }
+
+// ─── Admin notification routes ───────────────────────────────────────────────
+
+const adminRouter = Router()
+
+// Broadcast a notification to all users or a specific group
+adminRouter.post('/', async (req: Request, res: Response) => {
+  const adminUserId = req.userId!
+  const { title, body, groupId } = req.body as { title?: string; body?: string; groupId?: string }
+
+  if (!title || typeof title !== 'string' || title.trim().length === 0) {
+    res.status(400).json({ error: 'validation', message: 'Le titre est requis' })
+    return
+  }
+
+  if (title.length > 255) {
+    res.status(400).json({ error: 'validation', message: 'Le titre ne doit pas dépasser 255 caractères' })
+    return
+  }
+
+  // Determine recipients
+  let recipientUserIds: string[]
+  if (groupId) {
+    recipientUserIds = await db('group_members')
+      .where({ group_id: groupId })
+      .pluck('user_id')
+
+    if (recipientUserIds.length === 0) {
+      res.status(404).json({ error: 'not_found', message: 'Groupe introuvable ou vide' })
+      return
+    }
+  } else {
+    recipientUserIds = await db('users').pluck('id')
+  }
+
+  const notificationId = await createNotification({
+    type: 'admin_broadcast',
+    title: title.trim(),
+    body: body?.trim() || undefined,
+    groupId,
+    createdBy: adminUserId,
+    recipientUserIds,
+    expiresAt: new Date(Date.now() + 90 * 24 * 60 * 60 * 1000), // 90 days
+  })
+
+  logger.info(
+    { adminUserId, notificationId, recipientCount: recipientUserIds.length, groupId },
+    'admin broadcast notification sent'
+  )
+
+  res.status(201).json({ ok: true, notificationId, recipientCount: recipientUserIds.length })
+})
+
+export { adminRouter as adminNotificationRoutes }

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -15,6 +15,8 @@ import { AdminPage } from '@/pages/AdminPage'
 import { SubscriptionPage } from '@/pages/SubscriptionPage'
 import { Skeleton } from '@/components/ui/skeleton'
 import { DialogTestPage } from '@/pages/DialogTestPage'
+import { useNotificationListener } from '@/hooks/useNotificationListener'
+import { useNotificationStore } from '@/stores/notification.store'
 
 function App() {
   const { user, loading, fetchUser } = useAuthStore()
@@ -28,9 +30,13 @@ function App() {
       connectSocket()
     } else {
       disconnectSocket()
+      useNotificationStore.getState().clear()
     }
     return () => disconnectSocket()
   }, [user])
+
+  // Global notification listener (only when authenticated)
+  useNotificationListener()
 
   // Dev-only dialog test page (no auth required)
   if (import.meta.env.DEV && window.location.pathname === '/test-dialogs') {

--- a/packages/frontend/src/components/app-header.tsx
+++ b/packages/frontend/src/components/app-header.tsx
@@ -17,6 +17,7 @@ import {
   ResponsiveDialogTitle,
 } from '@/components/ui/responsive-dialog'
 import { WawptnLogo } from '@/components/icons/wawptn-logo'
+import { NotificationBell } from '@/components/notification-bell'
 
 interface AppHeaderProps {
   children?: React.ReactNode
@@ -63,6 +64,9 @@ export function AppHeader({ children, className, maxWidth = 'narrow' }: AppHeade
 
         {/* Today's bot persona */}
         {user && <PersonaBadge />}
+
+        {/* Notifications */}
+        {user && <NotificationBell />}
 
         {/* User menu */}
         <div className="relative">

--- a/packages/frontend/src/components/notification-bell.tsx
+++ b/packages/frontend/src/components/notification-bell.tsx
@@ -1,0 +1,157 @@
+import { useState, useMemo } from 'react'
+import { Bell, CheckCheck } from 'lucide-react'
+import { useNavigate } from 'react-router-dom'
+import { motion, AnimatePresence } from 'framer-motion'
+import { useTranslation } from 'react-i18next'
+import { useNotificationStore } from '@/stores/notification.store'
+import type { Notification } from '@wawptn/types'
+
+export function NotificationBell() {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const [open, setOpen] = useState(false)
+  const [now, setNow] = useState(() => Date.now())
+  const { notifications, unreadCount, markAsRead, markAllAsRead } = useNotificationStore()
+
+  // Use unreadCount as animation key so the bell re-animates on each new notification
+  const bellAnimationKey = useMemo(() => unreadCount, [unreadCount])
+
+  const handleNotificationClick = async (notification: Notification) => {
+    if (!notification.read) {
+      await markAsRead(notification.id)
+    }
+    const actionUrl = notification.metadata?.actionUrl as string | undefined
+    if (actionUrl) {
+      navigate(actionUrl)
+    }
+    setOpen(false)
+  }
+
+  const handleOpen = () => {
+    setNow(Date.now())
+    setOpen(!open)
+  }
+
+  const getTimeAgo = (dateStr: string) => {
+    const diff = now - new Date(dateStr).getTime()
+    const minutes = Math.floor(diff / 60000)
+    if (minutes < 1) return t('notifications.justNow')
+    if (minutes < 60) return t('notifications.minutesAgo', { count: minutes })
+    const hours = Math.floor(minutes / 60)
+    if (hours < 24) return t('notifications.hoursAgo', { count: hours })
+    const days = Math.floor(hours / 24)
+    return t('notifications.daysAgo', { count: days })
+  }
+
+  const getNotificationIcon = (type: string) => {
+    switch (type) {
+      case 'vote_opened': return '🗳️'
+      case 'vote_closed': return '🏆'
+      case 'admin_broadcast': return '📢'
+      default: return '🔔'
+    }
+  }
+
+  return (
+    <div className="relative">
+      <button
+        onClick={handleOpen}
+        className="relative flex items-center justify-center rounded-full hover:bg-white/[0.06] transition-colors p-2 -m-1 min-h-[44px] min-w-[44px]"
+        aria-label={t('notifications.title')}
+      >
+        <motion.div
+          key={bellAnimationKey}
+          animate={{ rotate: [0, 12, -12, 8, -8, 0] }}
+          transition={{ duration: 0.4 }}
+        >
+          <Bell className="w-5 h-5" />
+        </motion.div>
+        <AnimatePresence>
+          {unreadCount > 0 && (
+            <motion.span
+              initial={{ scale: 0 }}
+              animate={{ scale: [0, 1.2, 1] }}
+              exit={{ scale: 0 }}
+              className="absolute top-1.5 right-1.5 w-2.5 h-2.5 bg-destructive rounded-full"
+            />
+          )}
+        </AnimatePresence>
+      </button>
+
+      <AnimatePresence>
+        {open && (
+          <>
+            {/* Backdrop */}
+            <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} />
+
+            <motion.div
+              initial={{ opacity: 0, y: -8 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -8 }}
+              transition={{ duration: 0.15 }}
+              className="absolute right-0 top-full mt-1 z-50 w-80 max-w-[calc(100vw-2rem)] max-h-[calc(100vh-5rem)] rounded-md border border-border bg-popover shadow-md overflow-hidden flex flex-col"
+            >
+              {/* Header */}
+              <div className="flex items-center justify-between px-3 py-2 border-b border-border">
+                <span className="text-sm font-medium">{t('notifications.title')}</span>
+                {unreadCount > 0 && (
+                  <button
+                    onClick={() => markAllAsRead()}
+                    className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+                  >
+                    <CheckCheck className="w-3.5 h-3.5" />
+                    {t('notifications.markAllRead')}
+                  </button>
+                )}
+              </div>
+
+              {/* Notification list */}
+              <div className="overflow-y-auto flex-1">
+                {notifications.length === 0 ? (
+                  <div className="px-3 py-8 text-center text-sm text-muted-foreground">
+                    {t('notifications.empty')}
+                  </div>
+                ) : (
+                  <div className="divide-y divide-border">
+                    {notifications.map((notification, i) => (
+                      <motion.button
+                        key={notification.id}
+                        initial={{ opacity: 0, y: -8 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        transition={{ delay: i * 0.03, duration: 0.15 }}
+                        onClick={() => handleNotificationClick(notification)}
+                        className={`w-full text-left px-3 py-2.5 hover:bg-accent/50 transition-colors flex gap-2.5 ${
+                          !notification.read ? 'bg-accent/20' : ''
+                        }`}
+                      >
+                        <span className="text-base mt-0.5 flex-shrink-0">
+                          {getNotificationIcon(notification.type)}
+                        </span>
+                        <div className="flex-1 min-w-0">
+                          <p className={`text-sm leading-tight ${!notification.read ? 'font-medium' : 'text-muted-foreground'}`}>
+                            {notification.title}
+                          </p>
+                          {notification.body && (
+                            <p className="text-xs text-muted-foreground mt-0.5 line-clamp-2">
+                              {notification.body}
+                            </p>
+                          )}
+                          <p className="text-[10px] text-muted-foreground/60 mt-1">
+                            {getTimeAgo(notification.createdAt)}
+                          </p>
+                        </div>
+                        {!notification.read && (
+                          <span className="w-2 h-2 bg-primary rounded-full mt-1.5 flex-shrink-0" />
+                        )}
+                      </motion.button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </motion.div>
+          </>
+        )}
+      </AnimatePresence>
+    </div>
+  )
+}

--- a/packages/frontend/src/hooks/useNotificationListener.ts
+++ b/packages/frontend/src/hooks/useNotificationListener.ts
@@ -1,0 +1,29 @@
+import { useEffect } from 'react'
+import { getSocket } from '@/lib/socket'
+import { useNotificationStore } from '@/stores/notification.store'
+
+/**
+ * Global hook that listens for notification:new socket events
+ * and pushes them into the notification store.
+ * Must be mounted once at the app level after authentication.
+ */
+export function useNotificationListener() {
+  const { addNotification, fetchNotifications } = useNotificationStore()
+
+  useEffect(() => {
+    // Fetch existing unread notifications on mount
+    fetchNotifications()
+
+    const socket = getSocket()
+
+    const handleNewNotification = (data: Parameters<typeof addNotification>[0]) => {
+      addNotification(data)
+    }
+
+    socket.on('notification:new', handleNewNotification)
+
+    return () => {
+      socket.off('notification:new', handleNewNotification)
+    }
+  }, [addNotification, fetchNotifications])
+}

--- a/packages/frontend/src/i18n/locales/en.json
+++ b/packages/frontend/src/i18n/locales/en.json
@@ -330,5 +330,22 @@
     "premiumFeature4": "Discord bot with personalities",
     "premiumFeature5": "Scheduled auto-voting",
     "premiumCtaButton": "Upgrade to Premium"
+  },
+  "notifications": {
+    "title": "Notifications",
+    "empty": "No notifications",
+    "markAllRead": "Mark all as read",
+    "justNow": "Just now",
+    "minutesAgo": "{{count}}m ago",
+    "hoursAgo": "{{count}}h ago",
+    "daysAgo": "{{count}}d ago",
+    "broadcastTitle": "Send an announcement",
+    "broadcastTitleLabel": "Title",
+    "broadcastTitlePlaceholder": "Announcement title...",
+    "broadcastBodyLabel": "Message (optional)",
+    "broadcastBodyPlaceholder": "Announcement details...",
+    "broadcastSend": "Send",
+    "broadcastSuccess": "Announcement sent to {{count}} users",
+    "broadcastError": "Unable to send announcement"
   }
 }

--- a/packages/frontend/src/i18n/locales/fr.json
+++ b/packages/frontend/src/i18n/locales/fr.json
@@ -367,5 +367,22 @@
   },
   "persona": {
     "today": "Persona du jour"
+  },
+  "notifications": {
+    "title": "Notifications",
+    "empty": "Aucune notification",
+    "markAllRead": "Tout marquer comme lu",
+    "justNow": "À l'instant",
+    "minutesAgo": "Il y a {{count}} min",
+    "hoursAgo": "Il y a {{count}}h",
+    "daysAgo": "Il y a {{count}}j",
+    "broadcastTitle": "Envoyer une annonce",
+    "broadcastTitleLabel": "Titre",
+    "broadcastTitlePlaceholder": "Titre de l'annonce...",
+    "broadcastBodyLabel": "Message (optionnel)",
+    "broadcastBodyPlaceholder": "Détails de l'annonce...",
+    "broadcastSend": "Envoyer",
+    "broadcastSuccess": "Annonce envoyée à {{count}} utilisateurs",
+    "broadcastError": "Impossible d'envoyer l'annonce"
   }
 }

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -162,6 +162,17 @@ export const api = {
   deleteVoteSession: (groupId: string, sessionId: string) =>
     request<{ ok: boolean }>(`/groups/${groupId}/vote/${sessionId}`, { method: 'DELETE' }),
 
+  // Notifications
+  getNotifications: () => request<import('@wawptn/types').Notification[]>('/notifications'),
+  getNotificationCount: () => request<{ count: number }>('/notifications/count'),
+  markNotificationRead: (id: string) => request<{ ok: boolean }>(`/notifications/${id}/read`, { method: 'PATCH' }),
+  markAllNotificationsRead: () => request<{ ok: boolean; count: number }>('/notifications/read-all', { method: 'POST' }),
+  broadcastNotification: (title: string, body?: string, groupId?: string) =>
+    request<{ ok: boolean; notificationId: string; recipientCount: number }>('/admin/notifications', {
+      method: 'POST',
+      body: JSON.stringify({ title, body, groupId }),
+    }),
+
   // Persona
   getCurrentPersona: () => request<{ id: string; name: string; embedColor: number; introMessage: string }>('/persona/current'),
 

--- a/packages/frontend/src/pages/AdminPage.tsx
+++ b/packages/frontend/src/pages/AdminPage.tsx
@@ -3,9 +3,10 @@ import { useNavigate } from 'react-router-dom'
 import {
   ArrowLeft, Bot, Users, BarChart3, Save, RefreshCw, ShieldCheck,
   ShieldOff, Theater, Plus, Pencil, Trash2, Lock, Search, X,
-  Activity, Zap, Clock, Globe, Terminal,
+  Activity, Zap, Clock, Globe, Terminal, Megaphone, Send,
 } from 'lucide-react'
 import { toast } from 'sonner'
+import { useTranslation } from 'react-i18next'
 import { motion, AnimatePresence, type Variants } from 'framer-motion'
 import { AppHeader } from '@/components/app-header'
 import { Button } from '@/components/ui/button'
@@ -94,10 +95,11 @@ const EMPTY_FORM: PersonaFormData = {
   embedColor: '#5865F2',
 }
 
-type AdminTab = 'overview' | 'bot' | 'personas' | 'users'
+type AdminTab = 'overview' | 'bot' | 'personas' | 'users' | 'notifications'
 
 const TABS: { id: AdminTab; label: string; icon: typeof BarChart3 }[] = [
   { id: 'overview', label: 'Vue d\'ensemble', icon: Activity },
+  { id: 'notifications', label: 'Annonces', icon: Megaphone },
   { id: 'bot', label: 'Bot Discord', icon: Bot },
   { id: 'personas', label: 'Personas', icon: Theater },
   { id: 'users', label: 'Utilisateurs', icon: Users },
@@ -496,6 +498,18 @@ export function AdminPage() {
             </motion.div>
           )}
 
+          {activeTab === 'notifications' && (
+            <motion.div
+              key="notifications"
+              variants={tabContent}
+              initial="enter"
+              animate="center"
+              exit="exit"
+            >
+              <NotificationsTab />
+            </motion.div>
+          )}
+
           {activeTab === 'bot' && (
             <motion.div
               key="bot"
@@ -714,6 +728,79 @@ export function AdminPage() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+    </div>
+  )
+}
+
+/* ═══════════════════════════════════════════════════════
+   TAB: Notifications
+   ═══════════════════════════════════════════════════════ */
+
+function NotificationsTab() {
+  const { t } = useTranslation()
+  const [title, setTitle] = useState('')
+  const [body, setBody] = useState('')
+  const [sending, setSending] = useState(false)
+
+  const handleSend = async () => {
+    if (!title.trim()) return
+    setSending(true)
+    try {
+      const result = await api.broadcastNotification(title.trim(), body.trim() || undefined)
+      toast.success(t('notifications.broadcastSuccess', { count: result.recipientCount }))
+      setTitle('')
+      setBody('')
+    } catch {
+      toast.error(t('notifications.broadcastError'))
+    } finally {
+      setSending(false)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Megaphone className="w-4 h-4" />
+            {t('notifications.broadcastTitle')}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="space-y-1.5">
+            <label htmlFor="broadcast-title" className="text-sm font-medium">
+              {t('notifications.broadcastTitleLabel')}
+            </label>
+            <Input
+              id="broadcast-title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder={t('notifications.broadcastTitlePlaceholder')}
+              maxLength={255}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <label htmlFor="broadcast-body" className="text-sm font-medium">
+              {t('notifications.broadcastBodyLabel')}
+            </label>
+            <Textarea
+              id="broadcast-body"
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              placeholder={t('notifications.broadcastBodyPlaceholder')}
+              rows={3}
+            />
+          </div>
+          <Button
+            onClick={handleSend}
+            disabled={!title.trim() || sending}
+            className="w-full"
+          >
+            <Send className="w-4 h-4 mr-2" />
+            {sending ? '...' : t('notifications.broadcastSend')}
+          </Button>
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/packages/frontend/src/stores/notification.store.ts
+++ b/packages/frontend/src/stores/notification.store.ts
@@ -1,0 +1,75 @@
+import { create } from 'zustand'
+import type { Notification } from '@wawptn/types'
+import { api } from '@/lib/api'
+
+interface NotificationState {
+  notifications: Notification[]
+  unreadCount: number
+  loading: boolean
+  fetchNotifications: () => Promise<void>
+  fetchUnreadCount: () => Promise<void>
+  addNotification: (notification: Notification) => void
+  markAsRead: (id: string) => Promise<void>
+  markAllAsRead: () => Promise<void>
+  clear: () => void
+}
+
+export const useNotificationStore = create<NotificationState>((set) => ({
+  notifications: [],
+  unreadCount: 0,
+  loading: false,
+
+  fetchNotifications: async () => {
+    set({ loading: true })
+    try {
+      const notifications = await api.getNotifications()
+      set({ notifications, unreadCount: notifications.length, loading: false })
+    } catch {
+      set({ loading: false })
+    }
+  },
+
+  fetchUnreadCount: async () => {
+    try {
+      const { count } = await api.getNotificationCount()
+      set({ unreadCount: count })
+    } catch {
+      // ignore
+    }
+  },
+
+  addNotification: (notification: Notification) => {
+    set((state) => ({
+      notifications: [notification, ...state.notifications],
+      unreadCount: state.unreadCount + 1,
+    }))
+  },
+
+  markAsRead: async (id: string) => {
+    try {
+      await api.markNotificationRead(id)
+      set((state) => ({
+        notifications: state.notifications.map((n) =>
+          n.id === id ? { ...n, read: true } : n
+        ),
+        unreadCount: Math.max(0, state.unreadCount - 1),
+      }))
+    } catch {
+      // ignore
+    }
+  },
+
+  markAllAsRead: async () => {
+    try {
+      await api.markAllNotificationsRead()
+      set((state) => ({
+        notifications: state.notifications.map((n) => ({ ...n, read: true })),
+        unreadCount: 0,
+      }))
+    } catch {
+      // ignore
+    }
+  },
+
+  clear: () => set({ notifications: [], unreadCount: 0 }),
+}))

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -181,6 +181,23 @@ export interface DiscordGroupConfig {
 }
 
 // ============================================
+// Notifications
+// ============================================
+
+export type NotificationType = 'vote_opened' | 'vote_closed' | 'admin_broadcast'
+
+export interface Notification {
+  id: string
+  type: NotificationType
+  title: string
+  body: string | null
+  groupId: string | null
+  metadata: Record<string, unknown> | null
+  read: boolean
+  createdAt: string
+}
+
+// ============================================
 // Socket.io Events
 // ============================================
 
@@ -197,6 +214,7 @@ export interface ServerToClientEvents {
   'group:presence': (data: { onlineUserIds: string[] }) => void
   'member:online': (data: { groupId: string; userId: string }) => void
   'member:offline': (data: { groupId: string; userId: string }) => void
+  'notification:new': (data: Notification) => void
 }
 
 export interface ClientToServerEvents {


### PR DESCRIPTION
## Résumé technique

### Contexte
L'application WAWPTN utilise exclusivement l'authentification Steam OpenID — aucun email utilisateur n'est disponible. Pour communiquer avec les utilisateurs (annonces admin, notifications de votes), un système de notifications in-app est nécessaire comme canal de communication principal asynchrone.

**Décision issue d'une réunion rapide avec 4 personas :** Sprint Zero Sarah (PO), Whiteboard Damien (Architecte), SOLID Alex (Backend), Pixel-Perfect Hugo (Frontend). Consensus sur une architecture base de données + Socket.io temps réel.

### Approche retenue
Architecture **persistée en base** (2 tables normalisées) avec **livraison temps réel via Socket.io** et **fallback REST pour les utilisateurs offline**. Chaque socket rejoint automatiquement un room `user:{userId}` à la connexion, permettant le ciblage individuel sans contexte de groupe.

### Changements implémentés
| Fichier | Modification | Justification technique |
|---------|-------------|------------------------|
| `packages/types/src/index.ts` | Ajout `Notification`, `NotificationType`, événement `notification:new` | Types partagés pour le contrat backend/frontend |
| `packages/backend/migrations/20260323_add_notifications.ts` | Tables `notifications` + `notification_recipients` avec partial index | 2 tables séparées pour unread count O(1) via partial index |
| `packages/backend/src/infrastructure/notifications/notification-service.ts` | Service de création, lecture, marquage, nettoyage | Fonction centralisée (Open/Closed) — ajouter un type = nouveau callsite |
| `packages/backend/src/infrastructure/notifications/notification-cleanup.ts` | Cron hebdomadaire de purge | Évite l'accumulation sans borne des notifications expirées |
| `packages/backend/src/presentation/routes/notification.routes.ts` | Routes REST : GET, PATCH read, POST read-all, POST admin broadcast | API standard pour le frontend + endpoint admin |
| `packages/backend/src/infrastructure/socket/socket.ts` | Auto-join room `user:{userId}` | Permet le ciblage par utilisateur sans contexte de groupe |
| `packages/backend/src/domain/create-session.ts` | Notification `vote_opened` aux participants | Branché sur l'événement existant, non-bloquant |
| `packages/backend/src/domain/close-session.ts` | Notification `vote_closed` aux participants | Branché sur l'événement existant, non-bloquant |
| `packages/backend/src/index.ts` | Enregistrement des routes et du cron cleanup | Wiring standard |
| `packages/frontend/src/stores/notification.store.ts` | Zustand store avec fetch, add, markRead, markAll, clear | État global des notifications |
| `packages/frontend/src/hooks/useNotificationListener.ts` | Hook global Socket.io `notification:new` | Écoute globale quel que soit la page active |
| `packages/frontend/src/components/notification-bell.tsx` | Icône cloche avec badge + panel dropdown | UI du centre de notifications |
| `packages/frontend/src/components/app-header.tsx` | Intégration de NotificationBell | Entre PersonaBadge et l'avatar |
| `packages/frontend/src/App.tsx` | Mount du listener global + clear au logout | Cycle de vie des notifications |
| `packages/frontend/src/lib/api.ts` | 5 endpoints notification dans le client API | Intégration REST |
| `packages/frontend/src/pages/AdminPage.tsx` | Onglet "Annonces" avec formulaire broadcast | Interface admin pour envoyer des annonces |
| `packages/frontend/src/i18n/locales/{fr,en}.json` | Traductions notifications | FR + EN |

### Points d'attention pour la revue
- Le partial index `WHERE read_at IS NULL` est critique pour la performance du unread count
- Les notifications sont créées de manière **non-bloquante** (`.catch()`) dans les domain events pour ne pas ralentir les opérations de vote
- Le fan-out utilise `batchInsert` avec chunk de 500 pour les broadcasts admin
- L'expiration par défaut est 7 jours pour les notifications système, 90 jours pour les broadcasts admin
- Le nettoyage tourne le dimanche à 3h du matin via node-cron

### Tests
- TypeScript : compilation propre sur les 3 packages (types, backend, frontend)
- ESLint : 0 erreurs (3 warnings pré-existants)
- Pas de suite de tests unitaires détectée

### Étapes restantes
- [ ] Ajouter des types de notification supplémentaires (member:kicked, group:deleted)
- [ ] Optionnel : toasts Sonner à l'arrivée d'une nouvelle notification
- [ ] Optionnel : Web Push API pour les utilisateurs complètement offline

### Prochaines étapes
- [ ] Revue de code par l'équipe
- [ ] Validation des tests
- [ ] Merge après approbation

> _Attention : d'autres branches fast-meeting sont actives. Vérifier les conflits potentiels avant merge._

---
_Implémentation générée automatiquement par IA_