### PR TITLE
fix(frontend): prevent horizontal overflow on group detail page (mobile)

### DIFF
--- a/packages/frontend/src/components/app-footer.tsx
+++ b/packages/frontend/src/components/app-footer.tsx
@@ -6,9 +6,9 @@ export function AppFooter() {
 
   return (
     <footer className="border-t border-white/[0.04] px-4 py-6 mt-auto">
-      <div className="max-w-5xl mx-auto flex items-center justify-center gap-2.5 text-xs text-muted-foreground/50">
-        <WawptnLogo size={16} className="text-muted-foreground/50" />
-        <span>
+      <div className="max-w-5xl mx-auto flex flex-wrap items-center justify-center gap-x-2 gap-y-1 text-xs text-muted-foreground/50 text-center">
+        <WawptnLogo size={16} className="text-muted-foreground/50 shrink-0" />
+        <span className="break-words min-w-0">
           WAWPTN — {t('app.tagline')} — v{__APP_VERSION__} — {new Date(__BUILD_TIME__).toLocaleDateString('fr-FR', { day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit' })}
         </span>
       </div>

--- a/packages/frontend/src/components/app-header.tsx
+++ b/packages/frontend/src/components/app-header.tsx
@@ -50,21 +50,21 @@ export function AppHeader({ children, className, maxWidth = 'narrow' }: AppHeade
       <a href="#main-content" className="sr-only focus:not-sr-only focus:absolute focus:z-[60] focus:bg-primary focus:text-primary-foreground focus:px-4 focus:py-2 focus:rounded-md">
         {t('app.skipToContent', 'Skip to content')}
       </a>
-      <nav className={cn('mx-auto flex h-14 items-center px-[max(1rem,env(safe-area-inset-left))]', maxWidth === 'wide' ? 'max-w-6xl' : 'max-w-2xl')} style={{ paddingRight: 'max(1rem, env(safe-area-inset-right))' }} aria-label={t('app.name')}>
+      <nav className={cn('mx-auto flex h-14 items-center gap-1 px-[max(0.75rem,env(safe-area-inset-left))]', maxWidth === 'wide' ? 'max-w-6xl' : 'max-w-2xl')} style={{ paddingRight: 'max(0.75rem, env(safe-area-inset-right))' }} aria-label={t('app.name')}>
         {children && (
-          <div className="mr-2 flex items-center">
+          <div className="flex items-center min-w-0 flex-1 sm:flex-initial">
             {children}
           </div>
         )}
         <button
           onClick={() => navigate('/')}
-          className="flex items-center gap-2 hover:opacity-80 transition-opacity"
+          className="flex items-center gap-2 hover:opacity-80 transition-opacity shrink-0"
           aria-label={t('app.name') + ' — ' + t('app.tagline')}
         >
           <WawptnLogo size={28} className="text-primary" />
-          <span className="font-heading font-bold text-lg tracking-[-0.03em]">WAWPTN</span>
+          <span className={cn('font-heading font-bold text-lg tracking-[-0.03em]', children ? 'hidden sm:inline' : 'inline')}>WAWPTN</span>
         </button>
-        <div className="flex-1" />
+        <div className={cn('flex-1', children && 'hidden sm:block')} />
 
         {/* Today's bot persona */}
         {user && <PersonaBadge />}

--- a/packages/frontend/src/components/game-grid.tsx
+++ b/packages/frontend/src/components/game-grid.tsx
@@ -171,9 +171,9 @@ export function GameGrid({ games, loading, filters, onToggleMultiplayer, onToggl
   })
 
   return (
-    <div className="space-y-3">
-      <div className="flex items-center justify-between">
-        <h2 className="font-semibold">
+    <div className="space-y-3 min-w-0">
+      <div className="flex items-center justify-between min-w-0">
+        <h2 className="font-semibold truncate">
           {isFiltering
             ? t('group.commonGamesFiltered', { filtered: filteredGames.length, total: games.length })
             : t('group.commonGames', { count: games.length })}
@@ -181,72 +181,72 @@ export function GameGrid({ games, loading, filters, onToggleMultiplayer, onToggl
       </div>
 
       {!loading && games.length > 0 && (
-        <div className="space-y-2">
-          {/* Search + mode toggles */}
-          <div className="flex flex-col sm:flex-row gap-2 sm:items-center">
-            <div className="relative flex-1" role="search">
-              <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
-              <Input
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                placeholder={t('group.searchGames')}
-                aria-label={t('group.searchGames')}
-                className="pl-9 pr-9"
-              />
-              {searchQuery && (
-                <button
-                  type="button"
-                  onClick={() => setSearchQuery('')}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                  aria-label={t('group.clearSearch')}
-                >
-                  <X className="w-4 h-4" />
-                </button>
-              )}
-            </div>
-            <div className="flex gap-1.5 shrink-0 overflow-x-auto scrollbar-none">
-              <Button
-                variant={filters.multiplayerOnly ? 'default' : 'secondary'}
-                size="sm"
-                onClick={() => onToggleMultiplayer(!filters.multiplayerOnly)}
-                className="gap-1.5"
+        <div className="space-y-2 min-w-0">
+          {/* Search */}
+          <div className="relative w-full" role="search">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
+            <Input
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder={t('group.searchGames')}
+              aria-label={t('group.searchGames')}
+              className="pl-9 pr-9 w-full"
+            />
+            {searchQuery && (
+              <button
+                type="button"
+                onClick={() => setSearchQuery('')}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                aria-label={t('group.clearSearch')}
               >
-                <Users className="w-3.5 h-3.5" />
-                {t('group.multiplayerOnly')}
-              </Button>
-              <Button
-                variant={filters.coopOnly ? 'default' : 'secondary'}
-                size="sm"
-                onClick={() => onToggleCoop(!filters.coopOnly)}
-                className="gap-1.5"
-              >
-                <Handshake className="w-3.5 h-3.5" />
-                {t('group.coopOnly')}
-              </Button>
-              <Button
-                variant={filters.gamesOnly ? 'default' : 'secondary'}
-                size="sm"
-                onClick={() => onToggleGamesOnly(!filters.gamesOnly)}
-                className="gap-1.5"
-              >
-                <Monitor className="w-3.5 h-3.5" />
-                {t('group.gamesOnly')}
-              </Button>
-              <Button
-                variant={filters.controllerOnly ? 'default' : 'secondary'}
-                size="sm"
-                onClick={() => onToggleControllerOnly(!filters.controllerOnly)}
-                className="gap-1.5"
-              >
-                <Gamepad2 className="w-3.5 h-3.5" />
-                {t('group.controllerSupport')}
-              </Button>
-            </div>
+                <X className="w-4 h-4" />
+              </button>
+            )}
+          </div>
+
+          {/* Mode toggles — wrap on mobile, horizontal on sm+ */}
+          <div className="flex flex-wrap gap-1.5">
+            <Button
+              variant={filters.multiplayerOnly ? 'default' : 'secondary'}
+              size="sm"
+              onClick={() => onToggleMultiplayer(!filters.multiplayerOnly)}
+              className="gap-1.5"
+            >
+              <Users className="w-3.5 h-3.5" />
+              {t('group.multiplayerOnly')}
+            </Button>
+            <Button
+              variant={filters.coopOnly ? 'default' : 'secondary'}
+              size="sm"
+              onClick={() => onToggleCoop(!filters.coopOnly)}
+              className="gap-1.5"
+            >
+              <Handshake className="w-3.5 h-3.5" />
+              {t('group.coopOnly')}
+            </Button>
+            <Button
+              variant={filters.gamesOnly ? 'default' : 'secondary'}
+              size="sm"
+              onClick={() => onToggleGamesOnly(!filters.gamesOnly)}
+              className="gap-1.5"
+            >
+              <Monitor className="w-3.5 h-3.5" />
+              {t('group.gamesOnly')}
+            </Button>
+            <Button
+              variant={filters.controllerOnly ? 'default' : 'secondary'}
+              size="sm"
+              onClick={() => onToggleControllerOnly(!filters.controllerOnly)}
+              className="gap-1.5"
+            >
+              <Gamepad2 className="w-3.5 h-3.5" />
+              {t('group.controllerSupport')}
+            </Button>
           </div>
 
           {/* Metacritic filter */}
-          <div className="flex flex-wrap items-center gap-2">
-            <span className="text-xs text-muted-foreground flex items-center gap-1">
+          <div className="flex flex-wrap items-center gap-1.5">
+            <span className="text-xs text-muted-foreground flex items-center gap-1 shrink-0">
               <Star className="w-3 h-3" />
               {t('group.metacritic')}
             </span>
@@ -255,7 +255,7 @@ export function GameGrid({ games, loading, filters, onToggleMultiplayer, onToggl
                 key={threshold ?? 'all'}
                 variant={filters.minMetacritic === threshold ? 'default' : 'outline'}
                 size="sm"
-                className="h-8 px-3 text-xs"
+                className="h-8 px-2.5 text-xs"
                 onClick={() => onSetMinMetacritic(threshold)}
               >
                 {threshold === null ? t('group.allScores') : `${threshold}+`}
@@ -264,8 +264,8 @@ export function GameGrid({ games, loading, filters, onToggleMultiplayer, onToggl
           </div>
 
           {/* Sort */}
-          <div className="flex flex-wrap items-center gap-2">
-            <span className="text-xs text-muted-foreground flex items-center gap-1">
+          <div className="flex flex-wrap items-center gap-1.5">
+            <span className="text-xs text-muted-foreground flex items-center gap-1 shrink-0">
               <TrendingUp className="w-3 h-3" />
               {t('group.sortBy')}
             </span>
@@ -274,7 +274,7 @@ export function GameGrid({ games, loading, filters, onToggleMultiplayer, onToggl
                 key={s}
                 variant={filters.sortBy === s ? 'default' : 'outline'}
                 size="sm"
-                className="h-8 px-3 text-xs"
+                className="h-8 px-2.5 text-xs"
                 onClick={() => onSetSortBy(s)}
               >
                 {t(`group.sort_${s}`)}

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -116,6 +116,11 @@
   * {
     @apply border-border outline-ring;
   }
+  html, body {
+    /* Prevent horizontal overflow from edge-case wide children
+       while preserving sticky positioning (clip doesn't establish a scroll container) */
+    overflow-x: clip;
+  }
   body {
     @apply text-foreground antialiased;
     font-family: var(--font-sans);
@@ -590,6 +595,15 @@
   display: none;
 }
 .touch-scroll {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+/* Hide scrollbar while preserving scroll — used on horizontal filter/toggle rows */
+.scrollbar-none::-webkit-scrollbar {
+  display: none;
+}
+.scrollbar-none {
   -ms-overflow-style: none;
   scrollbar-width: none;
 }

--- a/packages/frontend/src/pages/GroupPage.tsx
+++ b/packages/frontend/src/pages/GroupPage.tsx
@@ -282,13 +282,13 @@ export function GroupPage() {
   return (
     <div className="min-h-screen flex flex-col">
       <AppHeader maxWidth="wide">
-        <div className="flex items-center gap-2 sm:gap-3 min-w-0 flex-wrap">
+        <div className="flex items-center gap-2 min-w-0 flex-1">
           <Button variant="ghost" size="icon" onClick={() => navigate('/')} aria-label={t('group.back')} className="shrink-0">
             <ArrowLeft className="w-5 h-5" />
           </Button>
-          <h1 className="text-base sm:text-lg font-heading font-bold truncate max-w-[50vw] sm:max-w-none">{currentGroup.name}</h1>
+          <h1 className="text-base sm:text-lg font-heading font-bold truncate min-w-0 flex-1">{currentGroup.name}</h1>
           {onlineUserIds.length > 0 && (
-            <Badge variant="secondary" className="text-[10px] px-1.5 py-0 gap-1 font-normal shrink-0">
+            <Badge variant="secondary" className="text-[10px] px-1.5 py-0 gap-1 font-normal shrink-0 hidden sm:inline-flex">
               <span className="w-1.5 h-1.5 rounded-full bg-online animate-pulse" />
               {onlineUserIds.length} en ligne
             </Badge>
@@ -296,7 +296,7 @@ export function GroupPage() {
         </div>
       </AppHeader>
 
-      <main id="main-content" className="max-w-6xl mx-auto px-3 sm:px-4 lg:px-6 py-4">
+      <main id="main-content" className="w-full max-w-6xl mx-auto px-3 sm:px-4 lg:px-6 py-4 min-w-0">
         {/* Mobile: mini-bar that opens sidebar sheet */}
         <button
           type="button"
@@ -304,7 +304,7 @@ export function GroupPage() {
           onClick={() => setMobileSidebarOpen(true)}
           aria-label={t('group.openSidebar')}
         >
-          <div className="flex items-center gap-3">
+          <div className="flex items-center gap-3 min-w-0">
             <div className="flex -space-x-2 shrink-0">
               {currentGroup.members.slice(0, 5).map((member) => (
                 <Avatar key={member.id} className="w-7 h-7 ring-2 ring-background">
@@ -337,9 +337,9 @@ export function GroupPage() {
           </div>
         </button>
 
-        <div className="lg:grid lg:grid-cols-[280px_1fr] lg:gap-6">
+        <div className="lg:grid lg:grid-cols-[280px_minmax(0,1fr)] lg:gap-6">
           {/* Sidebar — hidden on mobile, shown on lg+ */}
-          <div className="hidden lg:block">
+          <div className="hidden lg:block min-w-0">
             <GroupSidebar
               members={currentGroup.members}
               groupId={id!}
@@ -367,7 +367,7 @@ export function GroupPage() {
           </div>
 
           {/* Main content: games grid */}
-          <div className="space-y-3 sm:space-y-4">
+          <div className="space-y-3 sm:space-y-4 min-w-0">
             {/* Action buttons — full-width stacked on mobile, grid on sm+ */}
             <div className="hidden sm:grid sm:grid-cols-2 gap-3">
               <Button


### PR DESCRIPTION
## Summary

Fixes the group detail page forcing the mobile browser to zoom out. Several independent issues each pushed the page wider than the viewport on narrow screens:

- `.scrollbar-none` was referenced in `game-grid.tsx` / `group-sidebar.tsx` but **never defined** in CSS, so horizontal rows rendered visible scrollbars
- `AppFooter` rendered `WAWPTN — tagline — vX.Y.Z — date` as one non-wrapping span, wider than ~375px
- `AppHeader` on the group page stacked back button + name + online badge + logo + "WAWPTN" wordmark + persona + notifications + avatar — too much for a narrow viewport; the `h1` used a `max-w-[50vw]` hack instead of proper flex sizing
- `GameGrid` mode toggles used `shrink-0 overflow-x-auto` which (combined with the missing scrollbar-none utility) effectively forced their parent wider on mobile
- Several container levels were missing `min-w-0`, preventing intrinsic widths from shrinking

## Changes

- **`src/index.css`** — `html, body { overflow-x: clip }` safety net (clip preserves sticky positioning); defined the missing `.scrollbar-none` utility
- **`src/components/app-footer.tsx`** — footer line now wraps (`flex-wrap`, `break-words`)
- **`src/components/app-header.tsx`** — children slot gets `flex-1 min-w-0` when present; "WAWPTN" wordmark + right-side spacer hidden on mobile when children are present so the group name has room
- **`src/pages/GroupPage.tsx`** — sticky header uses `flex-1 min-w-0` truncation; redundant "X en ligne" badge hidden on mobile (already shown in the mini-bar); `min-w-0` on `<main>`, sidebar and grid content; grid template widened to `[280px_minmax(0,1fr)]`
- **`src/components/game-grid.tsx`** — search input on its own full-width row; mode toggles now use `flex-wrap` (no more `shrink-0 overflow-x-auto`); `min-w-0` on containers; tighter filter button padding

## Test plan

- [x] `tsc -b` passes
- [x] `eslint .` passes (only pre-existing warnings)
- [x] `vite build` succeeds
- [ ] Open `/groups/:id` on a 375px-wide viewport — page should render fully without needing to zoom out
- [ ] Verify sticky header still stays pinned when scrolling
- [ ] Verify the mini-bar still opens the sidebar sheet and the fixed bottom action bar still appears
- [ ] Verify filter toggles wrap to a second row instead of overflowing

https://claude.ai/code/session_01QgcqXU8bAJog5ZLBXyGoSw