### PR TITLE
refactor(backend): SoC/SOLID cleanup — service + repository + event bus layers

### DIFF
--- a/packages/backend/src/domain/__tests__/close-session.test.ts
+++ b/packages/backend/src/domain/__tests__/close-session.test.ts
@@ -104,6 +104,13 @@ vi.mock('@/domain/streaks.js', () => ({
 // ---------------------------------------------------------------------------
 
 import { closeSession } from '../close-session.js'
+import { registerSessionEffects } from '@/infrastructure/effects/session-effects.js'
+import { domainEvents } from '@/domain/events/event-bus.js'
+
+// Register effects once so the domain event bus has subscribers hooked into
+// the mocked infrastructure modules above.
+domainEvents.removeAllListeners()
+registerSessionEffects()
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/packages/backend/src/domain/__tests__/group-repository.test.ts
+++ b/packages/backend/src/domain/__tests__/group-repository.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// vi.hoisted — shared state between mock factories (hoisted) and tests
+// ---------------------------------------------------------------------------
+
+const { mockKnex, dbResultQueue, dbCallCounts, lastArgs } = vi.hoisted(() => {
+  /**
+   * Chainable mock mimicking a Knex query builder.
+   *
+   * Every method returns the same proxy, `await` resolves to `resolveValue`,
+   * and each method invocation is recorded in `callLog` so tests can assert
+   * on the exact chain that the repository built (e.g. `.where({ id })`).
+   */
+  function chain(
+    resolveValue: unknown,
+    callLog: Array<{ method: string; args: unknown[] }>,
+  ): unknown {
+    const proxy: unknown = new Proxy(() => {}, {
+      get(_t, prop: string) {
+        if (prop === 'then') {
+          return (res: (v: unknown) => void, rej: (e: unknown) => void) =>
+            Promise.resolve(resolveValue).then(res, rej)
+        }
+        return (...args: unknown[]) => {
+          callLog.push({ method: prop, args })
+          return proxy
+        }
+      },
+      apply() {
+        return proxy
+      },
+    })
+    return proxy
+  }
+
+  const dbResultQueue = new Map<string, unknown[]>()
+  const dbCallCounts = new Map<string, number>()
+  const lastArgs = {
+    table: null as string | null,
+    calls: [] as Array<{ method: string; args: unknown[] }>,
+  }
+
+  function nextResult(table: string): unknown {
+    const idx = dbCallCounts.get(table) ?? 0
+    dbCallCounts.set(table, idx + 1)
+    const arr = dbResultQueue.get(table)
+    if (!arr || arr.length === 0) return undefined
+    return arr[Math.min(idx, arr.length - 1)]
+  }
+
+  const mockKnex = Object.assign(
+    (table: string) => {
+      lastArgs.table = table
+      lastArgs.calls = []
+      return chain(nextResult(table), lastArgs.calls)
+    },
+    { raw: () => undefined },
+  )
+
+  return { mockKnex, dbResultQueue, dbCallCounts, lastArgs }
+})
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@/infrastructure/database/connection.js', () => ({ db: mockKnex }))
+
+// ---------------------------------------------------------------------------
+// Import module under test (after mocks are registered)
+// ---------------------------------------------------------------------------
+
+import { KnexGroupRepository } from '../../infrastructure/repositories/knex-group-repository.js'
+import type { Knex } from 'knex'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setResult(table: string, ...values: unknown[]) {
+  dbResultQueue.set(table, values)
+}
+
+function makeRepo(): KnexGroupRepository {
+  // The proxy-based mock is structurally compatible with Knex for the
+  // subset of operations the repository uses, but not nominally typed.
+  return new KnexGroupRepository(mockKnex as unknown as Knex)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('KnexGroupRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    dbResultQueue.clear()
+    dbCallCounts.clear()
+    lastArgs.table = null
+    lastArgs.calls = []
+  })
+
+  it('findById calls knex("groups").where({ id }).first() and returns the row', async () => {
+    const row = {
+      id: 'group-1',
+      name: 'Test Group',
+      created_by: 'user-1',
+      invite_token_hash: null,
+      invite_expires_at: null,
+      invite_max_uses: null,
+      invite_use_count: null,
+      common_game_threshold: null,
+      discord_channel_id: null,
+      discord_guild_id: null,
+      created_at: new Date(),
+      updated_at: new Date(),
+    }
+    setResult('groups', row)
+
+    const result = await makeRepo().findById('group-1')
+
+    expect(result).toEqual(row)
+    expect(lastArgs.table).toBe('groups')
+
+    const methods = lastArgs.calls.map(c => c.method)
+    expect(methods).toContain('where')
+    expect(methods).toContain('first')
+
+    const whereCall = lastArgs.calls.find(c => c.method === 'where')
+    expect(whereCall?.args[0]).toEqual({ id: 'group-1' })
+  })
+
+  it('findById returns null when the row is not found', async () => {
+    setResult('groups', undefined)
+
+    const result = await makeRepo().findById('missing-group')
+
+    expect(result).toBeNull()
+    expect(lastArgs.table).toBe('groups')
+  })
+})

--- a/packages/backend/src/domain/auth-service.ts
+++ b/packages/backend/src/domain/auth-service.ts
@@ -1,0 +1,118 @@
+import crypto from 'crypto'
+import { db } from '../infrastructure/database/connection.js'
+import { authLogger } from '../infrastructure/logger/logger.js'
+import { SESSION_MAX_AGE_MS, SESSION_TOKEN_BYTES } from '../config/session.js'
+
+/**
+ * Session and user management domain service.
+ *
+ * Centralises DB-touching auth logic so route handlers can focus on
+ * HTTP concerns (cookies, CSRF, redirects).
+ */
+
+/**
+ * Create a new session for a user.
+ * Generates a cryptographically random token, computes the expiry date
+ * from `SESSION_MAX_AGE_MS`, and inserts the session row.
+ */
+export async function createUserSession(
+  userId: string,
+): Promise<{ token: string; expiresAt: Date }> {
+  const token = crypto.randomBytes(SESSION_TOKEN_BYTES).toString('hex')
+  const expiresAt = new Date(Date.now() + SESSION_MAX_AGE_MS)
+
+  await db('sessions').insert({
+    user_id: userId,
+    token,
+    expires_at: expiresAt,
+  })
+
+  return { token, expiresAt }
+}
+
+/**
+ * Look up a session by its token and return the associated user ID
+ * when the session is valid (exists and not expired). Returns null otherwise.
+ */
+export async function getSessionUserId(token: string): Promise<string | null> {
+  const session = await db('sessions')
+    .where({ token })
+    .where('expires_at', '>', new Date())
+    .first()
+
+  return session?.user_id ?? null
+}
+
+/**
+ * Invalidate a session by deleting its row. Returns true when a row was
+ * deleted, false when the token was unknown.
+ */
+export async function invalidateSession(token: string): Promise<boolean> {
+  const deleted = await db('sessions').where({ token }).del()
+  return deleted > 0
+}
+
+/**
+ * Find an existing user by Steam ID or create a new one using the supplied
+ * Steam profile data. Also ensures the matching row in the `accounts` table
+ * linking the Steam provider to the user exists.
+ *
+ * Returns the user record (id, steamId, displayName, avatarUrl).
+ */
+export async function findOrCreateSteamUser(
+  steamId: string,
+  profile: { displayName: string; avatarUrl: string; profileUrl?: string },
+): Promise<{ id: string; steamId: string; displayName: string; avatarUrl: string }> {
+  let user = await db('users').where({ steam_id: steamId }).first()
+
+  if (user) {
+    // Update existing user profile with latest Steam data
+    await db('users').where({ id: user.id }).update({
+      display_name: profile.displayName,
+      avatar_url: profile.avatarUrl,
+      profile_url: profile.profileUrl ?? user.profile_url,
+      updated_at: db.fn.now(),
+    })
+  } else {
+    // Create new user
+    const [newUser] = await db('users').insert({
+      steam_id: steamId,
+      display_name: profile.displayName,
+      avatar_url: profile.avatarUrl,
+      profile_url: profile.profileUrl ?? null,
+      email: `${steamId}@steam.wawptn.app`,
+      email_verified: false,
+      library_visible: true,
+    }).returning('*')
+    user = newUser
+
+    // Create matching account link for the Steam provider
+    await db('accounts').insert({
+      user_id: user.id,
+      provider_id: 'steam',
+      account_id: steamId,
+    })
+
+    authLogger.info({ steamId, displayName: profile.displayName }, 'new user created')
+  }
+
+  // Ensure account link exists (covers pre-migration users that were created
+  // before the `accounts` table existed).
+  const existingAccount = await db('accounts')
+    .where({ user_id: user.id, provider_id: 'steam' })
+    .first()
+  if (!existingAccount) {
+    await db('accounts').insert({
+      user_id: user.id,
+      provider_id: 'steam',
+      account_id: steamId,
+    })
+  }
+
+  return {
+    id: user.id,
+    steamId: user.steam_id,
+    displayName: user.display_name,
+    avatarUrl: user.avatar_url,
+  }
+}

--- a/packages/backend/src/domain/close-session.ts
+++ b/packages/backend/src/domain/close-session.ts
@@ -1,10 +1,8 @@
 import { db } from '../infrastructure/database/connection.js'
-import { getIO } from '../infrastructure/socket/socket.js'
 import { logger } from '../infrastructure/logger/logger.js'
-import { notifyVoteClosed } from '../infrastructure/discord/notifier.js'
-import { createNotification } from '../infrastructure/notifications/notification-service.js'
 import { evaluateChallenges } from './challenges/challenge-service.js'
 import { updateStreak } from './streaks.js'
+import { domainEvents } from './events/event-bus.js'
 import type { VoteResult } from '@wawptn/types'
 
 /**
@@ -79,39 +77,19 @@ export async function closeSession(sessionId: string, groupId: string): Promise<
     totalVoters: Number(voterCount?.count || 0),
   }
 
-  // Broadcast result
-  getIO().to(`group:${groupId}`).emit('vote:closed', { sessionId, result })
-
-  // Notify Discord channel (non-blocking)
-  notifyVoteClosed(groupId, result).catch(err =>
-    logger.warn({ error: String(err), groupId }, 'Discord notification failed')
-  )
-
-  // In-app notification for group participants (non-blocking)
-  const group = await db('groups').where({ id: groupId }).first()
-  const groupName = group?.name || 'Groupe'
+  // Load participants for event payload + downstream domain logic (challenges, streaks)
   const participantIds: string[] = await db('voting_session_participants')
     .where({ session_id: sessionId })
     .pluck('user_id')
 
-  if (participantIds.length > 0 && winnerName) {
-    createNotification({
-      type: 'vote_closed',
-      title: `${winnerName} a gagné dans ${groupName} !`,
-      body: `${result.yesCount} sur ${result.totalVoters} ont voté pour.`,
-      groupId,
-      metadata: {
-        sessionId,
-        winnerAppId,
-        winnerName,
-        actionUrl: `/groups/${groupId}/vote`,
-      },
-      recipientUserIds: participantIds,
-      expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // 7 days
-    }).catch(err =>
-      logger.warn({ error: String(err), groupId }, 'in-app vote closed notification failed')
-    )
-  }
+  // Emit domain event — side effects (Socket.io, Discord, in-app notifs) are
+  // handled by subscribers registered in infrastructure/effects/session-effects.ts
+  domainEvents.emit('session:closed', {
+    sessionId,
+    groupId,
+    result,
+    participantIds,
+  })
 
   // Evaluate participation challenges for all participants (non-blocking)
   for (const pid of participantIds) {

--- a/packages/backend/src/domain/create-session.ts
+++ b/packages/backend/src/domain/create-session.ts
@@ -1,9 +1,7 @@
 import { db } from '../infrastructure/database/connection.js'
 import { computeCommonGames, type GameFilters } from '../infrastructure/database/common-games.js'
-import { getIO } from '../infrastructure/socket/socket.js'
-import { notifySessionCreated } from '../infrastructure/discord/notifier.js'
-import { createNotification } from '../infrastructure/notifications/notification-service.js'
 import { logger } from '../infrastructure/logger/logger.js'
+import { domainEvents } from './events/event-bus.js'
 
 export interface CreateSessionParams {
   groupId: string
@@ -37,7 +35,8 @@ export interface CreateSessionResult {
 /**
  * Create a voting session for a group.
  * Computes common games, sorts by popularity, inserts session + participants + games,
- * emits Socket.io event, and notifies Discord webhook.
+ * then emits a `session:created` domain event that infrastructure effects subscribe to
+ * (Socket.io, Discord webhook, in-app notifications).
  *
  * Throws on validation errors (with a `statusCode` property on the error).
  */
@@ -152,41 +151,20 @@ export async function createVotingSession(params: CreateSessionParams): Promise<
     return sess
   })
 
-  // Notify group (include participantIds so frontend can filter)
-  getIO().to(`group:${groupId}`).emit('session:created', {
+  // Emit domain event — side effects (Socket.io, Discord, in-app notifs) are
+  // handled by subscribers registered in infrastructure/effects/session-effects.ts
+  domainEvents.emit('session:created', {
     sessionId: session.id,
     groupId,
     createdBy,
     participantIds: validMembers,
-    ...(scheduledAt ? { scheduledAt: scheduledAt.toISOString() } : {}),
+    games: selectedGames.map(g => ({
+      steamAppId: g.steamAppId,
+      gameName: g.gameName,
+      headerImageUrl: g.headerImageUrl,
+    })),
+    ...(scheduledAt ? { scheduledAt } : {}),
   })
-
-  // Notify Discord channel (non-blocking)
-  notifySessionCreated(groupId, session.id, selectedGames.map(g => ({
-    gameName: g.gameName,
-    steamAppId: g.steamAppId,
-    headerImageUrl: g.headerImageUrl,
-  }))).catch(err =>
-    logger.warn({ error: String(err), groupId }, 'Discord session notification failed')
-  )
-
-  // In-app notification for participants (non-blocking)
-  const groupName = group?.name || 'Groupe'
-  const notifRecipients = validMembers.filter(uid => uid !== createdBy)
-  if (notifRecipients.length > 0) {
-    createNotification({
-      type: 'vote_opened',
-      title: `Un vote a commencé dans ${groupName}`,
-      body: `${selectedGames.length} jeux en commun sont soumis au vote.`,
-      groupId,
-      createdBy,
-      metadata: { sessionId: session.id, actionUrl: `/groups/${groupId}/vote` },
-      recipientUserIds: notifRecipients,
-      expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // 7 days
-    }).catch(err =>
-      logger.warn({ error: String(err), groupId }, 'in-app vote notification failed')
-    )
-  }
 
   logger.info({ sessionId: session.id, groupId, gameCount: selectedGames.length, participants: validMembers.length }, 'voting session created')
 

--- a/packages/backend/src/domain/events/event-bus.ts
+++ b/packages/backend/src/domain/events/event-bus.ts
@@ -1,0 +1,50 @@
+import { EventEmitter } from 'node:events'
+import type { VoteResult } from '@wawptn/types'
+
+export interface SessionCreatedEvent {
+  sessionId: string
+  groupId: string
+  createdBy: string
+  participantIds: string[]
+  games: Array<{ steamAppId: number; gameName: string; headerImageUrl: string | null }>
+  scheduledAt?: Date
+}
+
+export interface SessionClosedEvent {
+  sessionId: string
+  groupId: string
+  result: VoteResult
+  participantIds: string[]
+}
+
+export interface ChallengeUnlockedEvent {
+  userId: string
+  challengeId: string
+  challengeName: string
+  tier: string
+}
+
+// Strongly typed EventEmitter wrapper
+export interface DomainEventMap {
+  'session:created': [SessionCreatedEvent]
+  'session:closed': [SessionClosedEvent]
+  'challenge:unlocked': [ChallengeUnlockedEvent]
+}
+
+class DomainEventBus extends EventEmitter {
+  emit<K extends keyof DomainEventMap>(event: K, ...args: DomainEventMap[K]): boolean {
+    return super.emit(event, ...args)
+  }
+
+  on<K extends keyof DomainEventMap>(event: K, listener: (...args: DomainEventMap[K]) => void): this {
+    return super.on(event, listener)
+  }
+
+  off<K extends keyof DomainEventMap>(event: K, listener: (...args: DomainEventMap[K]) => void): this {
+    return super.off(event, listener)
+  }
+}
+
+// Singleton domain event bus
+export const domainEvents = new DomainEventBus()
+domainEvents.setMaxListeners(50)

--- a/packages/backend/src/domain/repositories/group-repository.ts
+++ b/packages/backend/src/domain/repositories/group-repository.ts
@@ -1,0 +1,45 @@
+/**
+ * Group repository interface — abstracts group and membership persistence
+ * so domain/application code does not depend directly on Knex/Postgres.
+ *
+ * Concrete implementations live under `src/infrastructure/repositories/`.
+ */
+
+export interface GroupRow {
+  id: string
+  name: string
+  created_by: string
+  invite_token_hash: string | null
+  invite_expires_at: Date | null
+  invite_max_uses: number | null
+  invite_use_count: number | null
+  common_game_threshold: number | null
+  discord_channel_id: string | null
+  discord_guild_id: string | null
+  created_at: Date
+  updated_at: Date
+}
+
+export interface GroupMemberRow {
+  group_id: string
+  user_id: string
+  role: 'owner' | 'member'
+  joined_at: Date
+}
+
+export interface IGroupRepository {
+  /** Find a single group by its UUID. Returns `null` when not found. */
+  findById(id: string): Promise<GroupRow | null>
+
+  /** Find a group linked to a given Discord channel. Returns `null` when not found. */
+  findByDiscordChannel(channelId: string): Promise<GroupRow | null>
+
+  /** List all memberships for a group, ordered by `joined_at` ascending. */
+  findMembersByGroupId(groupId: string): Promise<GroupMemberRow[]>
+
+  /** Look up a specific (group, user) membership row. Returns `null` when absent. */
+  findMembership(groupId: string, userId: string): Promise<GroupMemberRow | null>
+
+  /** List every group the given user is a member of, newest first. */
+  listUserGroups(userId: string): Promise<GroupRow[]>
+}

--- a/packages/backend/src/domain/repositories/vote-repository.ts
+++ b/packages/backend/src/domain/repositories/vote-repository.ts
@@ -1,0 +1,55 @@
+/**
+ * Vote repository interface — abstracts voting session and vote persistence
+ * so domain/application code does not depend directly on Knex/Postgres.
+ *
+ * Concrete implementations live under `src/infrastructure/repositories/`.
+ */
+
+export interface VotingSessionRow {
+  id: string
+  group_id: string
+  status: 'open' | 'closed'
+  created_by: string
+  winning_game_app_id: number | null
+  winning_game_id: string | null
+  winning_game_name: string | null
+  scheduled_at: Date | null
+  closed_at: Date | null
+  created_at: Date
+}
+
+export interface VoteRow {
+  session_id: string
+  user_id: string
+  steam_app_id: number
+  game_id: string | null
+  vote: boolean
+  created_at: Date
+}
+
+export interface IVoteRepository {
+  /** Return the currently open voting session for a group, or `null`. */
+  findOpenSession(groupId: string): Promise<VotingSessionRow | null>
+
+  /** Look up a voting session by id. Returns `null` when not found. */
+  findSessionById(id: string): Promise<VotingSessionRow | null>
+
+  /**
+   * List closed voting sessions for a group in reverse-chronological order,
+   * with pagination.
+   */
+  listClosedSessions(
+    groupId: string,
+    limit: number,
+    offset: number,
+  ): Promise<VotingSessionRow[]>
+
+  /** Count closed voting sessions for a group (useful for pagination). */
+  countClosedSessions(groupId: string): Promise<number>
+
+  /** Return every vote row belonging to a session. */
+  findVotesBySession(sessionId: string): Promise<VoteRow[]>
+
+  /** Count distinct users that have voted in a session. */
+  countVotersBySession(sessionId: string): Promise<number>
+}

--- a/packages/backend/src/domain/streaks.ts
+++ b/packages/backend/src/domain/streaks.ts
@@ -1,7 +1,21 @@
 import { db } from '../infrastructure/database/connection.js'
 import { logger } from '../infrastructure/logger/logger.js'
+import type { IGroupRepository } from './repositories/group-repository.js'
 
 const streakLogger = logger.child({ module: 'streaks' })
+
+/**
+ * Optional dependencies for streak functions.
+ *
+ * This is a proof-of-concept for dependency injection via the repository
+ * layer. For now the implementations still access `db` directly; future
+ * passes will progressively route queries through `deps.groupRepository`
+ * (and siblings) so these functions can be unit-tested without a real
+ * database.
+ */
+export interface StreakDeps {
+  groupRepository?: IGroupRepository
+}
 
 /**
  * Update a user's voting streak for a group after a session closes.
@@ -20,6 +34,7 @@ export async function updateStreak(
   userId: string,
   groupId: string,
   sessionId: string,
+  _deps: StreakDeps = {},
 ): Promise<void> {
   // Find the session that closed immediately before this one in the same group
   const previousSession = await db('voting_sessions')

--- a/packages/backend/src/domain/subscription-service.ts
+++ b/packages/backend/src/domain/subscription-service.ts
@@ -1,0 +1,55 @@
+import { db } from '../infrastructure/database/connection.js'
+
+/** Tier limits for free users */
+export const FREE_TIER_LIMITS = {
+  maxGroups: 2,
+  maxMembersPerGroup: 8,
+} as const
+
+/** Tier limits for premium users */
+export const PREMIUM_TIER_LIMITS = {
+  maxMembersPerGroup: 20,
+} as const
+
+/** In-memory cache for premium status with TTL */
+interface CacheEntry {
+  value: boolean
+  expiresAt: number
+}
+
+const PREMIUM_CACHE_TTL_MS = 60_000 // 60 seconds
+const premiumCache = new Map<string, CacheEntry>()
+
+/** Evict expired entries periodically to prevent unbounded growth */
+const EVICTION_INTERVAL_MS = 5 * 60_000 // 5 minutes
+setInterval(() => {
+  const now = Date.now()
+  for (const [key, entry] of premiumCache) {
+    if (entry.expiresAt <= now) premiumCache.delete(key)
+  }
+}, EVICTION_INTERVAL_MS).unref()
+
+/** Check if a user has an active premium subscription (cached, 60s TTL) */
+export async function isUserPremium(userId: string): Promise<boolean> {
+  const now = Date.now()
+  const cached = premiumCache.get(userId)
+  if (cached && cached.expiresAt > now) return cached.value
+
+  const subscription = await db('subscriptions')
+    .where({ user_id: userId })
+    .select('tier', 'status', 'current_period_end')
+    .first()
+
+  let premium = true
+  if (!subscription || subscription.tier !== 'premium') premium = false
+  else if (subscription.status !== 'active') premium = false
+  else if (subscription.current_period_end && new Date(subscription.current_period_end) < new Date()) premium = false
+
+  premiumCache.set(userId, { value: premium, expiresAt: now + PREMIUM_CACHE_TTL_MS })
+  return premium
+}
+
+/** Invalidate the cache for a specific user (call when subscription changes) */
+export function invalidatePremiumCache(userId: string): void {
+  premiumCache.delete(userId)
+}

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -28,6 +28,7 @@ import { personaRoutes } from './presentation/routes/persona.routes.js'
 import { notificationRoutes, adminNotificationRoutes } from './presentation/routes/notification.routes.js'
 import { challengeRoutes } from './presentation/routes/challenge.routes.js'
 import { startNotificationCleanup } from './infrastructure/notifications/notification-cleanup.js'
+import { registerSessionEffects } from './infrastructure/effects/session-effects.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -179,6 +180,10 @@ async function main() {
 
   // Socket.io
   createSocketServer(httpServer)
+
+  // Register domain event subscribers for session side effects
+  // (Socket.io emissions, Discord webhooks, in-app notifications)
+  registerSessionEffects()
 
   // Vote scheduler (auto-close scheduled sessions)
   startVoteScheduler()

--- a/packages/backend/src/infrastructure/effects/session-effects.ts
+++ b/packages/backend/src/infrastructure/effects/session-effects.ts
@@ -1,0 +1,96 @@
+// This file subscribes to domain events and triggers the appropriate side effects.
+// It's the ONLY place where domain events get translated to Socket.io, Discord, and notifications.
+
+import { domainEvents } from '../../domain/events/event-bus.js'
+import { getIO } from '../socket/socket.js'
+import { notifySessionCreated, notifyVoteClosed } from '../discord/notifier.js'
+import { createNotification } from '../notifications/notification-service.js'
+import { logger } from '../logger/logger.js'
+import { db } from '../database/connection.js'
+
+export function registerSessionEffects(): void {
+  domainEvents.on('session:created', async (event) => {
+    // Emit Socket.io event
+    try {
+      getIO().to(`group:${event.groupId}`).emit('session:created', {
+        sessionId: event.sessionId,
+        groupId: event.groupId,
+        createdBy: event.createdBy,
+        participantIds: event.participantIds,
+        ...(event.scheduledAt ? { scheduledAt: event.scheduledAt.toISOString() } : {}),
+      })
+    } catch (err) {
+      logger.warn({ error: String(err), groupId: event.groupId }, 'socket emit session:created failed')
+    }
+
+    // Send Discord webhook (non-blocking)
+    notifySessionCreated(event.groupId, event.sessionId, event.games).catch((err) =>
+      logger.warn({ error: String(err), groupId: event.groupId }, 'Discord session notification failed')
+    )
+
+    // In-app notifications
+    try {
+      const group = await db('groups').where({ id: event.groupId }).first()
+      const groupName = group?.name || 'Groupe'
+      const recipients = event.participantIds.filter((uid) => uid !== event.createdBy)
+      if (recipients.length > 0) {
+        createNotification({
+          type: 'vote_opened',
+          title: `Un vote a commencé dans ${groupName}`,
+          body: `${event.games.length} jeux en commun sont soumis au vote.`,
+          groupId: event.groupId,
+          createdBy: event.createdBy,
+          metadata: { sessionId: event.sessionId, actionUrl: `/groups/${event.groupId}/vote` },
+          recipientUserIds: recipients,
+          expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+        }).catch((err) =>
+          logger.warn({ error: String(err), groupId: event.groupId }, 'in-app vote notification failed')
+        )
+      }
+    } catch (err) {
+      logger.warn({ error: String(err), groupId: event.groupId }, 'failed to load group for notification')
+    }
+  })
+
+  domainEvents.on('session:closed', async (event) => {
+    // Emit Socket.io event
+    try {
+      getIO().to(`group:${event.groupId}`).emit('vote:closed', { sessionId: event.sessionId, result: event.result })
+    } catch (err) {
+      logger.warn({ error: String(err), groupId: event.groupId }, 'socket emit vote:closed failed')
+    }
+
+    // Discord webhook
+    notifyVoteClosed(event.groupId, event.result).catch((err) =>
+      logger.warn({ error: String(err), groupId: event.groupId }, 'Discord notification failed')
+    )
+
+    // In-app notification
+    try {
+      const group = await db('groups').where({ id: event.groupId }).first()
+      const groupName = group?.name || 'Groupe'
+      if (event.participantIds.length > 0 && event.result.gameName && event.result.gameName !== 'Unknown') {
+        createNotification({
+          type: 'vote_closed',
+          title: `${event.result.gameName} a gagné dans ${groupName} !`,
+          body: `${event.result.yesCount} sur ${event.result.totalVoters} ont voté pour.`,
+          groupId: event.groupId,
+          metadata: {
+            sessionId: event.sessionId,
+            winnerAppId: event.result.steamAppId,
+            winnerName: event.result.gameName,
+            actionUrl: `/groups/${event.groupId}/vote`,
+          },
+          recipientUserIds: event.participantIds,
+          expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+        }).catch((err) =>
+          logger.warn({ error: String(err), groupId: event.groupId }, 'in-app vote closed notification failed')
+        )
+      }
+    } catch (err) {
+      logger.warn({ error: String(err), groupId: event.groupId }, 'failed to load group for closed notification')
+    }
+  })
+
+  logger.info('session effects registered')
+}

--- a/packages/backend/src/infrastructure/repositories/knex-group-repository.ts
+++ b/packages/backend/src/infrastructure/repositories/knex-group-repository.ts
@@ -1,0 +1,56 @@
+import type { Knex } from 'knex'
+import { db } from '../database/connection.js'
+import type {
+  IGroupRepository,
+  GroupRow,
+  GroupMemberRow,
+} from '../../domain/repositories/group-repository.js'
+
+/**
+ * Knex-backed implementation of `IGroupRepository`.
+ *
+ * The `knex` instance is injected (defaulting to the shared `db` singleton),
+ * which lets callers pass a transaction (`trx`) or a test double.
+ */
+export class KnexGroupRepository implements IGroupRepository {
+  constructor(private readonly knex: Knex = db) {}
+
+  async findById(id: string): Promise<GroupRow | null> {
+    const row = await this.knex<GroupRow>('groups').where({ id }).first()
+    return row ?? null
+  }
+
+  async findByDiscordChannel(channelId: string): Promise<GroupRow | null> {
+    const row = await this.knex<GroupRow>('groups')
+      .where({ discord_channel_id: channelId })
+      .first()
+    return row ?? null
+  }
+
+  async findMembersByGroupId(groupId: string): Promise<GroupMemberRow[]> {
+    return this.knex<GroupMemberRow>('group_members')
+      .where({ group_id: groupId })
+      .orderBy('joined_at', 'asc')
+  }
+
+  async findMembership(
+    groupId: string,
+    userId: string,
+  ): Promise<GroupMemberRow | null> {
+    const row = await this.knex<GroupMemberRow>('group_members')
+      .where({ group_id: groupId, user_id: userId })
+      .first()
+    return row ?? null
+  }
+
+  async listUserGroups(userId: string): Promise<GroupRow[]> {
+    return this.knex<GroupRow>('groups')
+      .join('group_members', 'group_members.group_id', 'groups.id')
+      .where('group_members.user_id', userId)
+      .select('groups.*')
+      .orderBy('groups.created_at', 'desc')
+  }
+}
+
+/** Default singleton bound to the shared `db` connection. */
+export const groupRepository: IGroupRepository = new KnexGroupRepository()

--- a/packages/backend/src/infrastructure/repositories/knex-vote-repository.ts
+++ b/packages/backend/src/infrastructure/repositories/knex-vote-repository.ts
@@ -1,0 +1,66 @@
+import type { Knex } from 'knex'
+import { db } from '../database/connection.js'
+import type {
+  IVoteRepository,
+  VotingSessionRow,
+  VoteRow,
+} from '../../domain/repositories/vote-repository.js'
+
+/**
+ * Knex-backed implementation of `IVoteRepository`.
+ *
+ * The `knex` instance is injected (defaulting to the shared `db` singleton),
+ * which lets callers pass a transaction (`trx`) or a test double.
+ */
+export class KnexVoteRepository implements IVoteRepository {
+  constructor(private readonly knex: Knex = db) {}
+
+  async findOpenSession(groupId: string): Promise<VotingSessionRow | null> {
+    const row = await this.knex<VotingSessionRow>('voting_sessions')
+      .where({ group_id: groupId, status: 'open' })
+      .first()
+    return row ?? null
+  }
+
+  async findSessionById(id: string): Promise<VotingSessionRow | null> {
+    const row = await this.knex<VotingSessionRow>('voting_sessions')
+      .where({ id })
+      .first()
+    return row ?? null
+  }
+
+  async listClosedSessions(
+    groupId: string,
+    limit: number,
+    offset: number,
+  ): Promise<VotingSessionRow[]> {
+    return this.knex<VotingSessionRow>('voting_sessions')
+      .where({ group_id: groupId, status: 'closed' })
+      .orderBy('closed_at', 'desc')
+      .limit(limit)
+      .offset(offset)
+  }
+
+  async countClosedSessions(groupId: string): Promise<number> {
+    const row = await this.knex('voting_sessions')
+      .where({ group_id: groupId, status: 'closed' })
+      .count<{ count: string | number }>('* as count')
+      .first()
+    return Number(row?.count ?? 0)
+  }
+
+  async findVotesBySession(sessionId: string): Promise<VoteRow[]> {
+    return this.knex<VoteRow>('votes').where({ session_id: sessionId })
+  }
+
+  async countVotersBySession(sessionId: string): Promise<number> {
+    const row = await this.knex('votes')
+      .where({ session_id: sessionId })
+      .countDistinct<{ count: string | number }>('user_id as count')
+      .first()
+    return Number(row?.count ?? 0)
+  }
+}
+
+/** Default singleton bound to the shared `db` connection. */
+export const voteRepository: IVoteRepository = new KnexVoteRepository()

--- a/packages/backend/src/presentation/middleware/group-membership.middleware.ts
+++ b/packages/backend/src/presentation/middleware/group-membership.middleware.ts
@@ -1,0 +1,77 @@
+import type { Request, Response, NextFunction, RequestHandler } from 'express'
+import { db } from '../../infrastructure/database/connection.js'
+import { authLogger } from '../../infrastructure/logger/logger.js'
+
+// Extend Express Request with the resolved group membership
+declare global {
+  namespace Express {
+    interface Request {
+      membership?: {
+        role: 'owner' | 'member'
+        groupId: string
+      }
+    }
+  }
+}
+
+interface GroupMembershipRow {
+  group_id: string
+  user_id: string
+  role: 'owner' | 'member'
+  joined_at: Date
+  notifications_enabled: boolean
+}
+
+interface RequireGroupMembershipOptions {
+  /** If set, requires the user to have this role in the group */
+  role?: 'owner'
+  /** Request param name that holds the group id. Defaults to `'id'`. */
+  paramName?: string
+}
+
+/**
+ * Express middleware — verifies the authenticated user is a member of the
+ * group referenced by the route param (default: `:id`). On success, attaches
+ * `req.membership = { role, groupId }` for downstream handlers.
+ *
+ * Must be mounted after `requireAuth` so `req.userId` is populated.
+ */
+export function requireGroupMembership(options: RequireGroupMembershipOptions = {}): RequestHandler {
+  const paramName = options.paramName ?? 'id'
+  const requiredRole = options.role
+
+  return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      const userId = req.userId!
+      const groupId = String(req.params[paramName] ?? '')
+
+      if (!groupId) {
+        res.status(400).json({ error: 'validation', message: `Missing group id param '${paramName}'` })
+        return
+      }
+
+      const membership = await db<GroupMembershipRow>('group_members')
+        .where({ group_id: groupId, user_id: userId })
+        .first()
+
+      if (!membership) {
+        res.status(403).json({ error: 'forbidden', message: 'Not a member' })
+        return
+      }
+
+      if (requiredRole && membership.role !== requiredRole) {
+        res.status(403).json({ error: 'forbidden', message: 'Only group owner can perform this action' })
+        return
+      }
+
+      req.membership = { role: membership.role, groupId }
+      next()
+    } catch (error) {
+      authLogger.error(
+        { error: String(error), path: req.path },
+        'group membership middleware: database error'
+      )
+      res.status(403).json({ error: 'forbidden', message: 'Not a member' })
+    }
+  }
+}

--- a/packages/backend/src/presentation/middleware/tier.middleware.ts
+++ b/packages/backend/src/presentation/middleware/tier.middleware.ts
@@ -1,55 +1,13 @@
 import type { Request, Response, NextFunction } from 'express'
-import { db } from '../../infrastructure/database/connection.js'
 import { authLogger } from '../../infrastructure/logger/logger.js'
+import { isUserPremium } from '../../domain/subscription-service.js'
 
-/** Tier limits for free users */
-export const FREE_TIER_LIMITS = {
-  maxGroups: 2,
-  maxMembersPerGroup: 8,
-} as const
-
-/** Tier limits for premium users */
-export const PREMIUM_TIER_LIMITS = {
-  maxMembersPerGroup: 20,
-} as const
-
-/** In-memory cache for premium status with TTL */
-interface CacheEntry {
-  value: boolean
-  expiresAt: number
-}
-
-const PREMIUM_CACHE_TTL_MS = 60_000 // 60 seconds
-const premiumCache = new Map<string, CacheEntry>()
-
-/** Evict expired entries periodically to prevent unbounded growth */
-const EVICTION_INTERVAL_MS = 5 * 60_000 // 5 minutes
-setInterval(() => {
-  const now = Date.now()
-  for (const [key, entry] of premiumCache) {
-    if (entry.expiresAt <= now) premiumCache.delete(key)
-  }
-}, EVICTION_INTERVAL_MS).unref()
-
-/** Check if a user has an active premium subscription (cached, 60s TTL) */
-export async function isUserPremium(userId: string): Promise<boolean> {
-  const now = Date.now()
-  const cached = premiumCache.get(userId)
-  if (cached && cached.expiresAt > now) return cached.value
-
-  const subscription = await db('subscriptions')
-    .where({ user_id: userId })
-    .select('tier', 'status', 'current_period_end')
-    .first()
-
-  let premium = true
-  if (!subscription || subscription.tier !== 'premium') premium = false
-  else if (subscription.status !== 'active') premium = false
-  else if (subscription.current_period_end && new Date(subscription.current_period_end) < new Date()) premium = false
-
-  premiumCache.set(userId, { value: premium, expiresAt: now + PREMIUM_CACHE_TTL_MS })
-  return premium
-}
+// Re-export domain primitives for backwards compatibility with existing imports
+export {
+  isUserPremium,
+  FREE_TIER_LIMITS,
+  PREMIUM_TIER_LIMITS,
+} from '../../domain/subscription-service.js'
 
 /** Express middleware — blocks request if user is not premium */
 export async function requirePremium(req: Request, res: Response, next: NextFunction): Promise<void> {

--- a/packages/backend/src/presentation/routes/auth.routes.ts
+++ b/packages/backend/src/presentation/routes/auth.routes.ts
@@ -8,7 +8,8 @@ import { encryptToken } from '../../infrastructure/crypto/token-cipher.js'
 import { authLogger, steamLogger, epicLogger, gogLogger } from '../../infrastructure/logger/logger.js'
 import { env } from '../../config/env.js'
 import { requireAuth } from '../middleware/auth.middleware.js'
-import { SESSION_COOKIE_NAME, SESSION_MAX_AGE_MS, SESSION_TOKEN_BYTES, CSRF_COOKIE_NAME } from '../../config/session.js'
+import { SESSION_COOKIE_NAME, CSRF_COOKIE_NAME } from '../../config/session.js'
+import { createUserSession, getSessionUserId, findOrCreateSteamUser } from '../../domain/auth-service.js'
 
 const EPIC_LINK_STATE_COOKIE = 'wawptn.epic_link_state'
 const GOG_LINK_STATE_COOKIE = 'wawptn.gog_link_state'
@@ -19,30 +20,6 @@ const router = Router()
 function isAllowedReturnPath(path: string): boolean {
   return /^\/join\/[a-f0-9]{64}$/.test(path)
     || /^\/discord\/link\?code=[A-Za-z0-9]+$/.test(path)
-}
-
-// Create a session for a user and return the token
-async function createSession(userId: string): Promise<{ token: string; expiresAt: Date }> {
-  const token = crypto.randomBytes(SESSION_TOKEN_BYTES).toString('hex')
-  const expiresAt = new Date(Date.now() + SESSION_MAX_AGE_MS)
-
-  await db('sessions').insert({
-    user_id: userId,
-    token,
-    expires_at: expiresAt,
-  })
-
-  return { token, expiresAt }
-}
-
-// Look up session by token, return user ID if valid
-async function getSessionUserId(token: string): Promise<string | null> {
-  const session = await db('sessions')
-    .where({ token })
-    .where('expires_at', '>', new Date())
-    .first()
-
-  return session?.user_id ?? null
 }
 
 // Initiate Steam OpenID login
@@ -114,60 +91,24 @@ router.get('/steam/callback', async (req: Request, res: Response) => {
       return
     }
 
-    // Find or create user via direct DB queries
-    let user = await db('users').where({ steam_id: steamId }).first()
-
-    if (user) {
-      // Update existing user profile
-      await db('users').where({ id: user.id }).update({
-        display_name: profile.personaname,
-        avatar_url: profile.avatarfull,
-        profile_url: profile.profileurl,
-        updated_at: db.fn.now(),
-      })
-    } else {
-      // Create new user
-      const [newUser] = await db('users').insert({
-        steam_id: steamId,
-        display_name: profile.personaname,
-        avatar_url: profile.avatarfull,
-        profile_url: profile.profileurl,
-        email: `${steamId}@steam.wawptn.app`,
-        email_verified: false,
-        library_visible: true,
-      }).returning('*')
-      user = newUser
-
-      // Create account link
-      await db('accounts').insert({
-        user_id: user.id,
-        provider_id: 'steam',
-        account_id: steamId,
-      })
-
-      authLogger.info({ steamId, displayName: profile.personaname }, 'new user created')
-    }
+    // Find or create the user via the auth domain service
+    const user = await findOrCreateSteamUser(steamId, {
+      displayName: profile.personaname,
+      avatarUrl: profile.avatarfull,
+      profileUrl: profile.profileurl,
+    })
 
     // Admin promotion: set is_admin based on ADMIN_STEAM_ID env var
-    if (env.ADMIN_STEAM_ID && steamId === env.ADMIN_STEAM_ID && !user.is_admin) {
-      await db('users').where({ id: user.id }).update({ is_admin: true })
-      authLogger.info({ steamId }, 'admin status granted on login')
-    }
-
-    // Ensure account link exists (for pre-migration users)
-    const existingAccount = await db('accounts')
-      .where({ user_id: user.id, provider_id: 'steam' })
-      .first()
-    if (!existingAccount) {
-      await db('accounts').insert({
-        user_id: user.id,
-        provider_id: 'steam',
-        account_id: steamId,
-      })
+    if (env.ADMIN_STEAM_ID && steamId === env.ADMIN_STEAM_ID) {
+      const existing = await db('users').where({ id: user.id }).first()
+      if (existing && !existing.is_admin) {
+        await db('users').where({ id: user.id }).update({ is_admin: true })
+        authLogger.info({ steamId }, 'admin status granted on login')
+      }
     }
 
     // Create session
-    const session = await createSession(user.id)
+    const session = await createUserSession(user.id)
 
     // Set signed session cookie
     res.cookie(SESSION_COOKIE_NAME, session.token, {

--- a/packages/backend/src/presentation/routes/group.routes.ts
+++ b/packages/backend/src/presentation/routes/group.routes.ts
@@ -8,6 +8,7 @@ import { getIO, forceLeaveRoom } from '../../infrastructure/socket/socket.js'
 import { updateGroupSchedule } from '../../infrastructure/scheduler/auto-vote-scheduler.js'
 import { logger } from '../../infrastructure/logger/logger.js'
 import { isUserPremium, FREE_TIER_LIMITS, PREMIUM_TIER_LIMITS } from '../middleware/tier.middleware.js'
+import { requireGroupMembership } from '../middleware/group-membership.middleware.js'
 
 const router = Router()
 
@@ -88,19 +89,8 @@ router.get('/', async (req: Request, res: Response) => {
 })
 
 // Get group detail with members
-router.get('/:id', async (req: Request, res: Response) => {
-  const userId = req.userId!
+router.get('/:id', requireGroupMembership(), async (req: Request, res: Response) => {
   const groupId = String(req.params['id'])
-
-  // Verify membership
-  const membership = await db('group_members')
-    .where({ group_id: groupId, user_id: userId })
-    .first()
-
-  if (!membership) {
-    res.status(403).json({ error: 'forbidden', message: 'Not a member of this group' })
-    return
-  }
 
   const group = await db('groups').where({ id: groupId }).first()
   if (!group) {
@@ -187,7 +177,7 @@ router.post('/', async (req: Request, res: Response) => {
 })
 
 // Rename group (owner only)
-router.patch('/:id', async (req: Request, res: Response) => {
+router.patch('/:id', requireGroupMembership({ role: 'owner' }), async (req: Request, res: Response) => {
   const userId = req.userId!
   const groupId = String(req.params['id'])
   const { name } = req.body as { name: string }
@@ -199,15 +189,6 @@ router.patch('/:id', async (req: Request, res: Response) => {
 
   if (name.trim().length > 100) {
     res.status(400).json({ error: 'validation', message: 'Group name must be 100 characters or less' })
-    return
-  }
-
-  const membership = await db('group_members')
-    .where({ group_id: groupId, user_id: userId, role: 'owner' })
-    .first()
-
-  if (!membership) {
-    res.status(403).json({ error: 'forbidden', message: 'Only the group owner can rename the group' })
     return
   }
 
@@ -225,22 +206,13 @@ router.patch('/:id', async (req: Request, res: Response) => {
 })
 
 // Toggle Discord notifications for current user
-router.patch('/:id/notifications', async (req: Request, res: Response) => {
+router.patch('/:id/notifications', requireGroupMembership(), async (req: Request, res: Response) => {
   const userId = req.userId!
   const groupId = String(req.params['id'])
   const { enabled } = req.body as { enabled: boolean }
 
   if (typeof enabled !== 'boolean') {
     res.status(400).json({ error: 'validation', message: 'enabled must be a boolean' })
-    return
-  }
-
-  const membership = await db('group_members')
-    .where({ group_id: groupId, user_id: userId })
-    .first()
-
-  if (!membership) {
-    res.status(403).json({ error: 'forbidden', message: 'Not a member of this group' })
     return
   }
 
@@ -947,19 +919,9 @@ router.get('/:id/recommendations', async (req: Request, res: Response) => {
 })
 
 // Get member leaderboard/rankings for a group
-router.get('/:id/leaderboard', async (req: Request, res: Response) => {
+router.get('/:id/leaderboard', requireGroupMembership(), async (req: Request, res: Response) => {
   try {
-    const userId = req.userId!
     const groupId = String(req.params['id'])
-
-    const membership = await db('group_members')
-      .where({ group_id: groupId, user_id: userId })
-      .first()
-
-    if (!membership) {
-      res.status(403).json({ error: 'forbidden', message: 'Not a member' })
-      return
-    }
 
     // Total votes cast per member in this group's closed sessions
     const memberVotes = await db('votes')
@@ -1012,19 +974,9 @@ router.get('/:id/leaderboard', async (req: Request, res: Response) => {
 })
 
 // Get voting streaks for a group
-router.get('/:id/streaks', async (req: Request, res: Response) => {
+router.get('/:id/streaks', requireGroupMembership(), async (req: Request, res: Response) => {
   try {
-    const userId = req.userId!
     const groupId = String(req.params['id'])
-
-    const membership = await db('group_members')
-      .where({ group_id: groupId, user_id: userId })
-      .first()
-
-    if (!membership) {
-      res.status(403).json({ error: 'forbidden', message: 'Not a member of this group' })
-      return
-    }
 
     const { getGroupStreaks } = await import('../../domain/streaks.js')
     const streaks = await getGroupStreaks(groupId)


### PR DESCRIPTION
## Summary

Comprehensive refactor addressing Separation of Concerns and SOLID principle violations identified in the earlier architecture audit. Split into 3 phases:

### Phase 1 — Service extraction
- **`refactor(backend): extract subscription service from tier middleware`** — Moves `isUserPremium()`, cache, and tier limits from `tier.middleware.ts` to `domain/subscription-service.ts`. Middleware is re-exported for backwards compatibility.
- **`refactor(backend): extract requireGroupMembership middleware`** — New `group-membership.middleware.ts` replaces 5+ duplicated membership checks in route handlers. Supports optional `role` param for owner-only routes.
- **`refactor(backend): extract auth service for session management`** — New `domain/auth-service.ts` with `createUserSession`, `getSessionUserId`, `invalidateSession`, `findOrCreateSteamUser`. Cleans up `auth.routes.ts` — HTTP concerns stay in routes, domain logic in service.

### Phase 2 — Repository layer
- **`refactor(backend): add repository layer for groups and voting sessions`** — New `domain/repositories/` (interfaces) + `infrastructure/repositories/` (Knex implementations). Includes `KnexGroupRepository` and `KnexVoteRepository` with DI-ready constructors. Adds proof-of-concept unit tests that mock the `knex` function (no real DB needed). This establishes the abstraction boundary — routes can migrate incrementally.

### Phase 3 — Domain event bus
- **`refactor(backend): introduce domain event bus for session side effects`** — New `domain/events/event-bus.ts` with typed `DomainEventBus` extending `EventEmitter`. New `infrastructure/effects/session-effects.ts` subscribes to events and dispatches Socket.io, Discord, and in-app notifications. `create-session.ts` and `close-session.ts` no longer import `getIO`, `notifySessionCreated`, `notifyVoteClosed`, or `createNotification` — they emit a single domain event instead. Domain logic is now channel-agnostic (OCP: adding a new notification channel requires zero changes to domain code).

## Architectural impact

**Before:** Route handlers and domain functions directly imported `db`, `getIO`, Discord notifier, etc. Unit testing domain logic required a real database.

**After:**
- Domain membership checks live in one place (middleware)
- Subscription and session logic live in domain services, not routes/middleware
- Repository interfaces abstract database access (adopters can inject mocks)
- Domain side effects are decoupled via event bus (OCP-compliant extension)

All remaining `db()` calls in route handlers can be migrated to repositories incrementally. The infrastructure is now in place.

## Test plan

- [x] `npm run build:types` — clean
- [x] `npx tsc --noEmit -p packages/backend/tsconfig.json` — clean (0 errors)
- [x] `cd packages/backend && npx vitest run` — 14/14 tests pass (+2 new repository tests)
- [ ] Smoke test: create a voting session, close it, verify Socket.io/Discord/in-app notifications still fire (via event bus subscribers)
- [ ] Smoke test: verify existing membership-protected endpoints still return 403 for non-members

https://claude.ai/code/session_017mwHHRMym5m5pbWVFyZwjP