### PR TITLE
feat: referrals, presence, vote preview, reminders, invite page, tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ backups/
 uploads/
 test-results/
 playwright-report/
+.claude/

--- a/package-lock.json
+++ b/package-lock.json
@@ -7310,6 +7310,13 @@
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz",
@@ -7763,6 +7770,17 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -7808,6 +7826,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -8287,6 +8312,129 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.4",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@vladfrangu/async_event_emitter": {
       "version": "2.4.7",
       "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz",
@@ -8506,6 +8654,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ast-types": {
@@ -8839,6 +8997,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -9848,6 +10016,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -10255,6 +10430,16 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -13204,6 +13389,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
@@ -13589,6 +13785,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pg": {
       "version": "8.20.0",
@@ -15150,6 +15353,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -15342,6 +15552,13 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -15350,6 +15567,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",
@@ -15768,6 +15992,13 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
@@ -15792,6 +16023,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tldts": {
@@ -16531,6 +16772,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/void-elements": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
@@ -16670,6 +17001,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -17337,7 +17685,8 @@
         "@types/uuid": "^11.0.0",
         "ts-node": "^10.9.2",
         "tsx": "^4.21.0",
-        "typescript": "^5.9.3"
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.4"
       }
     },
     "packages/discord": {

--- a/packages/backend/migrations/20260412_add_referrals.ts
+++ b/packages/backend/migrations/20260412_add_referrals.ts
@@ -1,0 +1,17 @@
+import type { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('referrals', (table) => {
+    table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'))
+    table.uuid('referrer_user_id').notNullable().references('id').inTable('users').onDelete('CASCADE')
+    table.uuid('referred_user_id').notNullable().unique().references('id').inTable('users').onDelete('CASCADE')
+    table.uuid('group_id').notNullable().references('id').inTable('groups').onDelete('CASCADE')
+    table.timestamp('created_at', { useTz: true }).notNullable().defaultTo(knex.fn.now())
+
+    table.index('referrer_user_id')
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists('referrals')
+}

--- a/packages/backend/migrations/20260412_add_vote_reminders.ts
+++ b/packages/backend/migrations/20260412_add_vote_reminders.ts
@@ -1,0 +1,13 @@
+import type { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('voting_sessions', (table) => {
+    table.timestamp('reminder_sent_at').nullable()
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('voting_sessions', (table) => {
+    table.dropColumn('reminder_sent_at')
+  })
+}

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -12,7 +12,8 @@
     "db:migrate": "knex migrate:latest --knexfile knexfile.ts",
     "db:rollback": "knex migrate:rollback --knexfile knexfile.ts",
     "db:seed": "knex seed:run --knexfile knexfile.ts",
-    "db:make-migration": "knex migrate:make --knexfile knexfile.ts -x ts"
+    "db:make-migration": "knex migrate:make --knexfile knexfile.ts -x ts",
+    "test": "vitest run"
   },
   "dependencies": {
     "@wawptn/types": "*",
@@ -46,6 +47,7 @@
     "@types/uuid": "^11.0.0",
     "ts-node": "^10.9.2",
     "tsx": "^4.21.0",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.4"
   }
 }

--- a/packages/backend/src/domain/__tests__/close-session.test.ts
+++ b/packages/backend/src/domain/__tests__/close-session.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// vi.hoisted — variables available inside vi.mock factories (which are hoisted)
+// ---------------------------------------------------------------------------
+
+const { mockDb, mockEmit, trxResults, dbResults, trxCallCounts, dbCallCounts } = vi.hoisted(() => {
+  /**
+   * Chainable mock mimicking a Knex query builder.
+   * Every method returns the same proxy, and `await` resolves to `resolveValue`.
+   */
+  function chain(resolveValue: unknown = undefined): unknown {
+    const proxy: unknown = new Proxy(() => {}, {
+      get(_t, prop: string) {
+        if (prop === 'then') {
+          return (res: (v: unknown) => void, rej: (e: unknown) => void) =>
+            Promise.resolve(resolveValue).then(res, rej)
+        }
+        return (..._a: unknown[]) => proxy
+      },
+      apply() {
+        return proxy
+      },
+    })
+    return proxy
+  }
+
+  const trxResults = new Map<string, unknown[]>()
+  const dbResults = new Map<string, unknown[]>()
+  const trxCallCounts = new Map<string, number>()
+  const dbCallCounts = new Map<string, number>()
+
+  function nextResult(
+    map: Map<string, unknown[]>,
+    counts: Map<string, number>,
+    table: string,
+  ): unknown {
+    const idx = counts.get(table) ?? 0
+    counts.set(table, idx + 1)
+    const arr = map.get(table)
+    if (!arr || arr.length === 0) return undefined
+    return arr[Math.min(idx, arr.length - 1)]
+  }
+
+  const noop = () => {}
+
+  const mockDb = Object.assign(
+    (table: string) => chain(nextResult(dbResults, dbCallCounts, table)),
+    {
+      transaction: async (cb: (trx: unknown) => Promise<unknown>) => {
+        const trx = Object.assign(
+          (table: string) => chain(nextResult(trxResults, trxCallCounts, table)),
+          {
+            fn: { now: () => 'NOW()' },
+            raw: noop,
+          },
+        )
+        return cb(trx)
+      },
+      raw: noop,
+    },
+  )
+
+  const mockEmit = (() => {}) as unknown as ReturnType<typeof vi.fn>
+
+  return { mockDb, mockEmit, trxResults, dbResults, trxCallCounts, dbCallCounts }
+})
+
+// Replace noop stubs with proper vi.fn after hoisting
+const emit = vi.fn()
+// We need mockEmit to be a vi.fn — but since vi.fn can't be created inside vi.hoisted,
+// we use a module-scope vi.fn and wire it up.
+const socketEmit = vi.fn()
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@/infrastructure/database/connection.js', () => ({ db: mockDb }))
+
+vi.mock('@/infrastructure/socket/socket.js', () => ({
+  getIO: () => ({ to: () => ({ emit: socketEmit }) }),
+}))
+
+vi.mock('@/infrastructure/logger/logger.js', () => {
+  const noop = () => {}
+  const child = () => ({ info: noop, warn: noop, error: noop, debug: noop, child })
+  return { logger: { info: noop, warn: noop, error: noop, debug: noop, child } }
+})
+
+vi.mock('@/infrastructure/discord/notifier.js', () => ({
+  notifyVoteClosed: () => Promise.resolve(),
+}))
+
+vi.mock('@/infrastructure/notifications/notification-service.js', () => ({
+  createNotification: () => Promise.resolve(),
+}))
+
+vi.mock('@/domain/challenges/challenge-service.js', () => ({
+  evaluateChallenges: () => Promise.resolve(),
+}))
+
+vi.mock('@/domain/streaks.js', () => ({
+  updateStreak: () => Promise.resolve(),
+}))
+
+// ---------------------------------------------------------------------------
+// Import module under test
+// ---------------------------------------------------------------------------
+
+import { closeSession } from '../close-session.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setTrxResult(table: string, ...values: unknown[]) {
+  trxResults.set(table, values)
+}
+function setDbResult(table: string, ...values: unknown[]) {
+  dbResults.set(table, values)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('closeSession', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    socketEmit.mockClear()
+    trxResults.clear()
+    dbResults.clear()
+    trxCallCounts.clear()
+    dbCallCounts.clear()
+  })
+
+  it('should return the correct winner when one game has the most votes', async () => {
+    // Inside the transaction:
+    // trx('voting_sessions') call #1 → .where().update() → 1 (row updated)
+    // trx('votes') call #1 → tally results
+    // trx('voting_session_games') → game info
+    // trx('voting_sessions') call #2 → winner update → 1
+    // trx('votes') call #2 → countDistinct → { count }
+    setTrxResult('voting_sessions', 1, 1)
+    setTrxResult('votes',
+      [
+        { steam_app_id: 730, yes_count: '5' },
+        { steam_app_id: 440, yes_count: '3' },
+      ],
+      { count: '8' },
+    )
+    setTrxResult('voting_session_games', { game_name: 'Counter-Strike 2', game_id: 'game-cs2' })
+
+    // Post-transaction queries
+    setDbResult('groups', { name: 'Test Group' })
+    setDbResult('voting_session_participants', ['user-1', 'user-2'])
+
+    const result = await closeSession('session-1', 'group-1')
+
+    expect(result).not.toBeNull()
+    expect(result!.steamAppId).toBe(730)
+    expect(result!.gameName).toBe('Counter-Strike 2')
+    expect(result!.gameId).toBe('game-cs2')
+    expect(result!.yesCount).toBe(5)
+    expect(result!.totalVoters).toBe(8)
+    expect(result!.headerImageUrl).toContain('730')
+  })
+
+  it('should pick a winner from tied games via random tie-break', async () => {
+    const tiedVotes = [
+      { steam_app_id: 730, yes_count: '4' },
+      { steam_app_id: 440, yes_count: '4' },
+    ]
+
+    const randomSpy = vi.spyOn(Math, 'random')
+
+    // random picks first (index 0)
+    randomSpy.mockReturnValue(0)
+    setTrxResult('voting_sessions', 1, 1)
+    setTrxResult('votes', tiedVotes, { count: '6' })
+    setTrxResult('voting_session_games', { game_name: 'Counter-Strike 2', game_id: 'cs2' })
+    setDbResult('groups', { name: 'G' })
+    setDbResult('voting_session_participants', [])
+
+    const r1 = await closeSession('s1', 'g1')
+    expect(r1).not.toBeNull()
+    expect(r1!.steamAppId).toBe(730)
+
+    // Reset for second call
+    trxResults.clear()
+    dbResults.clear()
+    trxCallCounts.clear()
+    dbCallCounts.clear()
+
+    // random picks second (index 1)
+    randomSpy.mockReturnValue(0.99)
+    setTrxResult('voting_sessions', 1, 1)
+    setTrxResult('votes', tiedVotes, { count: '6' })
+    setTrxResult('voting_session_games', { game_name: 'Team Fortress 2', game_id: 'tf2' })
+    setDbResult('groups', { name: 'G' })
+    setDbResult('voting_session_participants', [])
+
+    const r2 = await closeSession('s2', 'g1')
+    expect(r2).not.toBeNull()
+    expect(r2!.steamAppId).toBe(440)
+    expect(r2!.gameName).toBe('Team Fortress 2')
+
+    randomSpy.mockRestore()
+  })
+
+  it('should handle empty votes gracefully', async () => {
+    setTrxResult('voting_sessions', 1, 1)
+    setTrxResult('votes', [], { count: '0' })
+    setDbResult('groups', { name: 'G' })
+    setDbResult('voting_session_participants', [])
+
+    const result = await closeSession('s1', 'g1')
+
+    expect(result).not.toBeNull()
+    expect(result!.steamAppId).toBe(0)
+    expect(result!.gameName).toBe('Unknown')
+    expect(result!.yesCount).toBe(0)
+    expect(result!.totalVoters).toBe(0)
+    expect(result!.headerImageUrl).toBeNull()
+  })
+
+  it('should return null when session is already closed', async () => {
+    setTrxResult('voting_sessions', 0) // 0 rows updated
+
+    const result = await closeSession('s1', 'g1')
+
+    expect(result).toBeNull()
+    expect(socketEmit).not.toHaveBeenCalled()
+  })
+
+  it('should emit vote:closed via Socket.io on success', async () => {
+    setTrxResult('voting_sessions', 1, 1)
+    setTrxResult('votes',
+      [{ steam_app_id: 730, yes_count: '3' }],
+      { count: '5' },
+    )
+    setTrxResult('voting_session_games', { game_name: 'CS2', game_id: 'cs2' })
+    setDbResult('groups', { name: 'G' })
+    setDbResult('voting_session_participants', [])
+
+    await closeSession('s1', 'g1')
+
+    expect(socketEmit).toHaveBeenCalledWith(
+      'vote:closed',
+      expect.objectContaining({
+        sessionId: 's1',
+        result: expect.objectContaining({ steamAppId: 730, gameName: 'CS2' }),
+      }),
+    )
+  })
+})

--- a/packages/backend/src/domain/__tests__/streaks.test.ts
+++ b/packages/backend/src/domain/__tests__/streaks.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// vi.hoisted — variables available inside vi.mock factories
+// ---------------------------------------------------------------------------
+
+const { mockDb, dbResultQueue, dbCallCounts } = vi.hoisted(() => {
+  function chain(resolveValue: unknown = undefined): unknown {
+    const proxy: unknown = new Proxy(() => {}, {
+      get(_t, prop: string) {
+        if (prop === 'then') {
+          return (res: (v: unknown) => void, rej: (e: unknown) => void) =>
+            Promise.resolve(resolveValue).then(res, rej)
+        }
+        return (..._a: unknown[]) => proxy
+      },
+      apply() {
+        return proxy
+      },
+    })
+    return proxy
+  }
+
+  const dbResultQueue = new Map<string, unknown[]>()
+  const dbCallCounts = new Map<string, number>()
+
+  function nextResult(table: string): unknown {
+    const idx = dbCallCounts.get(table) ?? 0
+    dbCallCounts.set(table, idx + 1)
+    const arr = dbResultQueue.get(table)
+    if (!arr || arr.length === 0) return undefined
+    return arr[Math.min(idx, arr.length - 1)]
+  }
+
+  const mockRaw = (() => Promise.resolve()) as unknown
+
+  const mockDb = Object.assign(
+    (table: string) => chain(nextResult(table)),
+    { raw: mockRaw },
+  )
+
+  return { mockDb, dbResultQueue, dbCallCounts }
+})
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@/infrastructure/database/connection.js', () => ({ db: mockDb }))
+
+vi.mock('@/infrastructure/logger/logger.js', () => {
+  const noop = () => {}
+  const child = () => ({ info: noop, warn: noop, error: noop, debug: noop, child })
+  return { logger: { info: noop, warn: noop, error: noop, debug: noop, child } }
+})
+
+// ---------------------------------------------------------------------------
+// Import module under test
+// ---------------------------------------------------------------------------
+
+import { updateStreak } from '../streaks.js'
+
+// Replace the raw stub with a real vi.fn so we can assert against it
+const rawFn = vi.fn().mockResolvedValue(undefined)
+;(mockDb as Record<string, unknown>).raw = rawFn
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setResult(table: string, ...values: unknown[]) {
+  dbResultQueue.set(table, values)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('updateStreak', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    rawFn.mockResolvedValue(undefined)
+    dbResultQueue.clear()
+    dbCallCounts.clear()
+  })
+
+  it('should start streak at 1 for a first-time participant', async () => {
+    setResult('voting_sessions', { id: 'prev-s1' })
+    setResult('streaks', undefined) // no existing streak
+
+    await updateStreak('user-1', 'group-1', 'session-1')
+
+    expect(rawFn).toHaveBeenCalledOnce()
+    const params = rawFn.mock.calls[0]![1] as unknown[]
+    expect(params[0]).toBe('user-1')    // userId
+    expect(params[1]).toBe('group-1')   // groupId
+    expect(params[2]).toBe(1)           // newStreak
+    expect(params[3]).toBe(1)           // bestStreak
+    expect(params[4]).toBe('session-1') // sessionId
+  })
+
+  it('should increment streak for consecutive participation', async () => {
+    setResult('voting_sessions', { id: 'prev-s1' })
+    setResult('streaks', {
+      current_streak: 3,
+      best_streak: 5,
+      last_session_id: 'prev-s1',
+    })
+
+    await updateStreak('user-1', 'group-1', 'session-2')
+
+    expect(rawFn).toHaveBeenCalledOnce()
+    const params = rawFn.mock.calls[0]![1] as unknown[]
+    expect(params[2]).toBe(4) // 3 + 1
+    expect(params[3]).toBe(5) // best stays at 5
+  })
+
+  it('should update best_streak when current exceeds it', async () => {
+    setResult('voting_sessions', { id: 'prev-s1' })
+    setResult('streaks', {
+      current_streak: 5,
+      best_streak: 5,
+      last_session_id: 'prev-s1',
+    })
+
+    await updateStreak('user-1', 'group-1', 'session-2')
+
+    expect(rawFn).toHaveBeenCalledOnce()
+    const params = rawFn.mock.calls[0]![1] as unknown[]
+    expect(params[2]).toBe(6) // 5 + 1
+    expect(params[3]).toBe(6) // new best
+  })
+
+  it('should reset streak to 1 when user missed a session', async () => {
+    setResult('voting_sessions', { id: 'prev-s2' })
+    setResult('streaks', {
+      current_streak: 4,
+      best_streak: 7,
+      last_session_id: 'prev-s1', // doesn't match prev-s2
+    })
+
+    await updateStreak('user-1', 'group-1', 'session-3')
+
+    expect(rawFn).toHaveBeenCalledOnce()
+    const params = rawFn.mock.calls[0]![1] as unknown[]
+    expect(params[2]).toBe(1) // reset
+    expect(params[3]).toBe(7) // best preserved
+  })
+
+  it('should be idempotent — skip if session already processed', async () => {
+    setResult('voting_sessions', { id: 'prev-s1' })
+    setResult('streaks', {
+      current_streak: 3,
+      best_streak: 5,
+      last_session_id: 'session-1', // same as current
+    })
+
+    await updateStreak('user-1', 'group-1', 'session-1')
+
+    expect(rawFn).not.toHaveBeenCalled()
+  })
+
+  it('should start at 1 when no previous session exists in the group', async () => {
+    setResult('voting_sessions', undefined)
+    setResult('streaks', undefined)
+
+    await updateStreak('user-1', 'group-1', 'session-1')
+
+    expect(rawFn).toHaveBeenCalledOnce()
+    const params = rawFn.mock.calls[0]![1] as unknown[]
+    expect(params[2]).toBe(1)
+    expect(params[3]).toBe(1)
+  })
+
+  it('should reset streak when no previous session but user has old streak', async () => {
+    setResult('voting_sessions', undefined)
+    setResult('streaks', {
+      current_streak: 5,
+      best_streak: 10,
+      last_session_id: 'old-session',
+    })
+
+    await updateStreak('user-1', 'group-1', 'session-1')
+
+    expect(rawFn).toHaveBeenCalledOnce()
+    const params = rawFn.mock.calls[0]![1] as unknown[]
+    expect(params[2]).toBe(1)  // reset
+    expect(params[3]).toBe(10) // best preserved
+  })
+})

--- a/packages/backend/src/domain/vote-reminder.ts
+++ b/packages/backend/src/domain/vote-reminder.ts
@@ -1,0 +1,103 @@
+import { db } from '../infrastructure/database/connection.js'
+import { createNotification } from '../infrastructure/notifications/notification-service.js'
+import { logger } from '../infrastructure/logger/logger.js'
+
+const reminderLogger = logger.child({ module: 'vote-reminder' })
+
+/**
+ * Send vote reminders for open voting sessions that have been open for more than 1 hour
+ * where not all participants have voted yet.
+ *
+ * Uses the `reminder_sent_at` column on `voting_sessions` to avoid spamming —
+ * a session only gets one reminder per lifetime.
+ */
+export async function sendVoteReminders(): Promise<void> {
+  try {
+    const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000)
+
+    // Find open sessions that are older than 1 hour and haven't had a reminder sent yet
+    const eligibleSessions = await db('voting_sessions')
+      .where('status', 'open')
+      .where('created_at', '<=', oneHourAgo)
+      .whereNull('reminder_sent_at')
+      .select('id', 'group_id')
+
+    if (eligibleSessions.length === 0) return
+
+    reminderLogger.info({ sessionCount: eligibleSessions.length }, 'processing vote reminders')
+
+    for (const session of eligibleSessions) {
+      try {
+        await processSessionReminder(session.id, session.group_id)
+      } catch (err) {
+        reminderLogger.error(
+          { error: String(err), sessionId: session.id, groupId: session.group_id },
+          'failed to send reminder for session'
+        )
+      }
+    }
+  } catch (err) {
+    reminderLogger.error({ error: String(err) }, 'sendVoteReminders failed')
+  }
+}
+
+async function processSessionReminder(sessionId: string, groupId: string): Promise<void> {
+  // Get all participant IDs for this session
+  const participantIds: string[] = await db('voting_session_participants')
+    .where({ session_id: sessionId })
+    .pluck('user_id')
+
+  if (participantIds.length === 0) return
+
+  // Get distinct user IDs who have already cast at least one vote in this session
+  const voterIds: string[] = await db('votes')
+    .where({ session_id: sessionId })
+    .distinct('user_id')
+    .pluck('user_id')
+
+  const voterSet = new Set(voterIds)
+  const pendingUserIds = participantIds.filter((uid) => !voterSet.has(uid))
+
+  if (pendingUserIds.length === 0) {
+    // Everyone has voted — mark as reminded to skip in future ticks
+    await db('voting_sessions')
+      .where({ id: sessionId })
+      .update({ reminder_sent_at: db.fn.now() })
+    return
+  }
+
+  // Get the number of games in this session (for the notification body)
+  const gameCountResult = await db('voting_session_games')
+    .where({ session_id: sessionId })
+    .count('* as count')
+    .first()
+
+  const gameCount = Number(gameCountResult?.count || 0)
+
+  // Get group name for the notification
+  const group = await db('groups').where({ id: groupId }).select('name').first()
+  const groupName = group?.name || 'votre groupe'
+
+  // Send in-app notification to pending voters (non-blocking pattern)
+  createNotification({
+    type: 'vote_reminder',
+    title: `N'oubliez pas de voter !`,
+    body: `Il reste ${gameCount} jeux à départager dans ${groupName}`,
+    groupId,
+    metadata: { sessionId, actionUrl: `/groups/${groupId}/vote` },
+    recipientUserIds: pendingUserIds,
+    expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000), // 24 hours
+  }).catch((err) =>
+    reminderLogger.warn({ error: String(err), sessionId, groupId }, 'vote reminder notification failed')
+  )
+
+  // Mark session as reminded to avoid duplicate reminders
+  await db('voting_sessions')
+    .where({ id: sessionId })
+    .update({ reminder_sent_at: db.fn.now() })
+
+  reminderLogger.info(
+    { sessionId, groupId, pendingCount: pendingUserIds.length, totalParticipants: participantIds.length },
+    'vote reminder sent'
+  )
+}

--- a/packages/backend/src/infrastructure/scheduler/vote-scheduler.ts
+++ b/packages/backend/src/infrastructure/scheduler/vote-scheduler.ts
@@ -1,6 +1,7 @@
 import cron from 'node-cron'
 import { db } from '../database/connection.js'
 import { closeSession } from '../../domain/close-session.js'
+import { sendVoteReminders } from '../../domain/vote-reminder.js'
 import { logger } from '../logger/logger.js'
 
 const schedulerLogger = logger.child({ module: 'scheduler' })
@@ -33,6 +34,15 @@ export function startVoteScheduler(): void {
       }
     } catch (err) {
       schedulerLogger.error({ error: String(err) }, 'Discord link code cleanup failed')
+    }
+  })
+
+  // Send vote reminders every 30 minutes for open sessions older than 1 hour
+  cron.schedule('*/30 * * * *', async () => {
+    try {
+      await sendVoteReminders()
+    } catch (err) {
+      schedulerLogger.error({ error: String(err) }, 'vote reminder tick failed')
     }
   })
 

--- a/packages/backend/src/presentation/routes/auth.routes.ts
+++ b/packages/backend/src/presentation/routes/auth.routes.ts
@@ -235,6 +235,38 @@ router.get('/me', async (req: Request, res: Response) => {
   }
 })
 
+// Get referral stats for the current user
+router.get('/me/referrals', requireAuth, async (req: Request, res: Response) => {
+  try {
+    const userId = req.userId!
+
+    const referrals = await db('referrals')
+      .where({ referrer_user_id: userId })
+      .join('users', 'users.id', 'referrals.referred_user_id')
+      .join('groups', 'groups.id', 'referrals.group_id')
+      .select(
+        'users.display_name as displayName',
+        'users.avatar_url as avatarUrl',
+        'groups.name as groupName',
+        'referrals.created_at as createdAt',
+      )
+      .orderBy('referrals.created_at', 'desc')
+
+    res.json({
+      totalReferrals: referrals.length,
+      referrals: referrals.map((r: { displayName: string; avatarUrl: string | null; groupName: string; createdAt: string }) => ({
+        displayName: r.displayName,
+        avatarUrl: r.avatarUrl,
+        groupName: r.groupName,
+        createdAt: r.createdAt,
+      })),
+    })
+  } catch (error) {
+    authLogger.error({ error: String(error) }, 'get referrals failed')
+    res.status(500).json({ error: 'internal', message: 'Failed to get referrals' })
+  }
+})
+
 // Get full profile with platform connections
 router.get('/profile', requireAuth, async (req: Request, res: Response) => {
   try {

--- a/packages/backend/src/presentation/routes/group.routes.ts
+++ b/packages/backend/src/presentation/routes/group.routes.ts
@@ -416,6 +416,18 @@ router.post('/join', async (req: Request, res: Response) => {
     })
   }
 
+  // Track referral: the group owner (created_by) is the referrer
+  if (group.created_by !== userId) {
+    await db('referrals')
+      .insert({
+        referrer_user_id: group.created_by,
+        referred_user_id: userId,
+        group_id: group.id,
+      })
+      .onConflict('referred_user_id')
+      .ignore()
+  }
+
   logger.info({ userId, groupId: group.id }, 'user joined group')
   res.json({ id: group.id, name: group.name, alreadyMember: false })
 })

--- a/packages/backend/src/presentation/routes/invite.routes.ts
+++ b/packages/backend/src/presentation/routes/invite.routes.ts
@@ -1,8 +1,114 @@
 import { Router, type Request, type Response } from 'express'
 import { db } from '../../infrastructure/database/connection.js'
 import { hashInviteToken } from '../../infrastructure/steam/steam-client.js'
+import { logger } from '../../infrastructure/logger/logger.js'
 
 const router = Router()
+
+/**
+ * Public JSON invite preview — returns group info, member avatars,
+ * top 3 most-voted games, and the most recent winning game.
+ * No authentication required so the JoinPage can show a rich preview.
+ */
+router.get('/:token/preview', async (req: Request, res: Response) => {
+  const token = String(req.params['token'])
+
+  try {
+    const hash = hashInviteToken(token)
+    const group = await db('groups')
+      .where({ invite_token_hash: hash })
+      .where('invite_expires_at', '>', new Date())
+      .first()
+
+    if (!group || group.invite_use_count >= group.invite_max_uses) {
+      res.json({
+        isValid: false,
+        groupName: '',
+        memberCount: 0,
+        memberAvatars: [],
+        topGames: [],
+        recentWinner: null,
+      })
+      return
+    }
+
+    // Member count
+    const countResult = await db('group_members')
+      .where({ group_id: group.id })
+      .count('* as count')
+      .first()
+    const memberCount = Number(countResult?.count || 0)
+
+    // Member avatars (up to 5)
+    const members = await db('group_members')
+      .join('users', 'users.id', 'group_members.user_id')
+      .where({ group_id: group.id })
+      .select('users.avatar_url')
+      .orderBy('group_members.joined_at', 'asc')
+      .limit(5) as { avatar_url: string | null }[]
+    const memberAvatars = members.map(m => m.avatar_url).filter(Boolean) as string[]
+
+    // Top 3 most voted-for games (by positive vote count across closed sessions)
+    const topGames = await db('votes')
+      .join('voting_sessions', 'voting_sessions.id', 'votes.session_id')
+      .join('voting_session_games', function () {
+        this.on('voting_session_games.session_id', '=', 'votes.session_id')
+            .andOn('voting_session_games.steam_app_id', '=', 'votes.steam_app_id')
+      })
+      .where({ 'voting_sessions.group_id': group.id, 'voting_sessions.status': 'closed', 'votes.vote': true })
+      .select(
+        'voting_session_games.game_name as gameName',
+        'voting_session_games.header_image_url as headerImageUrl',
+      )
+      .count('* as voteCount')
+      .groupBy('voting_session_games.game_name', 'voting_session_games.header_image_url')
+      .orderBy('voteCount', 'desc')
+      .limit(3) as unknown as { gameName: string; headerImageUrl: string | null }[]
+
+    // Recent winner: last closed session with a winning game
+    const lastWinner = await db('voting_sessions')
+      .where({ group_id: group.id, status: 'closed' })
+      .whereNotNull('winning_game_name')
+      .select('winning_game_name as gameName', 'winning_game_app_id as steamAppId')
+      .orderBy('closed_at', 'desc')
+      .first() as { gameName: string; steamAppId: number } | undefined
+
+    let recentWinner: { gameName: string; headerImageUrl: string | null } | null = null
+    if (lastWinner) {
+      // Get header image from voting_session_games
+      const gameRow = await db('voting_session_games')
+        .join('voting_sessions', 'voting_sessions.id', 'voting_session_games.session_id')
+        .where({ 'voting_sessions.group_id': group.id })
+        .where('voting_session_games.steam_app_id', lastWinner.steamAppId)
+        .select('voting_session_games.header_image_url')
+        .first() as { header_image_url: string | null } | undefined
+
+      recentWinner = {
+        gameName: lastWinner.gameName,
+        headerImageUrl: gameRow?.header_image_url ?? null,
+      }
+    }
+
+    res.json({
+      isValid: true,
+      groupName: group.name,
+      memberCount,
+      memberAvatars,
+      topGames: topGames.map(g => ({ gameName: g.gameName, headerImageUrl: g.headerImageUrl })),
+      recentWinner,
+    })
+  } catch (error) {
+    logger.error({ error: String(error), token }, 'invite preview failed')
+    res.json({
+      isValid: false,
+      groupName: '',
+      memberCount: 0,
+      memberAvatars: [],
+      topGames: [],
+      recentWinner: null,
+    })
+  }
+})
 
 /**
  * Public invite preview route for Discord/social media rich embeds.

--- a/packages/backend/vitest.config.ts
+++ b/packages/backend/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+export default defineConfig({
+  test: {
+    include: ['**/*.test.ts'],
+  },
+  resolve: {
+    alias: {
+      '@/': path.resolve(__dirname, 'src') + '/',
+    },
+  },
+})

--- a/packages/frontend/src/components/group-sidebar.tsx
+++ b/packages/frontend/src/components/group-sidebar.tsx
@@ -45,6 +45,7 @@ interface GroupSidebarProps {
   inviteToken: string | null
   voteHistory: VoteHistoryEntry[]
   onlineMembers: Set<string>
+  lastSeenMap: Map<string, number>
   currentUserId: string
   currentUserRole: string
   autoVoteSchedule: string | null
@@ -63,7 +64,17 @@ interface GroupSidebarProps {
   compact?: boolean
 }
 
-export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken, voteHistory, onlineMembers, currentUserId, currentUserRole, autoVoteSchedule, autoVoteDurationMinutes, onSync, onGenerateInvite, onLeaveGroup, onKickMember, onDeleteGroup, onRenameGroup, onDeleteHistory, onToggleNotifications, onUpdateAutoVote, onStartVote, compact = false }: GroupSidebarProps) {
+function getLastSeenLabel(lastSeenTs: number | undefined): string {
+  if (!lastSeenTs) return 'Hors ligne'
+  const diffMs = Date.now() - lastSeenTs
+  const diffMinutes = Math.floor(diffMs / 60000)
+  if (diffMinutes < 1) return 'Vu à l\u2019instant'
+  if (diffMinutes < 5) return 'Vu il y a quelques minutes'
+  if (diffMinutes < 60) return `Vu il y a ${diffMinutes} min`
+  return 'Hors ligne'
+}
+
+export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken, voteHistory, onlineMembers, lastSeenMap, currentUserId, currentUserRole, autoVoteSchedule, autoVoteDurationMinutes, onSync, onGenerateInvite, onLeaveGroup, onKickMember, onDeleteGroup, onRenameGroup, onDeleteHistory, onToggleNotifications, onUpdateAutoVote, onStartVote, compact = false }: GroupSidebarProps) {
   const { t, i18n } = useTranslation()
   const [confirmLeave, setConfirmLeave] = useState(false)
   const [confirmDelete, setConfirmDelete] = useState(false)
@@ -136,12 +147,22 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
     </div>
   )
 
+  const onlineCount = members.filter(m => onlineMembers.has(m.id)).length
+
   const membersHeader = (
     <div className="flex items-center justify-between">
-      <h2 className="font-semibold flex items-center gap-2 text-sm">
-        <Users className="w-4 h-4" />
-        {t('group.members', { count: members.length })}
-      </h2>
+      <div className="flex items-center gap-2">
+        <h2 className="font-semibold flex items-center gap-2 text-sm">
+          <Users className="w-4 h-4" />
+          {t('group.members', { count: members.length })}
+        </h2>
+        {onlineCount > 0 && (
+          <Badge variant="secondary" className="text-[10px] px-1.5 py-0 gap-1 font-normal">
+            <span className="w-1.5 h-1.5 rounded-full bg-online animate-pulse" />
+            {onlineCount} en ligne
+          </Badge>
+        )}
+      </div>
       {!compact && (
         <Tooltip>
           <TooltipTrigger asChild>
@@ -160,30 +181,38 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
       {sortedMembers.map((member) => {
         const isOnline = onlineMembers.has(member.id)
         const isSelf = member.id === currentUserId
+        const presenceLabel = isOnline
+          ? 'En ligne'
+          : getLastSeenLabel(lastSeenMap.get(member.id))
         return (
-          <div key={member.id} className="flex items-center gap-3 py-1.5 group">
+          <div key={member.id} className={`flex items-center gap-3 py-1.5 group transition-opacity ${!isOnline ? 'opacity-60' : ''}`}>
             <div className="relative">
               <Avatar className="w-8 h-8">
                 <AvatarImage src={member.avatarUrl} alt={member.displayName} />
                 <AvatarFallback>{member.displayName.charAt(0).toUpperCase()}</AvatarFallback>
               </Avatar>
               <span
-                className={`absolute bottom-0 right-0 w-2.5 h-2.5 rounded-full border-2 ${compact ? 'border-background' : 'border-card'} ${isOnline ? 'bg-online' : 'bg-muted-foreground/40'}`}
-                aria-label={isOnline ? 'En ligne' : 'Hors ligne'}
+                className={`absolute bottom-0 right-0 w-2.5 h-2.5 rounded-full border-2 ${compact ? 'border-background' : 'border-card'} ${isOnline ? 'bg-online animate-pulse' : 'bg-muted-foreground/40'}`}
+                aria-label={presenceLabel}
               />
             </div>
-            <div className="flex-1 min-w-0 flex items-center gap-1.5">
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span className={`text-sm font-medium truncate ${!isOnline ? 'text-muted-foreground' : ''}`}>{member.displayName}</span>
-                </TooltipTrigger>
-                <TooltipContent side="top" className="text-xs">
-                  {member.displayName}
-                </TooltipContent>
-              </Tooltip>
-              {member.role === 'owner' && (
-                <Crown className="w-4 h-4 text-reward shrink-0" aria-label={t('group.roleOwner')} />
-              )}
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-1.5">
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className={`text-sm font-medium truncate ${!isOnline ? 'text-muted-foreground' : ''}`}>{member.displayName}</span>
+                  </TooltipTrigger>
+                  <TooltipContent side="top" className="text-xs">
+                    {member.displayName}
+                  </TooltipContent>
+                </Tooltip>
+                {member.role === 'owner' && (
+                  <Crown className="w-4 h-4 text-reward shrink-0" aria-label={t('group.roleOwner')} />
+                )}
+              </div>
+              <p className={`text-[11px] leading-tight ${isOnline ? 'text-emerald-500' : 'text-muted-foreground'}`}>
+                {presenceLabel}
+              </p>
             </div>
             {!member.libraryVisible && (
               <span className="text-xs text-destructive">{t('group.privateLibrary')}</span>

--- a/packages/frontend/src/components/vote-setup-dialog.tsx
+++ b/packages/frontend/src/components/vote-setup-dialog.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import { ArrowLeft, Vote, Loader2, Users, Calendar, Handshake, CircleDollarSign, Lock } from 'lucide-react'
+import { ArrowLeft, Vote, Loader2, Users, Calendar, Handshake, CircleDollarSign, Lock, AlertTriangle } from 'lucide-react'
 import { useSubscriptionStore } from '@/stores/subscription.store'
 import {
   ResponsiveDialog,
@@ -48,6 +48,9 @@ export function VoteSetupDialog({ open, onOpenChange, members, groupId, onlineMe
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
   const [previewCount, setPreviewCount] = useState<number | null>(null)
   const [loadingPreview, setLoadingPreview] = useState(false)
+  const [livePreviewCount, setLivePreviewCount] = useState<number | null>(null)
+  const [loadingLivePreview, setLoadingLivePreview] = useState(false)
+  const livePreviewAbortRef = useRef<AbortController | null>(null)
   const [isScheduled, setIsScheduled] = useState(false)
   const [scheduledDate, setScheduledDate] = useState('')
   const [gameFilters, setGameFilters] = useState<VoteGameFilters>({
@@ -79,11 +82,55 @@ export function VoteSetupDialog({ open, onOpenChange, members, groupId, onlineMe
       setStep('select')
       setSelectedIds(new Set(members.map(m => m.id)))
       setPreviewCount(null)
+      setLivePreviewCount(null)
       setIsScheduled(false)
       setScheduledDate(defaultScheduledDate)
       setGameFilters({ multiplayer: false, coop: false, free: false })
     }
   }, [open, members, defaultScheduledDate])
+
+  // Debounced live preview of common game count
+  useEffect(() => {
+    if (!open || step !== 'select') return
+
+    const memberIdArray = Array.from(selectedIds)
+    if (memberIdArray.length < 2) {
+      setLivePreviewCount(null)
+      setLoadingLivePreview(false)
+      return
+    }
+
+    setLoadingLivePreview(true)
+
+    const timer = setTimeout(() => {
+      // Cancel any in-flight request
+      livePreviewAbortRef.current?.abort()
+      const controller = new AbortController()
+      livePreviewAbortRef.current = controller
+
+      api.previewCommonGames(groupId, memberIdArray, activeFilter)
+        .then((result) => {
+          if (!controller.signal.aborted) {
+            setLivePreviewCount(result.gameCount)
+          }
+        })
+        .catch(() => {
+          if (!controller.signal.aborted) {
+            setLivePreviewCount(null)
+          }
+        })
+        .finally(() => {
+          if (!controller.signal.aborted) {
+            setLoadingLivePreview(false)
+          }
+        })
+    }, 300)
+
+    return () => {
+      clearTimeout(timer)
+      livePreviewAbortRef.current?.abort()
+    }
+  }, [open, step, selectedIds, groupId, activeFilter])
 
   const sortedMembers = [...members].sort((a, b) => {
     const aOnline = onlineMembers.has(a.id)
@@ -195,6 +242,29 @@ export function VoteSetupDialog({ open, onOpenChange, members, groupId, onlineMe
                   )
                 })}
               </div>
+            </div>
+
+            {/* Live game count preview */}
+            <div className="mt-3 flex items-center gap-2 text-sm">
+              {selectedIds.size < 2 ? (
+                <span className="text-muted-foreground">
+                  Sélectionnez au moins 2 membres
+                </span>
+              ) : loadingLivePreview ? (
+                <span className="flex items-center gap-2 text-muted-foreground">
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                  Calcul des jeux en commun…
+                </span>
+              ) : livePreviewCount !== null && livePreviewCount === 0 ? (
+                <span className="flex items-center gap-2 text-amber-500">
+                  <AlertTriangle className="w-4 h-4" />
+                  Aucun jeu en commun trouvé
+                </span>
+              ) : livePreviewCount !== null ? (
+                <span className="text-muted-foreground">
+                  🎮 {livePreviewCount} {livePreviewCount === 1 ? 'jeu' : 'jeux'} en commun
+                </span>
+              ) : null}
             </div>
 
             <div className="flex flex-wrap justify-between items-center gap-2 mt-4">

--- a/packages/frontend/src/i18n/locales/en.json
+++ b/packages/frontend/src/i18n/locales/en.json
@@ -223,7 +223,11 @@
     "loginPrompt": "Sign in with Steam to join the group.",
     "connecting": "Joining group...",
     "failed": "Unable to join",
-    "goToGroups": "Go to my groups"
+    "goToGroups": "Go to my groups",
+    "memberCount_one": "{{count}} member",
+    "memberCount_other": "{{count}} members",
+    "lastPlayed": "Last game played:",
+    "popularGames": "Popular games in the group"
   },
   "invite": {
     "shareLink": "Share this link with your friends:",

--- a/packages/frontend/src/i18n/locales/fr.json
+++ b/packages/frontend/src/i18n/locales/fr.json
@@ -232,7 +232,11 @@
     "loginPrompt": "Connecte-toi avec Steam pour rejoindre le groupe.",
     "connecting": "Connexion au groupe...",
     "failed": "Impossible de rejoindre",
-    "goToGroups": "Aller à mes groupes"
+    "goToGroups": "Aller à mes groupes",
+    "memberCount_one": "{{count}} membre",
+    "memberCount_other": "{{count}} membres",
+    "lastPlayed": "Dernier jeu joué :",
+    "popularGames": "Jeux populaires du groupe"
   },
   "invite": {
     "shareLink": "Partage ce lien avec tes amis :",

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -59,6 +59,13 @@ export const api = {
     body: JSON.stringify({ code }),
   }),
 
+  // Invite preview (public, no auth — mounted at /invite, not /api)
+  getInvitePreview: async (token: string): Promise<import('@wawptn/types').InvitePreview> => {
+    const res = await fetch(`/invite/${token}/preview`)
+    if (!res.ok) throw new Error('Failed to load invite preview')
+    return res.json()
+  },
+
   // Groups
   getGroups: () => request<{ id: string; name: string; role: string; createdAt: string; memberCount: number; commonGameCount: number; lastSession: { gameName: string; gameAppId: number; closedAt: string } | null }[]>('/groups'),
   getGroup: (id: string) => request<{

--- a/packages/frontend/src/pages/GroupPage.tsx
+++ b/packages/frontend/src/pages/GroupPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useMemo } from 'react'
+import { useEffect, useState, useCallback, useMemo, useRef } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { ArrowLeft, Vote, ChevronUp, Dices } from 'lucide-react'
 import { toast } from 'sonner'
@@ -9,6 +9,7 @@ import { api } from '@/lib/api'
 import { getSocket } from '@/lib/socket'
 import { Button } from '@/components/ui/button'
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
+import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
 import {
   ResponsiveDialog,
@@ -47,6 +48,7 @@ export function GroupPage() {
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false)
   const [randomPickOpen, setRandomPickOpen] = useState(false)
   const [onlineUserIds, setOnlineUserIds] = useState<string[]>([])
+  const lastSeenMapRef = useRef<Map<string, number>>(new Map())
 
   const loadCommonGames = useCallback(async (groupId: string, filter?: string) => {
     setLoadingGames(true)
@@ -82,7 +84,10 @@ export function GroupPage() {
 
     socket.on('group:presence', (data) => setOnlineUserIds(data.onlineUserIds))
     socket.on('member:online', (data) => setOnlineUserIds((prev) => prev.includes(data.userId) ? prev : [...prev, data.userId]))
-    socket.on('member:offline', (data) => setOnlineUserIds((prev) => prev.filter((id) => id !== data.userId)))
+    socket.on('member:offline', (data) => {
+      lastSeenMapRef.current.set(data.userId, Date.now())
+      setOnlineUserIds((prev) => prev.filter((id) => id !== data.userId))
+    })
     socket.on('member:joined', () => fetchGroup(id))
     socket.on('member:left', () => fetchGroup(id))
     socket.on('member:kicked', (data) => {
@@ -254,6 +259,7 @@ export function GroupPage() {
   }
 
   const onlineMembers = useMemo(() => new Set(onlineUserIds), [onlineUserIds])
+  const lastSeenMap = lastSeenMapRef.current
   const currentUserRole = currentGroup?.members.find(m => m.id === user?.id)?.role || 'member'
 
   if (!currentGroup) {
@@ -281,6 +287,12 @@ export function GroupPage() {
             <ArrowLeft className="w-5 h-5" />
           </Button>
           <h1 className="text-lg font-heading font-bold truncate">{currentGroup.name}</h1>
+          {onlineUserIds.length > 0 && (
+            <Badge variant="secondary" className="hidden sm:inline-flex text-[10px] px-1.5 py-0 gap-1 font-normal shrink-0">
+              <span className="w-1.5 h-1.5 rounded-full bg-online animate-pulse" />
+              {onlineUserIds.length} en ligne
+            </Badge>
+          )}
         </div>
       </AppHeader>
 
@@ -308,7 +320,15 @@ export function GroupPage() {
             </div>
             <div className="flex-1 min-w-0 text-left">
               <p className="text-sm font-medium truncate">{currentGroup.name}</p>
-              <p className="text-xs text-muted-foreground">{t('group.members', { count: currentGroup.members.length })}</p>
+              <div className="flex items-center gap-2">
+                <p className="text-xs text-muted-foreground">{t('group.members', { count: currentGroup.members.length })}</p>
+                {onlineUserIds.length > 0 && (
+                  <Badge variant="secondary" className="text-[10px] px-1.5 py-0 gap-1 font-normal">
+                    <span className="w-1.5 h-1.5 rounded-full bg-online animate-pulse" />
+                    {onlineUserIds.length} en ligne
+                  </Badge>
+                )}
+              </div>
             </div>
             <ChevronUp className="w-4 h-4 text-muted-foreground shrink-0" />
           </div>
@@ -325,6 +345,7 @@ export function GroupPage() {
               inviteToken={inviteToken}
               voteHistory={voteHistory}
               onlineMembers={onlineMembers}
+              lastSeenMap={lastSeenMap}
               currentUserId={user?.id || ''}
               currentUserRole={currentUserRole}
               autoVoteSchedule={currentGroup.autoVoteSchedule}
@@ -446,6 +467,7 @@ export function GroupPage() {
               inviteToken={inviteToken}
               voteHistory={voteHistory}
               onlineMembers={onlineMembers}
+              lastSeenMap={lastSeenMap}
               currentUserId={user?.id || ''}
               currentUserRole={currentUserRole}
               autoVoteSchedule={currentGroup.autoVoteSchedule}

--- a/packages/frontend/src/pages/JoinPage.tsx
+++ b/packages/frontend/src/pages/JoinPage.tsx
@@ -1,11 +1,28 @@
 import { useEffect, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { Gamepad2, Loader2 } from 'lucide-react'
+import { Gamepad2, Loader2, Users, Trophy } from 'lucide-react'
 import { toast } from 'sonner'
 import { useTranslation } from 'react-i18next'
+import { motion, type Variants } from 'framer-motion'
+import type { InvitePreview } from '@wawptn/types'
 import { useAuthStore } from '@/stores/auth.store'
 import { api } from '@/lib/api'
 import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+
+const fadeUp: Variants = {
+  hidden: { opacity: 0, y: 16 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.4, ease: [0.22, 1, 0.36, 1] },
+  },
+}
+
+const stagger: Variants = {
+  hidden: {},
+  visible: { transition: { staggerChildren: 0.08 } },
+}
 
 export function JoinPage() {
   const { t } = useTranslation()
@@ -13,7 +30,28 @@ export function JoinPage() {
   const navigate = useNavigate()
   const { user } = useAuthStore()
   const [error, setError] = useState<string | null>(null)
+  const [preview, setPreview] = useState<InvitePreview | null>(null)
+  const [previewLoading, setPreviewLoading] = useState(true)
   const joining = !!user && !!token && !error
+
+  // Fetch invite preview (public, no auth needed)
+  useEffect(() => {
+    if (!token) return
+    let cancelled = false
+
+    api.getInvitePreview(token)
+      .then((data) => {
+        if (!cancelled) setPreview(data)
+      })
+      .catch(() => {
+        // Preview is best-effort, don't block the page
+      })
+      .finally(() => {
+        if (!cancelled) setPreviewLoading(false)
+      })
+
+    return () => { cancelled = true }
+  }, [token])
 
   useEffect(() => {
     if (!user || !token) return
@@ -37,12 +75,121 @@ export function JoinPage() {
   if (!user) {
     return (
       <div className="min-h-screen flex flex-col items-center justify-center px-4">
-        <Gamepad2 className="w-12 h-12 text-primary mb-4" />
-        <h1 className="text-2xl font-bold mb-2">{t('join.invited')}</h1>
-        <p className="text-muted-foreground mb-6">{t('join.loginPrompt')}</p>
-        <Button variant="steam" size="lg" asChild>
-          <a href={`/api/auth/steam/login?returnTo=/join/${token}`}>{t('login.signIn')}</a>
-        </Button>
+        <motion.div
+          className="flex flex-col items-center w-full max-w-md"
+          variants={stagger}
+          initial="hidden"
+          animate="visible"
+        >
+          <motion.div variants={fadeUp}>
+            <Gamepad2 className="w-12 h-12 text-primary mb-4" />
+          </motion.div>
+
+          <motion.h1 variants={fadeUp} className="text-2xl font-bold mb-2">
+            {t('join.invited')}
+          </motion.h1>
+
+          {/* Group name & member info from preview */}
+          {!previewLoading && preview?.isValid && (
+            <motion.div variants={fadeUp} className="flex flex-col items-center mb-6 w-full">
+              <p className="text-lg font-semibold text-foreground mb-2">{preview.groupName}</p>
+
+              {/* Member avatars & count */}
+              <div className="flex items-center gap-2 mb-4">
+                {preview.memberAvatars.length > 0 && (
+                  <div className="flex -space-x-2">
+                    {preview.memberAvatars.map((url, i) => (
+                      <img
+                        key={i}
+                        src={url}
+                        alt=""
+                        className="w-8 h-8 rounded-full border-2 border-background"
+                      />
+                    ))}
+                  </div>
+                )}
+                <span className="text-sm text-muted-foreground flex items-center gap-1">
+                  <Users className="w-4 h-4" />
+                  {t('join.memberCount', { count: preview.memberCount })}
+                </span>
+              </div>
+
+              {/* Recent winner */}
+              {preview.recentWinner && (
+                <Card className="w-full p-3 mb-4">
+                  <div className="flex items-center gap-3">
+                    <Trophy className="w-5 h-5 text-reward shrink-0" />
+                    <div className="flex items-center gap-3 min-w-0">
+                      {preview.recentWinner.headerImageUrl && (
+                        <img
+                          src={preview.recentWinner.headerImageUrl}
+                          alt={preview.recentWinner.gameName}
+                          className="w-16 h-8 rounded object-cover shrink-0"
+                        />
+                      )}
+                      <div className="min-w-0">
+                        <p className="text-xs text-muted-foreground">{t('join.lastPlayed')}</p>
+                        <p className="text-sm font-medium truncate">{preview.recentWinner.gameName}</p>
+                      </div>
+                    </div>
+                  </div>
+                </Card>
+              )}
+
+              {/* Top 3 popular games */}
+              {preview.topGames.length > 0 && (
+                <div className="w-full">
+                  <p className="text-xs text-muted-foreground mb-2">{t('join.popularGames')}</p>
+                  <div className="grid grid-cols-3 gap-2">
+                    {preview.topGames.map((game) => (
+                      <Card key={game.gameName} className="p-2 flex flex-col items-center gap-1.5">
+                        {game.headerImageUrl ? (
+                          <img
+                            src={game.headerImageUrl}
+                            alt={game.gameName}
+                            className="w-full aspect-[460/215] rounded object-cover"
+                          />
+                        ) : (
+                          <div className="w-full aspect-[460/215] rounded bg-muted flex items-center justify-center">
+                            <Gamepad2 className="w-6 h-6 text-muted-foreground" />
+                          </div>
+                        )}
+                        <p className="text-xs text-center font-medium leading-tight line-clamp-2">{game.gameName}</p>
+                      </Card>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </motion.div>
+          )}
+
+          {/* Fallback prompt when no preview or invalid */}
+          {!previewLoading && (!preview || !preview.isValid) && (
+            <motion.p variants={fadeUp} className="text-muted-foreground mb-6">
+              {t('join.loginPrompt')}
+            </motion.p>
+          )}
+
+          {/* Simple prompt when preview is valid but no rich data */}
+          {!previewLoading && preview?.isValid && !preview.recentWinner && preview.topGames.length === 0 && preview.memberAvatars.length === 0 && (
+            <motion.p variants={fadeUp} className="text-muted-foreground mb-2">
+              {t('join.loginPrompt')}
+            </motion.p>
+          )}
+
+          {/* Loading state for preview */}
+          {previewLoading && (
+            <motion.p variants={fadeUp} className="text-muted-foreground mb-6">
+              {t('join.loginPrompt')}
+            </motion.p>
+          )}
+
+          <motion.div variants={fadeUp}>
+            <Button variant="steam" size="lg" asChild>
+              <a href={`/api/auth/steam/login?returnTo=/join/${token}`}>{t('login.signIn')}</a>
+            </Button>
+          </motion.div>
+        </motion.div>
       </div>
     )
   }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -239,3 +239,21 @@ export interface ClientToServerEvents {
   'group:join': (groupId: string) => void
   'group:leave': (groupId: string) => void
 }
+
+// ============================================
+// Invite Preview
+// ============================================
+
+export interface InvitePreviewGame {
+  gameName: string
+  headerImageUrl: string | null
+}
+
+export interface InvitePreview {
+  isValid: boolean
+  groupName: string
+  memberCount: number
+  memberAvatars: string[]
+  topGames: InvitePreviewGame[]
+  recentWinner: InvitePreviewGame | null
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -201,7 +201,7 @@ export interface ChallengeProgress {
 // Notifications
 // ============================================
 
-export type NotificationType = 'vote_opened' | 'vote_closed' | 'admin_broadcast' | 'challenge_unlocked'
+export type NotificationType = 'vote_opened' | 'vote_closed' | 'vote_reminder' | 'admin_broadcast' | 'challenge_unlocked'
 
 export interface Notification {
   id: string


### PR DESCRIPTION
## Summary

- **Vote game count preview**: Debounced live preview showing "X jeux en commun" as members are selected in vote setup dialog
- **Referral tracking**: New `referrals` table, auto-tracks referrer on invite join, `GET /auth/me/referrals` endpoint
- **Presence indicators**: "X en ligne" badge in group header, green/gray dots on members, "Vu il y a X min" last-seen labels
- **Auto-vote reminders**: Sends in-app notifications to pending voters after 1hr open session, scheduler runs every 30min
- **Smart invite preview**: Rich join page with top 3 popular games, recent winner, member avatars — all before login
- **Test framework**: Vitest setup with 12 baseline unit tests for close-session and streak domain logic

## Test plan

- [ ] Verify live game count updates in vote setup dialog when toggling members
- [ ] Verify referral is recorded when joining via invite link
- [ ] Verify GET /auth/me/referrals returns referral list
- [ ] Verify presence badge shows "X en ligne" and member dots reflect status
- [ ] Verify "Vu il y a X min" appears for recently-offline members
- [ ] Verify vote reminder notification fires after 1hr for pending voters
- [ ] Verify invite preview page shows top games and recent winner
- [ ] Run `npm test` — 12 unit tests should pass

https://claude.ai/code/session_017mwHHRMym5m5pbWVFyZwjP