### PR TITLE
fix(backend): resolve TypeScript errors from stale merges

### DIFF
--- a/packages/backend/src/domain/__tests__/close-session.test.ts
+++ b/packages/backend/src/domain/__tests__/close-session.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 // vi.hoisted — variables available inside vi.mock factories (which are hoisted)
 // ---------------------------------------------------------------------------
 
-const { mockDb, mockEmit, trxResults, dbResults, trxCallCounts, dbCallCounts } = vi.hoisted(() => {
+const { mockDb, trxResults, dbResults, trxCallCounts, dbCallCounts } = vi.hoisted(() => {
   /**
    * Chainable mock mimicking a Knex query builder.
    * Every method returns the same proxy, and `await` resolves to `resolveValue`.
@@ -61,15 +61,10 @@ const { mockDb, mockEmit, trxResults, dbResults, trxCallCounts, dbCallCounts } =
     },
   )
 
-  const mockEmit = (() => {}) as unknown as ReturnType<typeof vi.fn>
-
-  return { mockDb, mockEmit, trxResults, dbResults, trxCallCounts, dbCallCounts }
+  return { mockDb, trxResults, dbResults, trxCallCounts, dbCallCounts }
 })
 
-// Replace noop stubs with proper vi.fn after hoisting
-const emit = vi.fn()
-// We need mockEmit to be a vi.fn — but since vi.fn can't be created inside vi.hoisted,
-// we use a module-scope vi.fn and wire it up.
+// Module-scope vi.fn for the socket emit (created after hoisted block)
 const socketEmit = vi.fn()
 
 // ---------------------------------------------------------------------------

--- a/packages/backend/src/domain/__tests__/streaks.test.ts
+++ b/packages/backend/src/domain/__tests__/streaks.test.ts
@@ -62,7 +62,7 @@ import { updateStreak } from '../streaks.js'
 
 // Replace the raw stub with a real vi.fn so we can assert against it
 const rawFn = vi.fn().mockResolvedValue(undefined)
-;(mockDb as Record<string, unknown>).raw = rawFn
+;(mockDb as unknown as Record<string, unknown>).raw = rawFn
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/packages/backend/src/presentation/routes/group.routes.ts
+++ b/packages/backend/src/presentation/routes/group.routes.ts
@@ -1,7 +1,7 @@
 import { Router, type Request, type Response } from 'express'
 import cron from 'node-cron'
 import { db } from '../../infrastructure/database/connection.js'
-import { computeCommonGames, countCommonGames, countCommonGamesForGroups } from '../../infrastructure/database/common-games.js'
+import { computeCommonGames, countCommonGamesForGroups } from '../../infrastructure/database/common-games.js'
 import { generateInviteToken, hashInviteToken } from '../../infrastructure/steam/steam-client.js'
 import { triggerBackgroundEnrichment } from '../../infrastructure/steam/steam-store-client.js'
 import { getIO, forceLeaveRoom } from '../../infrastructure/socket/socket.js'
@@ -1033,8 +1033,6 @@ router.get('/:id/streaks', async (req: Request, res: Response) => {
   } catch (error) {
     logger.error({ error: String(error), groupId: req.params['id'] }, 'failed to load group streaks')
     res.status(500).json({ error: 'internal', message: 'Failed to load group streaks' })
-  }
-})
   }
 })
 


### PR DESCRIPTION
## Summary

Hot-fix for TypeScript compilation errors that accumulated across earlier squash-merged PRs:

1. **Syntax error in `group.routes.ts`** — Line 1038 had stray `}` and `})` left over from an earlier cherry-pick conflict resolution when merging the leaderboard endpoint with the streaks endpoint. This was blocking backend compilation.
2. **Unused import** — `countCommonGames` was imported but no longer referenced after the N+1 optimization moved to `countCommonGamesForGroups`.
3. **Test cleanup** — `close-session.test.ts` had unused `mockEmit` / `emit` variables left over from the hoisted mock setup.
4. **Type assertion fix** — `streaks.test.ts` used `as Record<string, unknown>` which doesn't sufficiently overlap with the mockDb type; switched to `as unknown as Record<string, unknown>`.

All 12 vitest unit tests still pass. Backend `tsc --noEmit` is now clean.

## Test plan

- [x] `npm run build:types` — clean
- [x] `npx tsc --noEmit -p packages/backend/tsconfig.json` — clean (0 errors)
- [x] `npx vitest run` — 12/12 tests pass

https://claude.ai/code/session_017mwHHRMym5m5pbWVFyZwjP