### PR TITLE
feat(challenges): add gamification system with challenge tracking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -86,6 +86,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -7822,6 +7823,7 @@
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -7860,6 +7862,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.5.tgz",
       "integrity": "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -7903,6 +7906,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -7913,6 +7917,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -8029,6 +8034,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -8332,6 +8338,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8376,6 +8383,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -8718,6 +8726,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -9130,6 +9139,7 @@
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -9573,6 +9583,7 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -9970,6 +9981,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -10262,6 +10274,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -11236,6 +11249,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.4.tgz",
       "integrity": "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -11326,6 +11340,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4"
       },
@@ -14245,6 +14260,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14254,6 +14270,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -15724,6 +15741,7 @@
       "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -16103,6 +16121,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16431,6 +16450,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -16900,6 +16920,7 @@
       "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -17104,6 +17125,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -17247,6 +17269,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/packages/backend/migrations/20260324_add_challenges.ts
+++ b/packages/backend/migrations/20260324_add_challenges.ts
@@ -1,0 +1,59 @@
+import type { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  // Challenge definitions (seeded from code)
+  await knex.schema.createTable('challenges', (table) => {
+    table.string('id', 64).primary()
+    table.string('category', 32).notNullable() // playtime, dedication, collection, participation
+    table.string('title', 255).notNullable()
+    table.string('description', 512).notNullable()
+    table.string('icon', 8).notNullable() // emoji
+    table.integer('tier').notNullable() // 1=bronze, 2=silver, 3=gold
+    table.integer('threshold').notNullable()
+    table.integer('sort_order').defaultTo(0)
+    table.timestamp('created_at').notNullable().defaultTo(knex.fn.now())
+  })
+
+  // Per-user challenge progress
+  await knex.schema.createTable('user_challenges', (table) => {
+    table.uuid('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE')
+    table.string('challenge_id', 64).notNullable().references('id').inTable('challenges').onDelete('CASCADE')
+    table.integer('progress').notNullable().defaultTo(0)
+    table.timestamp('unlocked_at').nullable()
+    table.boolean('notified').defaultTo(false)
+    table.timestamp('updated_at').notNullable().defaultTo(knex.fn.now())
+    table.primary(['user_id', 'challenge_id'])
+  })
+
+  // Index for fast "my badges" queries
+  await knex.raw(`
+    CREATE INDEX idx_user_challenges_unlocked
+    ON user_challenges (user_id, unlocked_at)
+    WHERE unlocked_at IS NOT NULL
+  `)
+
+  // Seed initial challenges
+  await knex('challenges').insert([
+    // Playtime (total hours across all games, threshold in minutes)
+    { id: 'playtime_100h', category: 'playtime', title: 'Joueur du dimanche', description: '100 heures de jeu au total', icon: '🎮', tier: 1, threshold: 6000, sort_order: 1 },
+    { id: 'playtime_500h', category: 'playtime', title: 'Joueur assidu', description: '500 heures de jeu au total', icon: '🔥', tier: 2, threshold: 30000, sort_order: 2 },
+    { id: 'playtime_1000h', category: 'playtime', title: 'No-life assumé', description: '1 000 heures de jeu au total', icon: '👑', tier: 3, threshold: 60000, sort_order: 3 },
+
+    // Dedication (single game, threshold in minutes)
+    { id: 'single_game_100h', category: 'dedication', title: 'Fan inconditionnel', description: '100 heures sur un seul jeu', icon: '💎', tier: 1, threshold: 6000, sort_order: 4 },
+    { id: 'single_game_500h', category: 'dedication', title: 'Maître du jeu', description: '500 heures sur un seul jeu', icon: '🏆', tier: 3, threshold: 30000, sort_order: 5 },
+
+    // Collection (number of games owned)
+    { id: 'library_50', category: 'collection', title: 'Collectionneur', description: '50 jeux dans ta bibliothèque', icon: '📚', tier: 1, threshold: 50, sort_order: 6 },
+    { id: 'library_200', category: 'collection', title: 'Bibliothécaire', description: '200 jeux dans ta bibliothèque', icon: '🏛️', tier: 2, threshold: 200, sort_order: 7 },
+
+    // Participation (vote sessions participated in)
+    { id: 'votes_10', category: 'participation', title: 'Électeur motivé', description: 'Participer à 10 sessions de vote', icon: '🗳️', tier: 1, threshold: 10, sort_order: 8 },
+    { id: 'votes_50', category: 'participation', title: 'Pilier de soirée', description: 'Participer à 50 sessions de vote', icon: '⭐', tier: 3, threshold: 50, sort_order: 9 },
+  ])
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists('user_challenges')
+  await knex.schema.dropTableIfExists('challenges')
+}

--- a/packages/backend/src/domain/challenges/challenge-service.ts
+++ b/packages/backend/src/domain/challenges/challenge-service.ts
@@ -1,0 +1,192 @@
+import { db } from '../../infrastructure/database/connection.js'
+import { getIO } from '../../infrastructure/socket/socket.js'
+import { createNotification } from '../../infrastructure/notifications/notification-service.js'
+import { logger } from '../../infrastructure/logger/logger.js'
+import type { ChallengeProgress } from '@wawptn/types'
+
+const challengeLogger = logger.child({ module: 'challenges' })
+
+/** Evaluation strategies keyed by challenge category */
+interface EvalResult {
+  challengeId: string
+  progress: number
+}
+
+async function evaluatePlaytime(userId: string): Promise<EvalResult[]> {
+  const row = await db('user_games')
+    .where({ user_id: userId })
+    .sum('playtime_forever as total')
+    .first()
+  const total = Number(row?.total || 0)
+
+  return [
+    { challengeId: 'playtime_100h', progress: total },
+    { challengeId: 'playtime_500h', progress: total },
+    { challengeId: 'playtime_1000h', progress: total },
+  ]
+}
+
+async function evaluateDedication(userId: string): Promise<EvalResult[]> {
+  const row = await db('user_games')
+    .where({ user_id: userId })
+    .max('playtime_forever as max_playtime')
+    .first()
+  const maxPlaytime = Number(row?.max_playtime || 0)
+
+  return [
+    { challengeId: 'single_game_100h', progress: maxPlaytime },
+    { challengeId: 'single_game_500h', progress: maxPlaytime },
+  ]
+}
+
+async function evaluateCollection(userId: string): Promise<EvalResult[]> {
+  const row = await db('user_games')
+    .where({ user_id: userId })
+    .count('* as count')
+    .first()
+  const count = Number(row?.count || 0)
+
+  return [
+    { challengeId: 'library_50', progress: count },
+    { challengeId: 'library_200', progress: count },
+  ]
+}
+
+async function evaluateParticipation(userId: string): Promise<EvalResult[]> {
+  const row = await db('votes')
+    .where({ user_id: userId })
+    .countDistinct('session_id as count')
+    .first()
+  const count = Number(row?.count || 0)
+
+  return [
+    { challengeId: 'votes_10', progress: count },
+    { challengeId: 'votes_50', progress: count },
+  ]
+}
+
+const CATEGORY_EVALUATORS: Record<string, (userId: string) => Promise<EvalResult[]>> = {
+  playtime: evaluatePlaytime,
+  dedication: evaluateDedication,
+  collection: evaluateCollection,
+  participation: evaluateParticipation,
+}
+
+/**
+ * Evaluate challenges for a user in the given categories.
+ * Updates progress, detects new unlocks, fires notifications.
+ */
+export async function evaluateChallenges(
+  userId: string,
+  categories: string[],
+): Promise<void> {
+  // Gather all eval results for requested categories
+  const allResults: EvalResult[] = []
+  for (const category of categories) {
+    const evaluator = CATEGORY_EVALUATORS[category]
+    if (evaluator) {
+      const results = await evaluator(userId)
+      allResults.push(...results)
+    }
+  }
+
+  if (allResults.length === 0) return
+
+  // Fetch thresholds for these challenges
+  const challengeIds = allResults.map(r => r.challengeId)
+  const definitions = await db('challenges').whereIn('id', challengeIds)
+  const defMap = new Map(definitions.map((d: { id: string; threshold: number; title: string; description: string; icon: string; tier: number }) => [d.id, d]))
+
+  for (const result of allResults) {
+    const def = defMap.get(result.challengeId)
+    if (!def) continue
+
+    const isUnlocked = result.progress >= def.threshold
+
+    // Upsert progress — only set unlocked_at once via COALESCE
+    await db.raw(`
+      INSERT INTO user_challenges (user_id, challenge_id, progress, unlocked_at, notified, updated_at)
+      VALUES (?, ?, ?, ?, false, NOW())
+      ON CONFLICT (user_id, challenge_id)
+      DO UPDATE SET
+        progress = EXCLUDED.progress,
+        unlocked_at = COALESCE(user_challenges.unlocked_at, EXCLUDED.unlocked_at),
+        updated_at = NOW()
+    `, [userId, result.challengeId, result.progress, isUnlocked ? new Date() : null])
+
+    // Check if newly unlocked (notified = false AND unlocked_at is set)
+    if (isUnlocked) {
+      const updated = await db('user_challenges')
+        .where({ user_id: userId, challenge_id: result.challengeId, notified: false })
+        .whereNotNull('unlocked_at')
+        .update({ notified: true })
+
+      if (updated > 0) {
+        // New unlock — notify via Socket.io and in-app
+        challengeLogger.info(
+          { userId, challengeId: result.challengeId },
+          'challenge unlocked',
+        )
+
+        getIO().to(`user:${userId}`).emit('challenge:unlocked', {
+          userId,
+          challengeId: result.challengeId,
+          title: def.title,
+          icon: def.icon,
+          tier: def.tier,
+        })
+
+        createNotification({
+          type: 'challenge_unlocked',
+          title: `${def.icon} Défi débloqué : ${def.title}`,
+          body: def.description,
+          metadata: { challengeId: result.challengeId, tier: def.tier },
+          recipientUserIds: [userId],
+          expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000), // 30 days
+        }).catch(err =>
+          challengeLogger.warn({ error: String(err) }, 'challenge notification failed'),
+        )
+      }
+    }
+  }
+}
+
+/**
+ * Get all challenge progress for a user (computed live + merged with stored progress).
+ */
+export async function getChallengesForUser(userId: string): Promise<ChallengeProgress[]> {
+  // First, evaluate all categories to ensure progress is fresh
+  await evaluateChallenges(userId, ['playtime', 'dedication', 'collection', 'participation'])
+
+  // Then read the materialized state
+  const rows = await db('challenges')
+    .leftJoin('user_challenges', function () {
+      this.on('challenges.id', '=', 'user_challenges.challenge_id')
+        .andOn('user_challenges.user_id', '=', db.raw('?', [userId]))
+    })
+    .orderBy('challenges.sort_order', 'asc')
+    .select(
+      'challenges.id',
+      'challenges.category',
+      'challenges.title',
+      'challenges.description',
+      'challenges.icon',
+      'challenges.tier',
+      'challenges.threshold',
+      'user_challenges.progress',
+      'user_challenges.unlocked_at',
+    )
+
+  return rows.map((r: Record<string, unknown>) => ({
+    id: r.id as string,
+    category: r.category as string,
+    title: r.title as string,
+    description: r.description as string,
+    icon: r.icon as string,
+    tier: r.tier as number,
+    threshold: r.threshold as number,
+    progress: Number(r.progress || 0),
+    percentage: Math.min(100, Math.round((Number(r.progress || 0) / (r.threshold as number)) * 100)),
+    unlockedAt: r.unlocked_at ? (r.unlocked_at as Date).toISOString() : null,
+  }))
+}

--- a/packages/backend/src/domain/close-session.ts
+++ b/packages/backend/src/domain/close-session.ts
@@ -3,6 +3,7 @@ import { getIO } from '../infrastructure/socket/socket.js'
 import { logger } from '../infrastructure/logger/logger.js'
 import { notifyVoteClosed } from '../infrastructure/discord/notifier.js'
 import { createNotification } from '../infrastructure/notifications/notification-service.js'
+import { evaluateChallenges } from './challenges/challenge-service.js'
 import type { VoteResult } from '@wawptn/types'
 
 /**
@@ -98,6 +99,13 @@ export async function closeSession(sessionId: string, groupId: string): Promise<
       expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // 7 days
     }).catch(err =>
       logger.warn({ error: String(err), groupId }, 'in-app vote closed notification failed')
+    )
+  }
+
+  // Evaluate participation challenges for all participants (non-blocking)
+  for (const pid of participantIds) {
+    evaluateChallenges(pid, ['participation']).catch(err =>
+      logger.warn({ error: String(err), userId: pid }, 'challenge evaluation after session close failed')
     )
   }
 

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -26,6 +26,7 @@ import { subscriptionRoutes, subscriptionWebhookRouter } from './presentation/ro
 import { isStripeEnabled } from './infrastructure/stripe/stripe-client.js'
 import { personaRoutes } from './presentation/routes/persona.routes.js'
 import { notificationRoutes, adminNotificationRoutes } from './presentation/routes/notification.routes.js'
+import { challengeRoutes } from './presentation/routes/challenge.routes.js'
 import { startNotificationCleanup } from './infrastructure/notifications/notification-cleanup.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -122,6 +123,9 @@ async function main() {
 
   // Notification routes (requires authenticated user)
   app.use('/api/notifications', requireAuth, notificationRoutes)
+
+  // Challenge routes (requires authenticated user)
+  app.use('/api/challenges', requireAuth, challengeRoutes)
 
   // Admin routes (requires authenticated admin user)
   app.use('/api/admin', requireAuth, requireAdmin, adminRoutes)

--- a/packages/backend/src/presentation/routes/auth.routes.ts
+++ b/packages/backend/src/presentation/routes/auth.routes.ts
@@ -884,6 +884,13 @@ async function syncUserLibrary(userId: string, steamId: string): Promise<number>
 
   await db('users').where({ id: userId }).update({ library_visible: true, updated_at: now })
   steamLogger.info({ userId, steamId, gameCount: games.length }, 'library synced')
+
+  // Evaluate playtime/collection/dedication challenges after sync (non-blocking)
+  const { evaluateChallenges } = await import('../../domain/challenges/challenge-service.js')
+  evaluateChallenges(userId, ['playtime', 'dedication', 'collection']).catch(err =>
+    steamLogger.warn({ error: String(err), userId }, 'challenge evaluation after sync failed')
+  )
+
   return games.length
 }
 

--- a/packages/backend/src/presentation/routes/challenge.routes.ts
+++ b/packages/backend/src/presentation/routes/challenge.routes.ts
@@ -1,0 +1,26 @@
+import { Router, type Request, type Response } from 'express'
+import { getChallengesForUser } from '../../domain/challenges/challenge-service.js'
+import { logger } from '../../infrastructure/logger/logger.js'
+
+const router = Router()
+
+// Get current user's challenge progress
+router.get('/me', async (req: Request, res: Response) => {
+  const userId = req.userId!
+  try {
+    const challenges = await getChallengesForUser(userId)
+    const totalUnlocked = challenges.filter(c => c.unlockedAt !== null).length
+    res.json({
+      challenges,
+      stats: {
+        totalUnlocked,
+        totalChallenges: challenges.length,
+      },
+    })
+  } catch (error) {
+    logger.error({ error: String(error), userId }, 'failed to get challenges')
+    res.status(500).json({ error: 'internal', message: 'Failed to get challenges' })
+  }
+})
+
+export { router as challengeRoutes }

--- a/packages/backend/src/presentation/routes/vote.routes.ts
+++ b/packages/backend/src/presentation/routes/vote.routes.ts
@@ -4,6 +4,8 @@ import { getIO } from '../../infrastructure/socket/socket.js'
 import { closeSession } from '../../domain/close-session.js'
 import { createVotingSession } from '../../domain/create-session.js'
 import { isUserPremium } from '../middleware/tier.middleware.js'
+import { evaluateChallenges } from '../../domain/challenges/challenge-service.js'
+import { logger } from '../../infrastructure/logger/logger.js'
 
 const router = Router()
 
@@ -298,6 +300,11 @@ router.post('/:groupId/vote/:sessionId', async (req: Request, res: Response) => 
     voterCount: Number(voterCount?.count || 0),
     totalParticipants,
   })
+
+  // Evaluate participation challenges (non-blocking)
+  evaluateChallenges(userId, ['participation']).catch(err =>
+    logger.warn({ error: String(err), userId }, 'challenge evaluation after vote failed')
+  )
 
   res.json({ ok: true })
 })

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import { SubscriptionPage } from '@/pages/SubscriptionPage'
 import { Skeleton } from '@/components/ui/skeleton'
 import { DialogTestPage } from '@/pages/DialogTestPage'
 import { useNotificationListener } from '@/hooks/useNotificationListener'
+import { useChallengeListener } from '@/hooks/useChallengeListener'
 import { useNotificationStore } from '@/stores/notification.store'
 
 function App() {
@@ -36,6 +37,9 @@ function App() {
 
   // Global notification listener (only when authenticated)
   useNotificationListener()
+
+  // Global challenge unlock listener
+  useChallengeListener()
 
   // Dev-only dialog test page (no auth required)
   if (import.meta.env.DEV && window.location.pathname === '/test-dialogs') {

--- a/packages/frontend/src/components/challenge-card.tsx
+++ b/packages/frontend/src/components/challenge-card.tsx
@@ -1,0 +1,85 @@
+import { motion, type Variants } from 'framer-motion'
+import { useTranslation } from 'react-i18next'
+import { Progress } from '@/components/ui/progress'
+import { Badge } from '@/components/ui/badge'
+import type { ChallengeProgress } from '@wawptn/types'
+
+const TIER_STYLES: Record<number, { border: string; badge: string; label: string }> = {
+  1: { border: 'border-l-amber-700/60', badge: 'bg-amber-900/30 text-amber-400 border-amber-700/40', label: 'Bronze' },
+  2: { border: 'border-l-slate-400/60', badge: 'bg-slate-700/30 text-slate-300 border-slate-500/40', label: 'Argent' },
+  3: { border: 'border-l-yellow-500/60', badge: 'bg-yellow-900/30 text-yellow-400 border-yellow-600/40', label: 'Or' },
+}
+
+const unlockPop: Variants = {
+  hidden: { opacity: 0, scale: 0.8 },
+  visible: {
+    opacity: 1,
+    scale: 1,
+    transition: { type: 'spring', stiffness: 300, damping: 20 },
+  },
+}
+
+function formatProgress(challenge: ChallengeProgress): string {
+  if (challenge.category === 'playtime' || challenge.category === 'dedication') {
+    const currentH = Math.floor(challenge.progress / 60)
+    const targetH = Math.floor(challenge.threshold / 60)
+    return `${currentH}h / ${targetH}h`
+  }
+  return `${challenge.progress} / ${challenge.threshold}`
+}
+
+export function ChallengeCard({ challenge }: { challenge: ChallengeProgress }) {
+  const { t } = useTranslation()
+  const tier = TIER_STYLES[challenge.tier] || TIER_STYLES[1]!
+  const isUnlocked = challenge.unlockedAt !== null
+
+  return (
+    <motion.div
+      variants={unlockPop}
+      className={`
+        flex items-center gap-3 p-3.5 rounded-xl border border-border/50 bg-card/50 backdrop-blur-sm
+        border-l-[3px] transition-all duration-300 hover:bg-card/80 hover:border-border/70
+        ${tier.border}
+        ${isUnlocked ? 'ring-1 ring-inset ring-yellow-500/10' : ''}
+      `}
+    >
+      {/* Icon */}
+      <div className="text-2xl shrink-0 w-10 h-10 flex items-center justify-center rounded-lg bg-muted/30">
+        {challenge.icon}
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 mb-0.5">
+          <span className="font-medium text-sm truncate">{challenge.title}</span>
+          {isUnlocked && (
+            <Badge variant="outline" className={`text-[10px] py-0 h-5 shrink-0 ${tier.badge}`}>
+              {tier.label}
+            </Badge>
+          )}
+        </div>
+        <p className="text-[11px] text-muted-foreground mb-1.5">{challenge.description}</p>
+
+        {isUnlocked ? (
+          <div className="flex items-center gap-1.5">
+            <span className="text-[10px] text-success font-medium">
+              {t('challenges.unlocked')}
+            </span>
+            {challenge.unlockedAt && (
+              <span className="text-[10px] text-muted-foreground">
+                — {new Date(challenge.unlockedAt).toLocaleDateString('fr-FR', { day: 'numeric', month: 'short' })}
+              </span>
+            )}
+          </div>
+        ) : (
+          <div className="flex items-center gap-2">
+            <Progress value={challenge.percentage} className="h-1.5 flex-1" />
+            <span className="text-[10px] text-muted-foreground font-mono shrink-0">
+              {formatProgress(challenge)}
+            </span>
+          </div>
+        )}
+      </div>
+    </motion.div>
+  )
+}

--- a/packages/frontend/src/hooks/useChallengeListener.ts
+++ b/packages/frontend/src/hooks/useChallengeListener.ts
@@ -1,0 +1,32 @@
+import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+import { getSocket } from '@/lib/socket'
+import { useChallengeStore } from '@/stores/challenge.store'
+
+/**
+ * Global hook that listens for challenge:unlocked socket events
+ * and shows a celebratory toast. Refreshes challenge store on unlock.
+ * Must be mounted once at the app level after authentication.
+ */
+export function useChallengeListener() {
+  const { t } = useTranslation()
+  const fetchChallenges = useChallengeStore((s) => s.fetchChallenges)
+
+  useEffect(() => {
+    const socket = getSocket()
+
+    const handleUnlocked = (data: { userId: string; challengeId: string; title: string; icon: string; tier: number }) => {
+      toast.success(t('challenges.unlockedToast', { icon: data.icon, title: data.title }), {
+        duration: 6000,
+      })
+      fetchChallenges()
+    }
+
+    socket.on('challenge:unlocked', handleUnlocked)
+
+    return () => {
+      socket.off('challenge:unlocked', handleUnlocked)
+    }
+  }, [t, fetchChallenges])
+}

--- a/packages/frontend/src/i18n/locales/en.json
+++ b/packages/frontend/src/i18n/locales/en.json
@@ -329,6 +329,11 @@
     "premiumFeature5": "Scheduled auto-voting",
     "premiumCtaButton": "Upgrade to Premium"
   },
+  "challenges": {
+    "title": "Challenges",
+    "unlocked": "Unlocked ✓",
+    "unlockedToast": "{{icon}} Challenge unlocked: {{title}}"
+  },
   "notifications": {
     "title": "Notifications",
     "empty": "No notifications",

--- a/packages/frontend/src/i18n/locales/fr.json
+++ b/packages/frontend/src/i18n/locales/fr.json
@@ -363,6 +363,11 @@
     "groupLimitReached": "Limite de groupes atteinte ({{max}}). Passe en Premium pour des groupes illimités.",
     "memberLimitReached": "Ce groupe a atteint la limite de membres gratuite ({{max}})."
   },
+  "challenges": {
+    "title": "Défis",
+    "unlocked": "Débloqué ✓",
+    "unlockedToast": "{{icon}} Défi débloqué : {{title}}"
+  },
   "persona": {
     "today": "Persona du jour"
   },

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -173,6 +173,12 @@ export const api = {
       body: JSON.stringify({ title, body, groupId }),
     }),
 
+  // Challenges
+  getChallenges: () => request<{
+    challenges: import('@wawptn/types').ChallengeProgress[];
+    stats: { totalUnlocked: number; totalChallenges: number };
+  }>('/challenges/me'),
+
   // Persona
   getCurrentPersona: () => request<{ id: string; name: string; embedColor: number; introMessage: string }>('/persona/current'),
 

--- a/packages/frontend/src/pages/ProfilePage.tsx
+++ b/packages/frontend/src/pages/ProfilePage.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom'
 import { motion, type Variants } from 'framer-motion'
 import {
   ArrowLeft, RefreshCw, ExternalLink, Check, Clock,
-  Gamepad2, Link, Unlink, AlertTriangle, Timer, Trophy,
+  Gamepad2, Link, Unlink, AlertTriangle, Timer, Trophy, Target,
 } from 'lucide-react'
 import { PlatformIcon } from '@/components/icons/platforms'
 import { useTranslation } from 'react-i18next'
@@ -15,6 +15,8 @@ import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
 import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
 import { api } from '@/lib/api'
+import { useChallengeStore } from '@/stores/challenge.store'
+import { ChallengeCard } from '@/components/challenge-card'
 
 interface Platform {
   id: string
@@ -174,6 +176,8 @@ export function ProfilePage() {
   const [unlinking, setUnlinking] = useState<string | null>(null)
   const [searchParams, setSearchParams] = useSearchParams()
 
+  const { challenges, totalUnlocked, totalChallenges, fetchChallenges } = useChallengeStore()
+
   const loadProfile = useCallback(async () => {
     try {
       const data = await api.getProfile()
@@ -187,7 +191,8 @@ export function ProfilePage() {
 
   useEffect(() => {
     loadProfile()
-  }, [loadProfile])
+    fetchChallenges()
+  }, [loadProfile, fetchChallenges])
 
   useEffect(() => {
     const linked = searchParams.get('linked')
@@ -610,6 +615,26 @@ export function ProfilePage() {
                   ))}
                 </div>
               )}
+            </motion.div>
+          </motion.section>
+        )}
+
+        {/* ── Challenges ── */}
+        {challenges.length > 0 && (
+          <motion.section variants={fadeUp}>
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="profile-section-line text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+                <Target className="w-4 h-4 shrink-0" />
+                {t('challenges.title')}
+              </h3>
+              <Badge variant="secondary" className="text-[10px] py-0 h-5 font-mono">
+                {totalUnlocked}/{totalChallenges}
+              </Badge>
+            </div>
+            <motion.div variants={stagger} className="space-y-2.5">
+              {challenges.map((challenge) => (
+                <ChallengeCard key={challenge.id} challenge={challenge} />
+              ))}
             </motion.div>
           </motion.section>
         )}

--- a/packages/frontend/src/stores/challenge.store.ts
+++ b/packages/frontend/src/stores/challenge.store.ts
@@ -1,0 +1,32 @@
+import { create } from 'zustand'
+import type { ChallengeProgress } from '@wawptn/types'
+import { api } from '@/lib/api'
+
+interface ChallengeState {
+  challenges: ChallengeProgress[]
+  totalUnlocked: number
+  totalChallenges: number
+  loading: boolean
+  fetchChallenges: () => Promise<void>
+}
+
+export const useChallengeStore = create<ChallengeState>((set) => ({
+  challenges: [],
+  totalUnlocked: 0,
+  totalChallenges: 0,
+  loading: false,
+  fetchChallenges: async () => {
+    set({ loading: true })
+    try {
+      const data = await api.getChallenges()
+      set({
+        challenges: data.challenges,
+        totalUnlocked: data.stats.totalUnlocked,
+        totalChallenges: data.stats.totalChallenges,
+        loading: false,
+      })
+    } catch {
+      set({ loading: false })
+    }
+  },
+}))

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -181,10 +181,27 @@ export interface DiscordGroupConfig {
 }
 
 // ============================================
+// Challenges
+// ============================================
+
+export interface ChallengeProgress {
+  id: string
+  category: string
+  title: string
+  description: string
+  icon: string
+  tier: number
+  threshold: number
+  progress: number
+  percentage: number
+  unlockedAt: string | null
+}
+
+// ============================================
 // Notifications
 // ============================================
 
-export type NotificationType = 'vote_opened' | 'vote_closed' | 'admin_broadcast'
+export type NotificationType = 'vote_opened' | 'vote_closed' | 'admin_broadcast' | 'challenge_unlocked'
 
 export interface Notification {
   id: string
@@ -215,6 +232,7 @@ export interface ServerToClientEvents {
   'member:online': (data: { groupId: string; userId: string }) => void
   'member:offline': (data: { groupId: string; userId: string }) => void
   'notification:new': (data: Notification) => void
+  'challenge:unlocked': (data: { userId: string; challengeId: string; title: string; icon: string; tier: number }) => void
 }
 
 export interface ClientToServerEvents {


### PR DESCRIPTION
## Résumé technique

### Contexte
Ajout d'un système de gamification par défis/challenges permettant aux utilisateurs de débloquer des jalons liés à leur activité de jeu et de participation aux votes. Décision prise lors d'un fast-meeting avec 4 personas (PO, Backend, Frontend, Architecte).

### Approche retenue
Architecture hybride : définitions de challenges seedées en base depuis le code, progression matérialisée dans PostgreSQL (`challenges` + `user_challenges`). Évaluation event-driven déclenchée par le sync Steam et le cast de vote — pas de cron batch pour le MVP. Affichage intégré dans la ProfilePage avec barres de progression et badges de tier.

### Changements implémentés
| Fichier | Modification | Justification technique |
|---------|-------------|------------------------|
| `packages/backend/migrations/20260324_add_challenges.ts` | Création tables `challenges` + `user_challenges`, seed 9 challenges | Matérialisation de la progression pour lectures O(1) |
| `packages/backend/src/domain/challenges/challenge-service.ts` | Service d'évaluation par catégorie + notification d'unlock | Strategy pattern par catégorie, queries groupées pour minimiser les N+1 |
| `packages/backend/src/presentation/routes/challenge.routes.ts` | `GET /api/challenges/me` | Read-through : évalue puis retourne l'état matérialisé |
| `packages/backend/src/index.ts` | Enregistrement route `/api/challenges` | Derrière `requireAuth` |
| `packages/backend/src/presentation/routes/vote.routes.ts` | Hook post-vote → `evaluateChallenges(userId, ['participation'])` | Fire-and-forget, non-bloquant |
| `packages/backend/src/domain/close-session.ts` | Hook post-close → évaluation pour tous les participants | Même pattern que Discord notify |
| `packages/backend/src/presentation/routes/auth.routes.ts` | Hook post-sync Steam → évaluation playtime/collection/dedication | Import dynamique pour éviter dépendance circulaire |
| `packages/types/src/index.ts` | Types `ChallengeProgress`, `NotificationType` étendu, socket event `challenge:unlocked` | Contrat partagé frontend/backend |
| `packages/frontend/src/stores/challenge.store.ts` | Zustand store pour les challenges | Même pattern que auth/notification stores |
| `packages/frontend/src/components/challenge-card.tsx` | Composant ChallengeCard avec tiers bronze/argent/or | Réutilise Badge, Progress, Framer Motion |
| `packages/frontend/src/hooks/useChallengeListener.ts` | Listener socket `challenge:unlocked` → toast Sonner | Même pattern que useNotificationListener |
| `packages/frontend/src/pages/ProfilePage.tsx` | Section "Défis" après Top Games | Barres de progression + badges de tier |
| `packages/frontend/src/App.tsx` | Mount `useChallengeListener` globalement | Toast de célébration en temps réel |
| `packages/frontend/src/lib/api.ts` | `getChallenges()` endpoint | Retourne progression + stats |
| `packages/frontend/src/i18n/locales/{fr,en}.json` | Clés i18n challenges | FR + EN |

### 9 challenges initiaux
| Challenge | Catégorie | Seuil | Tier |
|-----------|-----------|-------|------|
| Joueur du dimanche | playtime | 100h total | 🥉 Bronze |
| Joueur assidu | playtime | 500h total | 🥈 Argent |
| No-life assumé | playtime | 1000h total | 🥇 Or |
| Fan inconditionnel | dedication | 100h 1 jeu | 🥉 Bronze |
| Maître du jeu | dedication | 500h 1 jeu | 🥇 Or |
| Collectionneur | collection | 50 jeux | 🥉 Bronze |
| Bibliothécaire | collection | 200 jeux | 🥈 Argent |
| Électeur motivé | participation | 10 sessions | 🥉 Bronze |
| Pilier de soirée | participation | 50 sessions | 🥇 Or |

### Points d'attention pour la revue
- Évaluation `getChallengesForUser` fait un read-through (évalue puis lit) — acceptable pour un MVP, à surveiller si le nombre de challenges augmente
- `COALESCE` sur `unlocked_at` dans l'upsert SQL garantit qu'un challenge n'est débloqué qu'une fois
- Flag `notified` atomique empêche les notifications dupliquées en cas d'évaluation concurrente
- Import dynamique dans `auth.routes.ts` pour éviter une dépendance circulaire potentielle

### Tests
- Type-check : ✅ types, backend et frontend compilent sans erreur
- Lint : ✅ aucune nouvelle erreur (5 warnings pré-existants)
- Tests unitaires : pas de suite de tests détectée

### Prochaines étapes
- [ ] Revue de code par l'équipe
- [ ] Validation en environnement de développement
- [ ] Merge après approbation

> ⚠️ _Attention : d'autres branches fast-meeting sont actives (`feat/fm-add-tooltips`, `feat/fm-steam-playtime`, etc.). Vérifier les conflits potentiels avant merge._

---
_Implémentation générée automatiquement par IA_