### PR TITLE
fix(frontend): display group name in header on group detail page

### DIFF
--- a/packages/frontend/src/pages/GroupPage.tsx
+++ b/packages/frontend/src/pages/GroupPage.tsx
@@ -275,9 +275,12 @@ export function GroupPage() {
   return (
     <div className="min-h-screen">
       <AppHeader maxWidth="wide">
-        <Button variant="ghost" size="icon" onClick={() => navigate('/')} aria-label={t('group.back')}>
-          <ArrowLeft className="w-5 h-5" />
-        </Button>
+        <div className="flex items-center gap-3 min-w-0">
+          <Button variant="ghost" size="icon" onClick={() => navigate('/')} aria-label={t('group.back')} className="shrink-0">
+            <ArrowLeft className="w-5 h-5" />
+          </Button>
+          <h1 className="text-lg font-heading font-bold truncate">{currentGroup.name}</h1>
+        </div>
       </AppHeader>
 
       <main id="main-content" className="max-w-6xl mx-auto p-4">


### PR DESCRIPTION
## Summary
- Display the group name prominently in the AppHeader next to the back arrow on the group detail page
- Previously the name was only visible in the mobile mini-bar and sidebar

## Test plan
- [ ] Navigate to a group detail page and verify the group name appears in the header
- [ ] Check long group names are truncated gracefully
- [ ] Verify both mobile and desktop layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)