### PR TITLE
Migrate shadcn/ui components to v4 patterns + add DropdownMenu

### DIFF
--- a/packages/frontend/src/components/app-header.tsx
+++ b/packages/frontend/src/components/app-header.tsx
@@ -7,6 +7,14 @@ import { useAuthStore } from '@/stores/auth.store'
 import { useSubscriptionStore } from '@/stores/subscription.store'
 import { Button } from '@/components/ui/button'
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 import { PersonaBadge } from '@/components/persona-badge'
 import {
   ResponsiveDialog,
@@ -31,7 +39,6 @@ export function AppHeader({ children, className, maxWidth = 'narrow' }: AppHeade
   const { user, logout } = useAuthStore()
   const { tier } = useSubscriptionStore()
   const [showLogoutDialog, setShowLogoutDialog] = useState(false)
-  const [showMenu, setShowMenu] = useState(false)
 
   const handleLogout = async () => {
     await logout()
@@ -69,68 +76,57 @@ export function AppHeader({ children, className, maxWidth = 'narrow' }: AppHeade
         {user && <NotificationBell />}
 
         {/* User menu */}
-        <div className="relative">
-          <button
-            onClick={() => setShowMenu(!showMenu)}
-            className="flex items-center justify-center rounded-full hover:ring-2 hover:ring-primary/20 transition-all p-1.5 -m-1 min-h-[44px] min-w-[44px]"
-            aria-label={t('profile.title')}
-          >
-            {user ? (
-              <Avatar className="w-8 h-8">
-                <AvatarImage src={user.avatarUrl} alt={user.displayName} />
-                <AvatarFallback>{user.displayName.charAt(0).toUpperCase()}</AvatarFallback>
-              </Avatar>
-            ) : (
-              <div className="w-8 h-8 rounded-full bg-muted flex items-center justify-center">
-                <User className="w-4 h-4" />
-              </div>
-            )}
-          </button>
-
-          {showMenu && (
-            <>
-              {/* Backdrop to close menu */}
-              <div className="fixed inset-0 z-40" onClick={() => setShowMenu(false)} />
-              <div className="absolute right-0 top-full mt-1 z-50 min-w-[180px] max-w-[calc(100vw-2rem)] rounded-md border border-border bg-popover p-1 shadow-md">
-                {user && (
-                  <div className="px-2 py-1.5 text-sm font-medium truncate border-b border-border mb-1 pb-1.5">
-                    {user.displayName}
-                  </div>
-                )}
-                <button
-                  className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground transition-colors"
-                  onClick={() => { setShowMenu(false); navigate('/profile') }}
-                >
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              className="flex items-center justify-center rounded-full hover:ring-2 hover:ring-primary/20 transition-all p-1.5 -m-1 min-h-[44px] min-w-[44px]"
+              aria-label={t('profile.title')}
+            >
+              {user ? (
+                <Avatar className="w-8 h-8">
+                  <AvatarImage src={user.avatarUrl} alt={user.displayName} />
+                  <AvatarFallback>{user.displayName.charAt(0).toUpperCase()}</AvatarFallback>
+                </Avatar>
+              ) : (
+                <div className="w-8 h-8 rounded-full bg-muted flex items-center justify-center">
                   <User className="w-4 h-4" />
-                  {t('profile.title')}
-                </button>
-                <button
-                  className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground transition-colors"
-                  onClick={() => { setShowMenu(false); navigate('/subscription') }}
-                >
-                  <Crown className={cn('w-4 h-4', tier === 'premium' ? 'text-reward' : 'text-muted-foreground')} />
-                  {tier === 'premium' ? t('subscription.premium') : t('subscription.upgrade')}
-                </button>
-                {user?.isAdmin && (
-                  <button
-                    className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground transition-colors"
-                    onClick={() => { setShowMenu(false); navigate('/admin') }}
-                  >
-                    <Shield className="w-4 h-4" />
-                    Administration
-                  </button>
-                )}
-                <button
-                  className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-destructive hover:bg-destructive/10 transition-colors"
-                  onClick={() => { setShowMenu(false); setShowLogoutDialog(true) }}
-                >
-                  <LogOut className="w-4 h-4" />
-                  {t('groups.logout')}
-                </button>
-              </div>
-            </>
-          )}
-        </div>
+                </div>
+              )}
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="min-w-[180px]">
+            {user && (
+              <>
+                <DropdownMenuLabel className="truncate">
+                  {user.displayName}
+                </DropdownMenuLabel>
+                <DropdownMenuSeparator />
+              </>
+            )}
+            <DropdownMenuItem onSelect={() => navigate('/profile')}>
+              <User />
+              {t('profile.title')}
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => navigate('/subscription')}>
+              <Crown className={cn(tier === 'premium' ? 'text-reward' : 'text-muted-foreground')} />
+              {tier === 'premium' ? t('subscription.premium') : t('subscription.upgrade')}
+            </DropdownMenuItem>
+            {user?.isAdmin && (
+              <DropdownMenuItem onSelect={() => navigate('/admin')}>
+                <Shield />
+                Administration
+              </DropdownMenuItem>
+            )}
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onSelect={() => setShowLogoutDialog(true)}
+              className="text-destructive focus:text-destructive focus:bg-destructive/10"
+            >
+              <LogOut />
+              {t('groups.logout')}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
       </nav>
 
       <ResponsiveDialog open={showLogoutDialog} onOpenChange={setShowLogoutDialog}>

--- a/packages/frontend/src/components/ui/badge.tsx
+++ b/packages/frontend/src/components/ui/badge.tsx
@@ -19,12 +19,18 @@ const badgeVariants = cva(
   }
 )
 
-interface BadgeProps
-  extends React.HTMLAttributes<HTMLDivElement>,
-    VariantProps<typeof badgeVariants> {}
-
-function Badge({ className, variant, ...props }: BadgeProps) {
-  return <div className={cn(badgeVariants({ variant }), className)} {...props} />
+function Badge({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<'div'> & VariantProps<typeof badgeVariants>) {
+  return (
+    <div
+      data-slot="badge"
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  )
 }
 
-export { Badge }
+export { Badge, badgeVariants }

--- a/packages/frontend/src/components/ui/button.tsx
+++ b/packages/frontend/src/components/ui/button.tsx
@@ -30,24 +30,23 @@ const buttonVariants = cva(
   }
 )
 
-interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-    VariantProps<typeof buttonVariants> {
-  asChild?: boolean
+function Button({
+  className,
+  variant,
+  size,
+  asChild = false,
+  ref,
+  ...props
+}: React.ComponentProps<'button'> & VariantProps<typeof buttonVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : 'button'
+  return (
+    <Comp
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      ref={ref}
+      {...props}
+    />
+  )
 }
 
-const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : 'button'
-    return (
-      <Comp
-        className={cn(buttonVariants({ variant, size, className }))}
-        ref={ref}
-        {...props}
-      />
-    )
-  }
-)
-Button.displayName = 'Button'
-
-export { Button }
+export { Button, buttonVariants }

--- a/packages/frontend/src/components/ui/card.tsx
+++ b/packages/frontend/src/components/ui/card.tsx
@@ -1,50 +1,45 @@
 import * as React from 'react'
 import { cn } from '@/lib/utils'
 
-const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
+function Card({ className, ref, ...props }: React.ComponentProps<'div'>) {
+  return (
     <div
       ref={ref}
+      data-slot="card"
       className={cn('rounded-xl border border-border bg-card/80 backdrop-blur-sm text-card-foreground shadow-[0_2px_12px_oklch(0_0_0_/_0.15)]', className)}
       {...props}
     />
   )
-)
-Card.displayName = 'Card'
+}
 
-const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn('flex flex-col space-y-1.5 p-4', className)} {...props} />
+function CardHeader({ className, ref, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div ref={ref} data-slot="card-header" className={cn('flex flex-col space-y-1.5 p-4', className)} {...props} />
   )
-)
-CardHeader.displayName = 'CardHeader'
+}
 
-const CardTitle = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn('font-semibold leading-none tracking-tight', className)} {...props} />
+function CardTitle({ className, ref, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div ref={ref} data-slot="card-title" className={cn('font-semibold leading-none tracking-tight', className)} {...props} />
   )
-)
-CardTitle.displayName = 'CardTitle'
+}
 
-const CardDescription = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn('text-sm text-muted-foreground', className)} {...props} />
+function CardDescription({ className, ref, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div ref={ref} data-slot="card-description" className={cn('text-sm text-muted-foreground', className)} {...props} />
   )
-)
-CardDescription.displayName = 'CardDescription'
+}
 
-const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn('p-4 pt-0', className)} {...props} />
+function CardContent({ className, ref, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div ref={ref} data-slot="card-content" className={cn('p-4 pt-0', className)} {...props} />
   )
-)
-CardContent.displayName = 'CardContent'
+}
 
-const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn('flex items-center p-4 pt-0', className)} {...props} />
+function CardFooter({ className, ref, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div ref={ref} data-slot="card-footer" className={cn('flex items-center p-4 pt-0', className)} {...props} />
   )
-)
-CardFooter.displayName = 'CardFooter'
+}
 
 export { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter }

--- a/packages/frontend/src/components/ui/dropdown-menu.tsx
+++ b/packages/frontend/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,206 @@
+import * as React from 'react'
+import { DropdownMenu as DropdownMenuPrimitive } from 'radix-ui'
+import { CheckIcon, ChevronRightIcon, CircleIcon } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+const DropdownMenu = DropdownMenuPrimitive.Root
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
+const DropdownMenuGroup = DropdownMenuPrimitive.Group
+const DropdownMenuPortal = DropdownMenuPrimitive.Portal
+const DropdownMenuSub = DropdownMenuPrimitive.Sub
+const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      className={cn(
+        'flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+        inset && 'pl-8',
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto" />
+    </DropdownMenuPrimitive.SubTrigger>
+  )
+}
+
+function DropdownMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn(
+        'z-50 min-w-[8rem] overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuContent({
+  className,
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        className={cn(
+          'z-50 min-w-[8rem] overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md',
+          'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+          className
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  )
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      className={cn(
+        'relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+        inset && 'pl-8',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      className={cn(
+        'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon className="h-4 w-4" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  )
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      className={cn(
+        'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+        className
+      )}
+      {...props}
+    >
+      <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CircleIcon className="h-2 w-2 fill-current" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  )
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.Label
+      data-slot="dropdown-menu-label"
+      className={cn(
+        'px-2 py-1.5 text-sm font-semibold',
+        inset && 'pl-8',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn('-mx-1 my-1 h-px bg-border', className)}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<'span'>) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn('ml-auto text-xs tracking-widest opacity-60', className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuGroup,
+  DropdownMenuPortal,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuRadioGroup,
+}

--- a/packages/frontend/src/components/ui/input.tsx
+++ b/packages/frontend/src/components/ui/input.tsx
@@ -1,21 +1,24 @@
 import * as React from 'react'
 import { cn } from '@/lib/utils'
 
-const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(
-  ({ className, type, ...props }, ref) => {
-    return (
-      <input
-        type={type}
-        className={cn(
-          'flex h-10 w-full rounded-lg border border-input bg-card/50 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/50 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/40 focus-visible:border-primary/30 transition-all duration-300 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/30',
-          className
-        )}
-        ref={ref}
-        {...props}
-      />
-    )
-  }
-)
-Input.displayName = 'Input'
+function Input({
+  className,
+  type,
+  ref,
+  ...props
+}: React.ComponentProps<'input'>) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        'flex h-10 w-full rounded-lg border border-input bg-card/50 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/50 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/40 focus-visible:border-primary/30 transition-all duration-300 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/30',
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  )
+}
 
 export { Input }

--- a/packages/frontend/src/components/ui/progress.tsx
+++ b/packages/frontend/src/components/ui/progress.tsx
@@ -1,32 +1,31 @@
 import * as React from 'react'
 import { cn } from '@/lib/utils'
 
-interface ProgressProps extends React.HTMLAttributes<HTMLDivElement> {
-  value: number
-  max?: number
-}
-
-const Progress = React.forwardRef<HTMLDivElement, ProgressProps>(
-  ({ className, value, max = 100, ...props }, ref) => {
-    const percentage = max > 0 ? Math.min((value / max) * 100, 100) : 0
-    return (
+function Progress({
+  className,
+  value,
+  max = 100,
+  ref,
+  ...props
+}: React.ComponentProps<'div'> & { value: number; max?: number }) {
+  const percentage = max > 0 ? Math.min((value / max) * 100, 100) : 0
+  return (
+    <div
+      ref={ref}
+      data-slot="progress"
+      role="progressbar"
+      aria-valuenow={value}
+      aria-valuemin={0}
+      aria-valuemax={max}
+      className={cn('h-2 w-full overflow-hidden rounded-full bg-secondary', className)}
+      {...props}
+    >
       <div
-        ref={ref}
-        role="progressbar"
-        aria-valuenow={value}
-        aria-valuemin={0}
-        aria-valuemax={max}
-        className={cn('h-2 w-full overflow-hidden rounded-full bg-secondary', className)}
-        {...props}
-      >
-        <div
-          className="h-full rounded-full bg-primary transition-all duration-500 ease-out"
-          style={{ width: `${percentage}%` }}
-        />
-      </div>
-    )
-  }
-)
-Progress.displayName = 'Progress'
+        className="h-full rounded-full bg-primary transition-all duration-500 ease-out"
+        style={{ width: `${percentage}%` }}
+      />
+    </div>
+  )
+}
 
 export { Progress }

--- a/packages/frontend/src/components/ui/skeleton.tsx
+++ b/packages/frontend/src/components/ui/skeleton.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react'
 import { cn } from '@/lib/utils'
 
-function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+function Skeleton({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
+      data-slot="skeleton"
       className={cn('rounded-md bg-gradient-to-r from-muted via-muted/60 to-muted bg-[length:200%_100%] animate-[shimmer_1.5s_ease-in-out_infinite]', className)}
       {...props}
     />

--- a/packages/frontend/src/components/ui/textarea.tsx
+++ b/packages/frontend/src/components/ui/textarea.tsx
@@ -1,20 +1,22 @@
 import * as React from 'react'
 import { cn } from '@/lib/utils'
 
-const Textarea = React.forwardRef<HTMLTextAreaElement, React.TextareaHTMLAttributes<HTMLTextAreaElement>>(
-  ({ className, ...props }, ref) => {
-    return (
-      <textarea
-        className={cn(
-          'flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/30',
-          className
-        )}
-        ref={ref}
-        {...props}
-      />
-    )
-  }
-)
-Textarea.displayName = 'Textarea'
+function Textarea({
+  className,
+  ref,
+  ...props
+}: React.ComponentProps<'textarea'>) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        'flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/30',
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  )
+}
 
 export { Textarea }


### PR DESCRIPTION
## Résumé technique

### Contexte
Les composants shadcn/ui utilisent un mélange de patterns v3 (`React.forwardRef`, imports `@radix-ui/react-*`) et v4 (`data-slot`, function components, `React.ComponentProps`). Seul le Checkbox était conforme v4. Le menu utilisateur dans le header était codé à la main (useState + backdrop div) sans aucune gestion d'accessibilité clavier (pas de navigation flèches, pas d'Escape, pas de focus trapping, pas de rôle ARIA `menu`).

### Approche retenue
Migration manuelle et chirurgicale — jamais `shadcn add --overwrite` — pour préserver toutes les customisations projet (variant `steam`, shadows oklch, shimmer custom). Le menu dropdown est remplacé par le composant shadcn `DropdownMenu` (Radix-backed) pour corriger le défaut d'accessibilité.

### Changements implémentés
| Fichier | Modification | Justification technique |
|---------|-------------|------------------------|
| `dropdown-menu.tsx` | Nouveau composant shadcn v4 | Remplace le menu codé à la main, apporte keyboard nav + ARIA |
| `app-header.tsx` | Remplacement du dropdown hand-rolled | Suppression de `useState(showMenu)` + backdrop, utilisation de `DropdownMenu` avec `onSelect` |
| `button.tsx` | forwardRef → function component + `data-slot` + export `buttonVariants` | Alignement React 19, convention v4, variant `steam` préservée |
| `badge.tsx` | Typage v4 + `data-slot` + export `badgeVariants` | Convention v4, composition patterns |
| `card.tsx` | 6 sous-composants forwardRef → function + `data-slot` | Backdrop-blur et shadow oklch custom préservés |
| `input.tsx` | forwardRef → function + `data-slot` | Styles custom (bg-card/50, ring-ring/40) préservés |
| `textarea.tsx` | forwardRef → function + `data-slot` | Migration mécanique |
| `progress.tsx` | forwardRef → function + `data-slot` | ARIA attributes préservés, implémentation custom conservée |
| `skeleton.tsx` | Typage v4 + `data-slot` | Animation shimmer custom préservée |

### Points d'attention pour la revue
- Le `DropdownMenu` utilise `onSelect` au lieu de `onClick` — vérifier que la navigation fonctionne sur chaque item (Profile, Subscription, Admin, Logout)
- L'item Logout ouvre un `ResponsiveDialog` — vérifier que la transition menu → dialog ne cause pas de conflit de focus
- Les composants `Dialog`, `Drawer`, `ResponsiveDialog`, `Avatar`, `Separator` et `Tooltip` ne sont pas migrés dans ce PR (changements à plus haut risque)

### Tests
- Build Vite : ✅ succès (2449 modules, 2.60s)
- TypeScript : ✅ aucune nouvelle erreur (erreurs pré-existantes sur `@wawptn/types` non liées)
- ESLint : ✅ 0 erreurs, warnings pré-existants uniquement

### Étapes restantes
- [ ] Migrer `avatar.tsx` vers pattern v4
- [ ] Migrer `separator.tsx` vers pattern v4
- [ ] Migrer `tooltip.tsx` vers pattern v4
- [ ] Migrer `dialog.tsx` vers pattern v4 (risque: ResponsiveDialog dépend)
- [ ] Migrer `drawer.tsx` vers pattern v4 (risque: ResponsiveDialog dépend)
- [ ] Mettre à jour `responsive-dialog.tsx` après migration Dialog + Drawer

### Prochaines étapes
- [ ] Revue de code par l'équipe
- [ ] Validation manuelle : keyboard nav du dropdown (flèches, Escape, Tab)
- [ ] Validation manuelle : transition logout item → dialog sur mobile
- [ ] Merge après approbation

> ⚠️ Attention : d'autres branches fast-meeting sont actives. Vérifier les conflits potentiels avant merge.

---
_Implémentation générée automatiquement par IA_