### PR TITLE
feat(mobile): comprehensive touch UX overhaul

### DIFF
--- a/packages/frontend/src/components/group-sidebar.tsx
+++ b/packages/frontend/src/components/group-sidebar.tsx
@@ -102,9 +102,12 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
   })
 
   const historySection = voteHistory.length > 0 && (
-    <div className="space-y-2">
+    <div className={compact ? 'flex gap-2 sm:gap-3 overflow-x-auto scrollbar-none snap-x snap-mandatory pb-1 -mx-1 px-1' : 'space-y-2'}>
       {voteHistory.map((session, index) => (
-        <div key={session.id} className="flex items-center gap-3 group/history">
+        <div key={session.id} className={compact
+          ? 'flex-none w-[200px] snap-start rounded-lg border border-border bg-card/50 p-2 flex items-center gap-2 group/history'
+          : 'flex items-center gap-3 group/history'
+        }>
           <img
             src={`https://cdn.akamai.steamstatic.com/steam/apps/${session.winningGameAppId}/header.jpg`}
             alt={session.winningGameName}
@@ -130,7 +133,7 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
                 <Button
                   variant="ghost"
                   size="icon"
-                  className={`h-7 w-7 text-muted-foreground hover:text-destructive ${compact ? 'opacity-100' : 'opacity-0 group-hover/history:opacity-100'} transition-opacity shrink-0`}
+                  className={`h-8 w-8 min-h-[44px] min-w-[44px] text-muted-foreground hover:text-destructive active:bg-accent/10 ${compact ? 'opacity-100' : 'opacity-0 group-hover/history:opacity-100'} transition-opacity shrink-0`}
                   onClick={() => setConfirmDeleteHistory(session)}
                   aria-label={t('group.deleteHistory')}
                 >
@@ -166,7 +169,7 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
       {!compact && (
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button variant="ghost" size="icon" onClick={onSync} disabled={syncing} aria-label={t('group.syncLibraries')}>
+            <Button variant="ghost" size="icon" onClick={onSync} disabled={syncing} aria-label={t('group.syncLibraries')} className="h-11 w-11 min-h-[44px] min-w-[44px] active:bg-accent/10">
               <RefreshCw className={`w-4 h-4 ${syncing ? 'animate-spin text-primary' : ''}`} />
             </Button>
           </TooltipTrigger>
@@ -177,7 +180,7 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
   )
 
   const membersList = (
-    <div className="space-y-2">
+    <div className="space-y-1 sm:space-y-2">
       {sortedMembers.map((member) => {
         const isOnline = onlineMembers.has(member.id)
         const isSelf = member.id === currentUserId
@@ -185,7 +188,7 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
           ? 'En ligne'
           : getLastSeenLabel(lastSeenMap.get(member.id))
         return (
-          <div key={member.id} className={`flex items-center gap-3 py-1.5 group transition-opacity ${!isOnline ? 'opacity-60' : ''}`}>
+          <div key={member.id} className={`flex items-center gap-3 min-h-[48px] py-1.5 px-1 -mx-1 rounded-md group transition-opacity ${!isOnline ? 'opacity-60' : ''}`}>
             <div className="relative">
               <Avatar className="w-8 h-8">
                 <AvatarImage src={member.avatarUrl} alt={member.displayName} />
@@ -223,11 +226,11 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
                   <Button
                     variant="ghost"
                     size="icon"
-                    className={`h-7 w-7 text-muted-foreground hover:text-destructive ${compact ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'} transition-opacity`}
+                    className={`h-11 w-11 min-h-[44px] min-w-[44px] text-muted-foreground hover:text-destructive active:bg-accent/10 ${compact ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'} transition-opacity`}
                     onClick={() => setConfirmKick(member)}
                     aria-label={t('group.kickMember', { name: member.displayName })}
                   >
-                    <UserMinus className="w-3.5 h-3.5" />
+                    <UserMinus className="w-4 h-4" />
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent side="left" className="text-xs">
@@ -242,7 +245,7 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
   )
 
   const actionButtons = (
-    <div className="space-y-2">
+    <div className="space-y-1.5 sm:space-y-2">
       {compact && (
         <Button
           variant="outline"
@@ -352,10 +355,10 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
   )
 
   return (
-    <aside className="space-y-4">
+    <aside className="space-y-2 sm:space-y-3">
       {compact ? (
         // Compact layout for mobile bottom sheets — no Card wrappers
-        <div className="space-y-4">
+        <div className="space-y-2 sm:space-y-3">
           {historySection && (
             <div className="space-y-2">
               <h2 className="font-semibold flex items-center gap-2 text-sm">
@@ -376,13 +379,13 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
         <>
           {historySection && (
             <Card>
-              <CardHeader className="pb-3">
+              <CardHeader className="p-3 sm:p-4 pb-2 sm:pb-3">
                 <h2 className="font-semibold flex items-center gap-2 text-sm">
                   <History className="w-4 h-4" />
                   {t('group.history')}
                 </h2>
               </CardHeader>
-              <CardContent className="space-y-2">
+              <CardContent className="p-3 sm:p-4 pt-0 space-y-2">
                 {historySection}
               </CardContent>
             </Card>
@@ -393,10 +396,10 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
           <GroupStats groupId={groupId} />
 
           <Card>
-            <CardHeader className="space-y-0 pb-3">
+            <CardHeader className="p-3 sm:p-4 pb-2 sm:pb-3 space-y-0">
               {membersHeader}
             </CardHeader>
-            <CardContent className="space-y-3">
+            <CardContent className="p-3 sm:p-4 pt-0 space-y-2 sm:space-y-3">
               {membersList}
               {actionButtons}
             </CardContent>

--- a/packages/frontend/src/components/random-pick-modal.tsx
+++ b/packages/frontend/src/components/random-pick-modal.tsx
@@ -32,6 +32,33 @@ function shuffleArray<T>(array: T[]): T[] {
   return shuffled
 }
 
+/** Celebration sparkle particles shown on reveal */
+function CelebrationParticles() {
+  const particles = Array.from({ length: 18 }, (_, i) => ({
+    id: i,
+    x: Math.random() * 100,
+    delay: Math.random() * 0.4,
+    duration: 0.7 + Math.random() * 0.5,
+    size: 4 + Math.random() * 8,
+    color: i % 3 === 0 ? 'bg-primary/60' : i % 3 === 1 ? 'bg-neon/50' : 'bg-ember/50',
+  }))
+
+  return (
+    <div className="pointer-events-none absolute inset-0 overflow-hidden">
+      {particles.map(p => (
+        <motion.div
+          key={p.id}
+          className={`absolute rounded-full ${p.color}`}
+          style={{ left: `${p.x}%`, width: p.size, height: p.size }}
+          initial={{ y: '50%', opacity: 1, scale: 0 }}
+          animate={{ y: '-120%', opacity: 0, scale: 1.2 }}
+          transition={{ delay: p.delay, duration: p.duration, ease: 'easeOut' }}
+        />
+      ))}
+    </div>
+  )
+}
+
 function RandomPickContent({ games }: { games: Game[] }) {
   const { t } = useTranslation()
   // Lazy initializer — only runs once on mount (when dialog opens)
@@ -74,31 +101,41 @@ function RandomPickContent({ games }: { games: Game[] }) {
     <AnimatePresence mode="wait">
       <motion.div
         key={`${currentGame.steamAppId}-${pickCount}`}
-        initial={{ rotateY: 90, opacity: 0 }}
-        animate={{ rotateY: 0, opacity: 1 }}
-        exit={{ rotateY: -90, opacity: 0 }}
-        transition={{ duration: 0.3 }}
+        initial={{ rotateY: 90, opacity: 0, scale: 0.9 }}
+        animate={{ rotateY: 0, opacity: 1, scale: 1 }}
+        exit={{ rotateY: -90, opacity: 0, scale: 0.9 }}
+        transition={{ type: 'spring', stiffness: 300, damping: 25, duration: 0.3 }}
+        className="relative"
       >
+        <CelebrationParticles />
         <Card className="border-0 rounded-none shadow-none">
           {currentGame.headerImageUrl && (
-            <img
+            <motion.img
               src={currentGame.headerImageUrl}
               alt={currentGame.gameName}
-              className="w-full aspect-[460/215] object-cover"
+              className="w-full aspect-[460/215] object-cover sm:rounded-t-lg"
+              initial={{ scale: 1.05, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              transition={{ duration: 0.4, ease: 'easeOut' }}
             />
           )}
-          <div className="p-6 pb-[max(1.5rem,env(safe-area-inset-bottom))] space-y-4">
-            <div className="text-center">
+          <div className="p-4 sm:p-6 pb-[max(1.5rem,env(safe-area-inset-bottom))] space-y-4">
+            <motion.div
+              className="text-center"
+              initial={{ y: 8, opacity: 0 }}
+              animate={{ y: 0, opacity: 1 }}
+              transition={{ delay: 0.15, duration: 0.3, ease: 'easeOut' }}
+            >
               <p className="text-xs text-muted-foreground uppercase tracking-wide mb-1">
                 {t('randomPick.pickNumber', { number: pickCount })}
               </p>
-              <h2 className="text-xl font-bold">{currentGame.gameName}</h2>
-            </div>
+              <h2 className="text-2xl sm:text-xl font-bold">{currentGame.gameName}</h2>
+            </motion.div>
 
-            <div className="flex gap-3">
+            <div className="flex flex-col sm:flex-row gap-3">
               <Button
                 variant="secondary"
-                className="flex-1 gap-2"
+                className="w-full sm:w-auto sm:flex-1 gap-2"
                 onClick={reroll}
                 disabled={games.length <= 1}
               >
@@ -107,7 +144,7 @@ function RandomPickContent({ games }: { games: Game[] }) {
               </Button>
 
               {Number.isInteger(currentGame.steamAppId) && currentGame.steamAppId > 0 && (
-                <Button variant="steam" className="flex-1 gap-2" asChild>
+                <Button variant="steam" className="w-full sm:w-auto sm:flex-1 gap-2" asChild>
                   <a href={`steam://run/${currentGame.steamAppId}`}>
                     <ExternalLink className="w-4 h-4" />
                     {t('randomPick.launch')}
@@ -123,7 +160,7 @@ function RandomPickContent({ games }: { games: Game[] }) {
             )}
 
             {games.length > 1 && (
-              <p className="text-xs text-muted-foreground text-center">
+              <p className="text-xs text-muted-foreground text-center hidden sm:block">
                 {t('randomPick.keyboardHint')}
               </p>
             )}

--- a/packages/frontend/src/components/ui/button.tsx
+++ b/packages/frontend/src/components/ui/button.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-sm font-semibold transition-all duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-sm font-semibold transition-all duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] active:scale-[0.97] active:transition-transform active:duration-100 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
   {
     variants: {
       variant: {
@@ -19,7 +19,7 @@ const buttonVariants = cva(
       size: {
         default: 'h-10 px-4 py-2 min-h-[44px]',
         sm: 'h-9 px-3 text-xs min-h-[44px]',
-        lg: 'h-12 px-8 text-base',
+        lg: 'h-12 px-8 text-base min-h-[48px]',
         icon: 'h-10 w-10 min-h-[44px] min-w-[44px]',
       },
     },

--- a/packages/frontend/src/components/ui/drawer.tsx
+++ b/packages/frontend/src/components/ui/drawer.tsx
@@ -24,7 +24,7 @@ function DrawerOverlay({
     <DrawerPrimitive.Overlay
       ref={ref}
       data-slot="drawer-overlay"
-      className={cn('fixed inset-0 z-50 bg-black/80', className)}
+      className={cn('fixed inset-0 z-50 bg-black/40', className)}
       {...props}
     />
   )
@@ -43,12 +43,12 @@ function DrawerContent({
         ref={ref}
         data-slot="drawer-content"
         className={cn(
-          'fixed inset-x-0 bottom-0 z-50 mt-24 flex max-h-[96dvh] flex-col rounded-t-2xl border border-border bg-card pb-[max(1.5rem,env(safe-area-inset-bottom))]',
+          'fixed inset-x-0 bottom-0 z-50 mt-24 flex max-h-[96dvh] flex-col rounded-t-2xl border border-border bg-card pb-[max(1.5rem,env(safe-area-inset-bottom))] overscroll-contain',
           className
         )}
         {...props}
       >
-        <div className="mx-auto mt-4 h-1.5 w-12 shrink-0 rounded-full bg-muted-foreground/40" />
+        <div className="mx-auto mt-3 h-1.5 w-12 shrink-0 rounded-full bg-muted-foreground/60 shadow-[0_0_8px_oklch(0.55_0.27_270_/_0.15)]" />
         {children}
       </DrawerPrimitive.Content>
     </DrawerPortal>

--- a/packages/frontend/src/components/ui/responsive-dialog.tsx
+++ b/packages/frontend/src/components/ui/responsive-dialog.tsx
@@ -83,13 +83,13 @@ function ResponsiveDialogContent({
   }
 
   return (
-    <DrawerContent ref={ref} className={cn('px-4', className)} {...props}>
-      <div className="relative">
-        <div className="overflow-y-auto overflow-x-hidden max-h-[calc(96dvh-4rem)] px-0.5 py-2 min-w-0">
+    <DrawerContent ref={ref} className={cn('px-3 sm:px-4', className)} {...props}>
+      <div className="relative overscroll-contain">
+        <div className="overflow-y-auto overflow-x-hidden overscroll-contain max-h-[calc(96dvh-4rem)] px-0.5 py-2 min-w-0 touch-scroll">
           {children}
         </div>
         {/* Scroll fade indicator */}
-        <div className="pointer-events-none absolute bottom-0 left-0 right-0 h-6 bg-gradient-to-t from-background to-transparent" />
+        <div className="pointer-events-none absolute bottom-0 left-0 right-0 h-6 bg-gradient-to-t from-card to-transparent" />
       </div>
     </DrawerContent>
   )

--- a/packages/frontend/src/components/vote-setup-dialog.tsx
+++ b/packages/frontend/src/components/vote-setup-dialog.tsx
@@ -205,28 +205,34 @@ export function VoteSetupDialog({ open, onOpenChange, members, groupId, onlineMe
             </ResponsiveDialogHeader>
 
             <div className="space-y-3">
-              <label htmlFor="select-all" className="flex items-center gap-3 py-2.5 cursor-pointer">
+              <div
+                role="button"
+                tabIndex={0}
+                onClick={toggleAll}
+                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleAll() } }}
+                className="flex items-center gap-3 py-3 px-2 -mx-2 rounded-md cursor-pointer hover:bg-accent/50 active:bg-accent/10 transition-colors"
+              >
                 <Checkbox
                   id="select-all"
                   checked={allSelected}
                   onCheckedChange={toggleAll}
-                  className="size-5"
+                  className="size-6 sm:size-5 shrink-0"
                 />
                 <span className="text-sm font-medium text-muted-foreground">{t('voteSetup.selectAll')}</span>
-              </label>
+              </div>
 
               <div className="border-t border-border" />
 
-              <div className="max-h-[40dvh] overflow-y-auto overflow-x-hidden">
+              <div className="max-h-[50dvh] sm:max-h-[40dvh] overflow-y-auto overflow-x-hidden overscroll-contain">
                 {sortedMembers.map((member) => {
                   const isOnline = onlineMembers.has(member.id)
                   return (
-                    <label key={member.id} htmlFor={`member-${member.id}`} className="flex items-center gap-3 py-2.5 px-2 rounded-md cursor-pointer hover:bg-accent/50 min-w-0">
+                    <label key={member.id} htmlFor={`member-${member.id}`} className="flex items-center gap-3 py-2.5 px-2 rounded-md cursor-pointer hover:bg-accent/50 active:bg-accent/10 transition-colors min-w-0">
                       <Checkbox
                         id={`member-${member.id}`}
                         checked={selectedIds.has(member.id)}
                         onCheckedChange={() => toggleMember(member.id)}
-                        className="size-5 shrink-0"
+                        className="size-6 sm:size-5 shrink-0"
                       />
                       <div className="relative shrink-0">
                         <Avatar className="w-7 h-7">
@@ -267,11 +273,11 @@ export function VoteSetupDialog({ open, onOpenChange, members, groupId, onlineMe
               ) : null}
             </div>
 
-            <div className="flex flex-wrap justify-between items-center gap-2 mt-4">
+            <div className="flex flex-col sm:flex-row sm:justify-between items-center gap-2 mt-4">
               <span className="text-xs text-muted-foreground">
                 {t('voteSetup.selectedCount', { count: selectedIds.size })}
               </span>
-              <Button onClick={handleNext} disabled={!canProceed || loadingPreview}>
+              <Button onClick={handleNext} disabled={!canProceed || loadingPreview} className="w-full sm:w-auto">
                 {loadingPreview && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
                 {t('voteSetup.next')}
               </Button>
@@ -294,7 +300,7 @@ export function VoteSetupDialog({ open, onOpenChange, members, groupId, onlineMe
               </ResponsiveDialogDescription>
             </ResponsiveDialogHeader>
 
-            <div className="flex items-center gap-2 flex-wrap py-2">
+            <div className="flex items-center gap-2 flex-wrap py-2 px-3 sm:px-4">
               {members.filter(m => selectedIds.has(m.id)).map((member) => (
                 <Avatar key={member.id} className="w-8 h-8">
                   <AvatarImage src={member.avatarUrl} alt={member.displayName} />
@@ -379,7 +385,7 @@ export function VoteSetupDialog({ open, onOpenChange, members, groupId, onlineMe
               )}
             </div>
 
-            <ResponsiveDialogFooter className="mt-4 gap-2 sm:justify-between">
+            <ResponsiveDialogFooter className="mt-4 flex flex-col sm:flex-row gap-2 sm:justify-between">
               <Button variant="ghost" onClick={handleBack} className="w-full sm:w-auto">
                 <ArrowLeft className="w-4 h-4 mr-2" />
                 {t('voteSetup.back')}

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -569,3 +569,33 @@
     transform: none;
   }
 }
+
+/* ── Mobile touch improvements ── */
+
+/* Prevent iOS input zoom (inputs < 16px trigger zoom) */
+@media screen and (max-width: 640px) {
+  input, select, textarea {
+    font-size: 16px;
+  }
+}
+
+/* Improve touch scrolling */
+.touch-scroll {
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
+}
+
+/* Hide scrollbar on touch-friendly containers while keeping scroll functionality */
+.touch-scroll::-webkit-scrollbar {
+  display: none;
+}
+.touch-scroll {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+/* Prevent pull-to-refresh interfering with drawers/modals */
+[data-slot="drawer-content"] {
+  overscroll-behavior: contain;
+  touch-action: pan-y;
+}

--- a/packages/frontend/src/pages/GroupPage.tsx
+++ b/packages/frontend/src/pages/GroupPage.tsx
@@ -282,13 +282,13 @@ export function GroupPage() {
   return (
     <div className="min-h-screen flex flex-col">
       <AppHeader maxWidth="wide">
-        <div className="flex items-center gap-3 min-w-0">
+        <div className="flex items-center gap-2 sm:gap-3 min-w-0 flex-wrap">
           <Button variant="ghost" size="icon" onClick={() => navigate('/')} aria-label={t('group.back')} className="shrink-0">
             <ArrowLeft className="w-5 h-5" />
           </Button>
-          <h1 className="text-lg font-heading font-bold truncate">{currentGroup.name}</h1>
+          <h1 className="text-base sm:text-lg font-heading font-bold truncate max-w-[50vw] sm:max-w-none">{currentGroup.name}</h1>
           {onlineUserIds.length > 0 && (
-            <Badge variant="secondary" className="hidden sm:inline-flex text-[10px] px-1.5 py-0 gap-1 font-normal shrink-0">
+            <Badge variant="secondary" className="text-[10px] px-1.5 py-0 gap-1 font-normal shrink-0">
               <span className="w-1.5 h-1.5 rounded-full bg-online animate-pulse" />
               {onlineUserIds.length} en ligne
             </Badge>
@@ -296,11 +296,11 @@ export function GroupPage() {
         </div>
       </AppHeader>
 
-      <main id="main-content" className="max-w-6xl mx-auto p-4">
+      <main id="main-content" className="max-w-6xl mx-auto px-3 sm:px-4 lg:px-6 py-4">
         {/* Mobile: mini-bar that opens sidebar sheet */}
         <button
           type="button"
-          className="lg:hidden mb-4 w-full rounded-lg border border-border bg-card/50 p-3 active:bg-card/80 transition-colors"
+          className="lg:hidden mb-4 w-full min-h-[44px] rounded-lg border border-border bg-card/50 p-3 active:bg-card/80 active:scale-[0.98] transition-all"
           onClick={() => setMobileSidebarOpen(true)}
           aria-label={t('group.openSidebar')}
         >
@@ -320,7 +320,7 @@ export function GroupPage() {
             </div>
             <div className="flex-1 min-w-0 text-left">
               <p className="text-sm font-medium truncate">{currentGroup.name}</p>
-              <div className="flex items-center gap-2">
+              <div className="flex items-center gap-2 flex-wrap">
                 <p className="text-xs text-muted-foreground">{t('group.members', { count: currentGroup.members.length })}</p>
                 {onlineUserIds.length > 0 && (
                   <Badge variant="secondary" className="text-[10px] px-1.5 py-0 gap-1 font-normal">
@@ -330,7 +330,10 @@ export function GroupPage() {
                 )}
               </div>
             </div>
-            <ChevronUp className="w-4 h-4 text-muted-foreground shrink-0" />
+            <div className="flex flex-col items-center shrink-0">
+              <ChevronUp className="w-5 h-5 text-muted-foreground animate-bounce" />
+              <span className="text-[9px] text-muted-foreground leading-none">Ouvrir</span>
+            </div>
           </div>
         </button>
 
@@ -364,9 +367,9 @@ export function GroupPage() {
           </div>
 
           {/* Main content: games grid */}
-          <div className="space-y-4">
-            {/* Action buttons */}
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <div className="space-y-3 sm:space-y-4">
+            {/* Action buttons — full-width stacked on mobile, grid on sm+ */}
+            <div className="hidden sm:grid sm:grid-cols-2 gap-3">
               <Button
                 onClick={() => setVoteSetupOpen(true)}
                 className="h-auto py-4 flex-col card-hover-glow"
@@ -387,6 +390,29 @@ export function GroupPage() {
                 <span className="text-sm opacity-80">{t('group.randomPickHint')}</span>
               </Button>
             </div>
+
+            {/* Mobile: fixed bottom action bar */}
+            <div className="fixed bottom-0 left-0 right-0 z-40 sm:hidden bg-background/95 backdrop-blur-sm border-t border-border px-3 pt-2 pb-[max(1rem,env(safe-area-inset-bottom))]">
+              <div className="flex gap-2">
+                <Button
+                  onClick={() => setVoteSetupOpen(true)}
+                  className="flex-1 h-12 gap-2 active:scale-[0.98] transition-transform"
+                >
+                  <Vote className="w-5 h-5" />
+                  <span className="font-heading font-bold">{t('group.startVote')}</span>
+                </Button>
+                <Button
+                  variant="secondary"
+                  onClick={() => setRandomPickOpen(true)}
+                  disabled={commonGames.length === 0}
+                  className="h-12 px-4 active:scale-[0.98] transition-transform"
+                >
+                  <Dices className="w-5 h-5" />
+                </Button>
+              </div>
+            </div>
+            {/* Spacer for fixed bottom bar on mobile */}
+            <div className="h-16 sm:hidden" />
 
             <RandomPickModal
               open={randomPickOpen}

--- a/packages/frontend/src/pages/VotePage.tsx
+++ b/packages/frontend/src/pages/VotePage.tsx
@@ -303,7 +303,7 @@ export function VotePage() {
     const isScheduledSession = scheduledDate && scheduledDate.getTime() > Date.now()
 
     return (
-      <div className="min-h-screen flex flex-col items-center justify-center p-4">
+      <div className="min-h-screen flex flex-col items-center justify-center px-3 sm:px-4 py-4">
         <Check className="w-16 h-16 text-success mb-4" />
         <h2 className="text-2xl font-heading font-bold mb-2">{t('vote.submitted')}</h2>
 
@@ -408,7 +408,7 @@ export function VotePage() {
               >
                 <button
                   onClick={() => toggleGame(game.steamAppId)}
-                  className="w-full text-left"
+                  className="w-full text-left active:scale-95 active:bg-accent/10 transition-transform"
                   aria-label={isSelected ? t('vote.deselectGame', { name: game.gameName }) : t('vote.selectGame', { name: game.gameName })}
                   aria-pressed={isSelected}
                 >
@@ -443,7 +443,7 @@ export function VotePage() {
                           e.stopPropagation()
                           setDetailGame(game)
                         }}
-                        className="ml-1 shrink-0 p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors"
+                        className="ml-1 shrink-0 min-w-[44px] min-h-[44px] flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-secondary active:bg-accent/10 active:scale-95 transition-all"
                         aria-label={t('vote.gameDetails')}
                       >
                         <Info className="w-3.5 h-3.5" />
@@ -469,18 +469,23 @@ export function VotePage() {
         />
 
         {/* Floating submit button */}
-        <div className="fixed bottom-0 left-0 right-0 p-4 pb-[max(1rem,env(safe-area-inset-bottom))] bg-background/80 backdrop-blur-sm border-t border-border">
+        <div className="fixed bottom-0 left-0 right-0 p-2.5 sm:p-4 pb-[max(0.625rem,env(safe-area-inset-bottom))] sm:pb-[max(1rem,env(safe-area-inset-bottom))] bg-background/80 backdrop-blur-sm shadow-[0_-4px_12px_rgba(0,0,0,0.1)]">
           <div className="max-w-2xl mx-auto flex items-center justify-between">
             <span role="status" aria-live="polite" className="text-sm text-muted-foreground">
               {t('vote.gamesSelected', { count: selectedGames.size })}
             </span>
-            <Button onClick={submitVotes} disabled={submitting || selectedGames.size === 0} aria-label={t('vote.submitSelection')}>
+            <Button onClick={submitVotes} disabled={submitting || selectedGames.size === 0} aria-label={t('vote.submitSelection')} className="relative">
               {submitting ? (
                 <Loader2 className="w-4 h-4 animate-spin mr-2" />
               ) : (
                 <Send className="w-4 h-4 mr-2" />
               )}
               {t('vote.submitSelection')}
+              {selectedGames.size > 0 && (
+                <span className="absolute -top-2 -right-2 min-w-[20px] h-5 px-1 rounded-full bg-primary text-primary-foreground text-xs font-bold flex items-center justify-center">
+                  {selectedGames.size}
+                </span>
+              )}
             </Button>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Comprehensive mobile touch UX overhaul across the entire frontend.

- **Group page + sidebar**: Tighter mobile spacing (px-3 sm:px-4), 44px+ touch targets on all action buttons, vote history horizontal snap scroll, bouncing chevron hint on sidebar toggle, presence badge visible on all screens
- **Base components**: Button press feedback (active:scale-0.97), drawer backdrop dimmed to 40%, overscroll-contain on drawers, iOS input zoom prevention (16px font), touch-scroll utility class, enhanced random-pick celebration (18 multi-color particles, spring scale animation, full-width mobile buttons)
- **Vote flow**: Floating submit bar with reduced mobile padding + top shadow, 44px info button targets, press feedback on game cards, selection count badge on submit button, larger checkboxes on mobile (24px vs 20px), full-width member row touch targets, stacked action buttons on mobile, expanded member list height (50dvh)

Game grid was already fully mobile-optimized (snap scrolling, fade gradients, 44px targets, iOS zoom prevention) — no changes needed.

## Test plan

- [ ] Test on iPhone SE (375px) — verify no horizontal overflow, all buttons tappable
- [ ] Test on iPhone 14 (390px) — verify vote flow, setup dialog, game selection
- [ ] Test vote setup dialog — checkboxes 24px on mobile, full-row tappable, stacked buttons
- [ ] Test game card selection — press feedback visible on tap
- [ ] Test floating submit bar — proper safe-area padding, shadow visible
- [ ] Test group sidebar — 48px member rows, 44px action buttons, history horizontal scroll
- [ ] Test random pick modal — full-width buttons, celebration particles, spring animation
- [ ] Test drawer — lighter backdrop, no background scroll, prominent grab handle
- [ ] Verify desktop experience unchanged

https://claude.ai/code/session_017mwHHRMym5m5pbWVFyZwjP