### PR TITLE
feat(discord): add daily challenge slash command with claim tracking

### DIFF
--- a/packages/backend/migrations/20260413_add_daily_challenges.ts
+++ b/packages/backend/migrations/20260413_add_daily_challenges.ts
@@ -1,0 +1,42 @@
+import type { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  // Daily challenge rolled per group per day
+  await knex.schema.createTable('discord_daily_challenges', (table) => {
+    table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'))
+    table.uuid('group_id').notNullable().references('id').inTable('groups').onDelete('CASCADE')
+    table.date('challenge_date').notNullable()
+    table.integer('steam_app_id').notNullable()
+    table.text('game_id').nullable()
+    table.text('game_name').notNullable()
+    table.text('header_image_url').nullable()
+    table.text('discord_channel_id').notNullable()
+    table.text('discord_message_id').nullable()
+    table.uuid('created_by_user_id').nullable().references('id').inTable('users').onDelete('SET NULL')
+    table.timestamp('created_at', { useTz: true }).defaultTo(knex.fn.now())
+
+    table.unique(['group_id', 'challenge_date'])
+  })
+
+  // Claims (one per user per challenge)
+  await knex.schema.createTable('discord_daily_challenge_claims', (table) => {
+    table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'))
+    table.uuid('challenge_id').notNullable().references('id').inTable('discord_daily_challenges').onDelete('CASCADE')
+    table.uuid('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE')
+    table.timestamp('claimed_at', { useTz: true }).defaultTo(knex.fn.now())
+
+    table.unique(['challenge_id', 'user_id'])
+  })
+
+  await knex.raw(
+    'CREATE INDEX idx_daily_challenges_group_date ON discord_daily_challenges(group_id, challenge_date DESC)'
+  )
+  await knex.raw(
+    'CREATE INDEX idx_daily_challenge_claims_user ON discord_daily_challenge_claims(user_id)'
+  )
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists('discord_daily_challenge_claims')
+  await knex.schema.dropTableIfExists('discord_daily_challenges')
+}

--- a/packages/backend/src/presentation/routes/discord.routes.ts
+++ b/packages/backend/src/presentation/routes/discord.routes.ts
@@ -3,7 +3,7 @@ import { Router, type Request, type Response } from 'express'
 import { db } from '../../infrastructure/database/connection.js'
 import { computeCommonGames } from '../../infrastructure/database/common-games.js'
 import { getIO } from '../../infrastructure/socket/socket.js'
-import { logger } from '../../infrastructure/logger/logger.js'
+import { logger, authLogger } from '../../infrastructure/logger/logger.js'
 import { env } from '../../config/env.js'
 import { requireAuth } from '../middleware/auth.middleware.js'
 import { isUserPremium } from '../middleware/tier.middleware.js'
@@ -363,6 +363,191 @@ router.get('/random', async (req: Request, res: Response) => {
       headerImageUrl: game.headerImageUrl,
     },
   })
+})
+
+// ─── Daily challenge (Discord) ──────────────────────────────────────────────
+
+// Create (or fetch existing) daily challenge for the group linked to a channel
+router.post('/daily-challenge/create', async (req: Request, res: Response) => {
+  try {
+    const userId = req.userId
+    if (!userId) {
+      res.status(403).json({ error: 'forbidden', message: 'Discord account not linked. Use /wawptn-link first.' })
+      return
+    }
+
+    const { channelId, guildId } = req.body as { channelId?: string; guildId?: string }
+    if (!channelId || !guildId) {
+      res.status(400).json({ error: 'validation', message: 'channelId and guildId are required' })
+      return
+    }
+
+    // Resolve the group via channel link
+    const group = await db('groups').where({ discord_channel_id: channelId }).first()
+    if (!group) {
+      res.status(404).json({ error: 'not_found', message: 'Aucun groupe lié à ce canal Discord' })
+      return
+    }
+
+    // Check premium (Discord bot integration requires group owner premium)
+    const ownerPremium = await isGroupOwnerPremium(group.id)
+    if (!ownerPremium) {
+      res.status(403).json({ error: 'premium_required', message: 'Discord bot integration requires a premium subscription' })
+      return
+    }
+
+    // Compute today's date in Europe/Paris timezone
+    const todayRow = await db.raw(`SELECT (now() AT TIME ZONE 'Europe/Paris')::date AS today`)
+    const today = todayRow.rows[0].today as string
+
+    // Idempotent: if a challenge exists for today, return it unchanged
+    const existing = await db('discord_daily_challenges')
+      .where({ group_id: group.id, challenge_date: today })
+      .first()
+
+    if (existing) {
+      res.json({
+        challenge: {
+          id: existing.id,
+          steamAppId: existing.steam_app_id,
+          gameId: existing.game_id,
+          gameName: existing.game_name,
+          headerImageUrl: existing.header_image_url,
+          alreadyExists: true,
+        },
+      })
+      return
+    }
+
+    // Pick a random common game from the group members' libraries
+    const memberIds = await db('group_members').where({ group_id: group.id }).pluck('user_id')
+    const games = await computeCommonGames(memberIds, { threshold: memberIds.length })
+
+    if (games.length === 0) {
+      res.status(422).json({ error: 'no_common_games', message: 'Aucun jeu en commun trouvé pour ce groupe.' })
+      return
+    }
+
+    const randomIndex = Math.floor(Math.random() * games.length)
+    const game = games[randomIndex]!
+
+    const [inserted] = await db('discord_daily_challenges')
+      .insert({
+        group_id: group.id,
+        challenge_date: today,
+        steam_app_id: game.steamAppId,
+        game_id: game.gameId,
+        game_name: game.gameName,
+        header_image_url: game.headerImageUrl,
+        discord_channel_id: channelId,
+        created_by_user_id: userId,
+      })
+      .returning('*')
+
+    logger.info({ groupId: group.id, challengeId: inserted.id, date: today }, 'Daily challenge created')
+
+    res.json({
+      challenge: {
+        id: inserted.id,
+        steamAppId: inserted.steam_app_id,
+        gameId: inserted.game_id,
+        gameName: inserted.game_name,
+        headerImageUrl: inserted.header_image_url,
+        alreadyExists: false,
+      },
+    })
+  } catch (error) {
+    authLogger.error({ error: String(error) }, 'daily-challenge create failed')
+    res.status(500).json({ error: 'internal', message: 'Erreur lors de la création du défi du jour' })
+  }
+})
+
+// Claim today's challenge (user has played/accepted)
+router.post('/daily-challenge/claim', async (req: Request, res: Response) => {
+  try {
+    const userId = req.userId
+    if (!userId) {
+      res.status(403).json({ error: 'forbidden', message: 'Discord account not linked. Use /wawptn-link first.' })
+      return
+    }
+
+    const { challengeId } = req.body as { challengeId?: string }
+    if (!challengeId) {
+      res.status(400).json({ error: 'validation', message: 'challengeId is required' })
+      return
+    }
+
+    const challenge = await db('discord_daily_challenges').where({ id: challengeId }).first()
+    if (!challenge) {
+      res.status(404).json({ error: 'not_found', message: 'Défi introuvable' })
+      return
+    }
+
+    // Insert claim (idempotent via onConflict ignore)
+    await db('discord_daily_challenge_claims')
+      .insert({
+        challenge_id: challengeId,
+        user_id: userId,
+      })
+      .onConflict(['challenge_id', 'user_id'])
+      .ignore()
+
+    // Fetch this user's claim record to determine rank
+    const userClaim = await db('discord_daily_challenge_claims')
+      .where({ challenge_id: challengeId, user_id: userId })
+      .first()
+
+    // Rank = number of claims on this challenge with claimed_at <= userClaim.claimed_at
+    const rankRow = await db('discord_daily_challenge_claims')
+      .where({ challenge_id: challengeId })
+      .andWhere('claimed_at', '<=', userClaim.claimed_at)
+      .count<{ count: string }[]>('* as count')
+      .first()
+
+    const totalRow = await db('discord_daily_challenge_claims')
+      .where({ challenge_id: challengeId })
+      .count<{ count: string }[]>('* as count')
+      .first()
+
+    const rank = Number(rankRow?.count ?? 0)
+    const totalClaims = Number(totalRow?.count ?? 0)
+
+    res.json({
+      rank,
+      totalClaims,
+      firstClaimer: rank === 1,
+    })
+  } catch (error) {
+    authLogger.error({ error: String(error) }, 'daily-challenge claim failed')
+    res.status(500).json({ error: 'internal', message: 'Erreur lors de la validation du défi' })
+  }
+})
+
+// Store the Discord message ID tied to a daily challenge
+router.patch('/daily-challenge/:id/message', async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params
+    const { messageId } = req.body as { messageId?: string }
+
+    if (!messageId) {
+      res.status(400).json({ error: 'validation', message: 'messageId is required' })
+      return
+    }
+
+    const updated = await db('discord_daily_challenges')
+      .where({ id })
+      .update({ discord_message_id: messageId })
+
+    if (updated === 0) {
+      res.status(404).json({ error: 'not_found', message: 'Défi introuvable' })
+      return
+    }
+
+    res.json({ ok: true })
+  } catch (error) {
+    authLogger.error({ error: String(error) }, 'daily-challenge message update failed')
+    res.status(500).json({ error: 'internal', message: 'Erreur lors de la mise à jour du message' })
+  }
 })
 
 // ─── Conversational chat (LLM-powered) ──────────────────────────────────────

--- a/packages/discord/src/commands/daily-challenge.ts
+++ b/packages/discord/src/commands/daily-challenge.ts
@@ -1,0 +1,118 @@
+import {
+  SlashCommandBuilder,
+  EmbedBuilder,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  type ChatInputCommandInteraction,
+} from 'discord.js'
+import { backendApi, getBotSettings } from '../lib/api.js'
+import { resolveGroup } from '../lib/resolve-group.js'
+import { getTodayPersona, getDefaultPersona, getPersonaById, type Persona } from '../personas.js'
+
+interface DailyChallengeResponse {
+  challenge: {
+    id: string
+    steamAppId: number
+    gameId: string | null
+    gameName: string
+    headerImageUrl: string | null
+    alreadyExists: boolean
+  }
+}
+
+async function getActivePersona(): Promise<Persona> {
+  try {
+    const settings = await getBotSettings()
+    if (settings.persona_override) {
+      const override = getPersonaById(settings.persona_override)
+      if (override) return override
+    }
+    if (!settings.persona_rotation_enabled) return getDefaultPersona()
+    return getTodayPersona(settings.disabled_personas ?? [])
+  } catch {
+    return getTodayPersona()
+  }
+}
+
+export const data = new SlashCommandBuilder()
+  .setName('wawptn-daily-challenge')
+  .setDescription('Lancer le défi du jour pour ton groupe')
+
+export async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
+  await interaction.deferReply({ ephemeral: true })
+
+  const group = await resolveGroup(interaction)
+  if (!group) return
+
+  try {
+    const result = await backendApi<DailyChallengeResponse>(
+      '/api/discord/daily-challenge/create',
+      {
+        method: 'POST',
+        discordUserId: interaction.user.id,
+        body: {
+          channelId: interaction.channelId,
+          guildId: interaction.guildId ?? '',
+        },
+      },
+    )
+
+    const { challenge } = result
+    const persona = await getActivePersona()
+
+    const embed = new EmbedBuilder()
+      .setTitle('🎯 Défi du jour !')
+      .setDescription(
+        `Qui jouera à **${challenge.gameName}** en premier aujourd'hui ?\n\n` +
+          `Clique sur le bouton ci-dessous pour relever le défi !`,
+      )
+      .setColor(persona.embedColor ?? 0xFEE75C)
+      .setFooter({ text: `WAWPTN — ${persona.name}` })
+      .setTimestamp()
+
+    if (challenge.headerImageUrl) {
+      embed.setImage(challenge.headerImageUrl)
+    }
+
+    if (challenge.steamAppId) {
+      embed.setURL(`https://store.steampowered.com/app/${challenge.steamAppId}`)
+    }
+
+    const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder()
+        .setCustomId(`daily-challenge:${challenge.id}`)
+        .setLabel('🏆 Je relève le défi !')
+        .setStyle(ButtonStyle.Primary),
+    )
+
+    // Send the challenge as a public message
+    if (interaction.channel && 'send' in interaction.channel) {
+      const sent = await interaction.channel.send({ embeds: [embed], components: [row] })
+
+      // Store the Discord message ID so we can reference it later
+      try {
+        await backendApi(`/api/discord/daily-challenge/${challenge.id}/message`, {
+          method: 'PATCH',
+          body: { messageId: sent.id },
+        })
+      } catch (err) {
+        console.error('[daily-challenge] Failed to store message ID:', err)
+      }
+    }
+
+    const replyContent = challenge.alreadyExists
+      ? `ℹ️ Le défi du jour pour **${group.groupName}** a déjà été lancé aujourd'hui.`
+      : `🎯 Défi du jour lancé dans **${group.groupName}** !`
+
+    await interaction.editReply({
+      content: replyContent,
+      components: [],
+    })
+  } catch (error) {
+    await interaction.editReply({
+      content: `❌ ${error instanceof Error ? error.message : 'Erreur lors du lancement du défi'}`,
+      components: [],
+    })
+  }
+}

--- a/packages/discord/src/index.ts
+++ b/packages/discord/src/index.ts
@@ -24,6 +24,7 @@ import * as linkCommand from './commands/link.js'
 import * as gamesCommand from './commands/games.js'
 import * as voteCommand from './commands/vote.js'
 import * as randomCommand from './commands/random.js'
+import * as dailyChallengeCommand from './commands/daily-challenge.js'
 
 validateEnv()
 
@@ -41,6 +42,7 @@ const commands = new Map([
   ['wawptn-games', gamesCommand],
   ['wawptn-vote', voteCommand],
   ['wawptn-random', randomCommand],
+  ['wawptn-daily-challenge', dailyChallengeCommand],
 ])
 
 client.once(Events.ClientReady, async (c) => {
@@ -92,45 +94,94 @@ client.on(Events.InteractionCreate, async (interaction: Interaction) => {
     return
   }
 
-  // Handle button interactions (voting)
+  // Handle button interactions
   if (interaction.isButton()) {
-    const [action, sessionId, steamAppIdStr, vote] = interaction.customId.split(':')
-    if (action !== 'vote' || !sessionId || !steamAppIdStr || !vote) return
+    const parts = interaction.customId.split(':')
+    const action = parts[0]
 
-    await interaction.deferReply({ ephemeral: true })
+    // ─── Voting buttons ──────────────────────────────────────────────────
+    if (action === 'vote') {
+      const [, sessionId, steamAppIdStr, vote] = parts
+      if (!sessionId || !steamAppIdStr || !vote) return
 
-    try {
-      // Check if Discord user is linked
-      const status = await backendApi<{ linked: boolean; userId?: string }>(`/api/discord/link/status`, {
-        discordUserId: interaction.user.id,
-      })
+      await interaction.deferReply({ ephemeral: true })
 
-      if (!status.linked) {
-        await interaction.editReply({
-          content: '🔗 Vous devez d\'abord lier votre compte ! Utilisez la commande `/wawptn-link`.',
+      try {
+        // Check if Discord user is linked
+        const status = await backendApi<{ linked: boolean; userId?: string }>(`/api/discord/link/status`, {
+          discordUserId: interaction.user.id,
         })
-        return
+
+        if (!status.linked) {
+          await interaction.editReply({
+            content: '🔗 Vous devez d\'abord lier votre compte ! Utilisez la commande `/wawptn-link`.',
+          })
+          return
+        }
+
+        // Cast the vote via backend API
+        const steamAppId = parseInt(steamAppIdStr, 10)
+        await backendApi(`/api/discord/vote`, {
+          method: 'POST',
+          discordUserId: interaction.user.id,
+          body: {
+            sessionId,
+            steamAppId,
+            vote: vote === 'yes',
+          },
+        })
+
+        await interaction.editReply({
+          content: `✅ Vote enregistré : ${vote === 'yes' ? '👍' : '👎'}`,
+        })
+      } catch (error) {
+        await interaction.editReply({
+          content: `❌ ${error instanceof Error ? error.message : 'Erreur lors du vote'}`,
+        })
       }
+      return
+    }
 
-      // Cast the vote via backend API
-      const steamAppId = parseInt(steamAppIdStr, 10)
-      await backendApi(`/api/discord/vote`, {
-        method: 'POST',
-        discordUserId: interaction.user.id,
-        body: {
-          sessionId,
-          steamAppId,
-          vote: vote === 'yes',
-        },
-      })
+    // ─── Daily challenge claim button ────────────────────────────────────
+    if (action === 'daily-challenge') {
+      const challengeId = parts[1]
+      if (!challengeId) return
 
-      await interaction.editReply({
-        content: `✅ Vote enregistré : ${vote === 'yes' ? '👍' : '👎'}`,
-      })
-    } catch (error) {
-      await interaction.editReply({
-        content: `❌ ${error instanceof Error ? error.message : 'Erreur lors du vote'}`,
-      })
+      await interaction.deferReply({ ephemeral: true })
+
+      try {
+        // Check if Discord user is linked
+        const status = await backendApi<{ linked: boolean; userId?: string }>(`/api/discord/link/status`, {
+          discordUserId: interaction.user.id,
+        })
+
+        if (!status.linked) {
+          await interaction.editReply({
+            content: '🔗 Vous devez d\'abord lier votre compte ! Utilisez la commande `/wawptn-link`.',
+          })
+          return
+        }
+
+        const result = await backendApi<{ rank: number; totalClaims: number; firstClaimer: boolean }>(
+          `/api/discord/daily-challenge/claim`,
+          {
+            method: 'POST',
+            discordUserId: interaction.user.id,
+            body: { challengeId },
+          },
+        )
+
+        const message = result.firstClaimer
+          ? '🥇 Bravo ! Tu es le premier à relever le défi aujourd\'hui !'
+          : `Rang #${result.rank} sur ${result.totalClaims} — tu as relevé le défi !`
+
+        await interaction.editReply({ content: message })
+      } catch (error) {
+        await interaction.editReply({
+          content: `❌ ${error instanceof Error ? error.message : 'Erreur lors de la validation du défi'}`,
+        })
+      }
+      return
     }
   }
 })

--- a/packages/frontend/src/components/random-pick-modal.tsx
+++ b/packages/frontend/src/components/random-pick-modal.tsx
@@ -32,9 +32,17 @@ function shuffleArray<T>(array: T[]): T[] {
   return shuffled
 }
 
-/** Celebration sparkle particles shown on reveal */
-function CelebrationParticles() {
-  const particles = Array.from({ length: 18 }, (_, i) => ({
+interface Particle {
+  id: number
+  x: number
+  delay: number
+  duration: number
+  size: number
+  color: string
+}
+
+function createParticles(): Particle[] {
+  return Array.from({ length: 18 }, (_, i) => ({
     id: i,
     x: Math.random() * 100,
     delay: Math.random() * 0.4,
@@ -42,6 +50,13 @@ function CelebrationParticles() {
     size: 4 + Math.random() * 8,
     color: i % 3 === 0 ? 'bg-primary/60' : i % 3 === 1 ? 'bg-neon/50' : 'bg-ember/50',
   }))
+}
+
+/** Celebration sparkle particles shown on reveal */
+function CelebrationParticles() {
+  // Use lazy state initializer so Math.random is only called once on mount
+  // (React Compiler rejects calls to impure functions during render)
+  const [particles] = useState<Particle[]>(createParticles)
 
   return (
     <div className="pointer-events-none absolute inset-0 overflow-hidden">


### PR DESCRIPTION
## Summary

Adds a `/wawptn-daily-challenge` Discord slash command — an engagement hook that picks a random common game from a linked group each day and lets members race to claim the challenge.

**Backend:**
- New `discord_daily_challenges` table (one row per group per day, Europe/Paris timezone) and `discord_daily_challenge_claims` table (first-come ranking)
- `POST /api/discord/daily-challenge/create` — idempotent: returns existing challenge or picks a random common game from the linked group
- `POST /api/discord/daily-challenge/claim` — records a claim and returns the user's rank + total claims + whether they were first
- `PATCH /api/discord/daily-challenge/:id/message` — stores the Discord message ID for future reference
- All endpoints respect the existing bot auth + premium gate patterns

**Discord bot:**
- New `wawptn-daily-challenge` slash command with persona-styled embed ("🎯 Défi du jour !", "Qui jouera à **X** en premier aujourd'hui ?")
- Primary button "🏆 Je relève le défi !" — click rewards first claimer with "🥇 Bravo !" or others with "Rang #N sur M"
- Refactored button interaction handler in `index.ts` to route between `vote:` and `daily-challenge:` button types
- Uses `resolveGroup()` for channel-to-group linking and `getActivePersona()` for persona-themed footer

**Bonus fix:**
- Fixed a pre-existing `react-hooks/purity` lint error in `random-pick-modal.tsx` (celebration particles were calling `Math.random()` during render) by using a `useState` lazy initializer

## Test plan

- [ ] Run migration — verify both tables and indexes are created
- [ ] Run `/wawptn-daily-challenge` in a linked Discord channel — verify embed posts publicly with game + button
- [ ] Run the command twice in the same day — verify it's idempotent (returns same challenge)
- [ ] Click the challenge button as first user — verify "🥇 Bravo !" message
- [ ] Click as second user — verify "Rang #2 sur 2" message
- [ ] Run `/wawptn-daily-challenge` in an unlinked channel — verify error message
- [ ] Run in a linked channel but without premium — verify premium-required error
- [ ] Verify persona embed footer rotates daily

https://claude.ai/code/session_017mwHHRMym5m5pbWVFyZwjP