### PR TITLE
feat(admin): grant premium access to admins and admin-selected users

### DIFF
--- a/packages/backend/migrations/20260413_add_admin_granted_premium.ts
+++ b/packages/backend/migrations/20260413_add_admin_granted_premium.ts
@@ -1,0 +1,19 @@
+import type { Knex } from 'knex'
+
+/**
+ * Admin-granted premium: admins can grant premium access to any user
+ * without going through Stripe. This flag lives on the users table so
+ * it can never be clobbered by Stripe webhook updates on the
+ * `subscriptions` row.
+ */
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('users', (table) => {
+    table.boolean('admin_granted_premium').notNullable().defaultTo(false)
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('users', (table) => {
+    table.dropColumn('admin_granted_premium')
+  })
+}

--- a/packages/backend/src/domain/subscription-service.ts
+++ b/packages/backend/src/domain/subscription-service.ts
@@ -29,11 +29,19 @@ setInterval(() => {
   }
 }, EVICTION_INTERVAL_MS).unref()
 
-/** Check if a user has an active premium subscription (cached, 60s TTL) */
+/** Check if a user has an active premium subscription (cached, 60s TTL).
+ * Admins always receive premium access regardless of subscription state. */
 export async function isUserPremium(userId: string): Promise<boolean> {
   const now = Date.now()
   const cached = premiumCache.get(userId)
   if (cached && cached.expiresAt > now) return cached.value
+
+  // Admins always have premium access
+  const user = await db('users').where({ id: userId }).select('is_admin').first()
+  if (user?.is_admin) {
+    premiumCache.set(userId, { value: true, expiresAt: now + PREMIUM_CACHE_TTL_MS })
+    return true
+  }
 
   const subscription = await db('subscriptions')
     .where({ user_id: userId })

--- a/packages/backend/src/domain/subscription-service.ts
+++ b/packages/backend/src/domain/subscription-service.ts
@@ -30,15 +30,19 @@ setInterval(() => {
 }, EVICTION_INTERVAL_MS).unref()
 
 /** Check if a user has an active premium subscription (cached, 60s TTL).
- * Admins always receive premium access regardless of subscription state. */
+ * Admins always receive premium access regardless of subscription state.
+ * Users explicitly granted premium by an admin are also considered premium. */
 export async function isUserPremium(userId: string): Promise<boolean> {
   const now = Date.now()
   const cached = premiumCache.get(userId)
   if (cached && cached.expiresAt > now) return cached.value
 
-  // Admins always have premium access
-  const user = await db('users').where({ id: userId }).select('is_admin').first()
-  if (user?.is_admin) {
+  // Admins and admin-granted premium users always have premium access
+  const user = await db('users')
+    .where({ id: userId })
+    .select('is_admin', 'admin_granted_premium')
+    .first()
+  if (user?.is_admin || user?.admin_granted_premium) {
     premiumCache.set(userId, { value: true, expiresAt: now + PREMIUM_CACHE_TTL_MS })
     return true
   }

--- a/packages/backend/src/presentation/routes/admin.routes.ts
+++ b/packages/backend/src/presentation/routes/admin.routes.ts
@@ -1,6 +1,7 @@
 import { Router, type Request, type Response } from 'express'
 import { db } from '../../infrastructure/database/connection.js'
 import { authLogger } from '../../infrastructure/logger/logger.js'
+import { invalidatePremiumCache } from '../../domain/subscription-service.js'
 
 const router = Router()
 
@@ -71,7 +72,21 @@ interface UserRow {
   display_name: string
   avatar_url: string
   is_admin: boolean
+  admin_granted_premium: boolean
+  stripe_tier: string | null
+  stripe_status: string | null
+  stripe_period_end: Date | null
   created_at: Date
+}
+
+/** Compute whether a user is currently premium, accounting for both
+ * admin-granted access and an active Stripe subscription. */
+function computeIsPremium(u: UserRow): boolean {
+  if (u.is_admin || u.admin_granted_premium) return true
+  if (u.stripe_tier !== 'premium') return false
+  if (u.stripe_status !== 'active') return false
+  if (u.stripe_period_end && new Date(u.stripe_period_end) < new Date()) return false
+  return true
 }
 
 router.get('/users', async (req: Request, res: Response) => {
@@ -84,18 +99,30 @@ router.get('/users', async (req: Request, res: Response) => {
     const applyFilter = <T extends import('knex').Knex.QueryBuilder>(qb: T): T => {
       if (q) {
         qb.where((w) => {
-          w.whereILike('display_name', `%${q}%`).orWhereILike('steam_id', `%${q}%`)
+          w.whereILike('users.display_name', `%${q}%`).orWhereILike('users.steam_id', `%${q}%`)
         })
       }
       return qb
     }
 
-    const totalResult = await applyFilter(db('users')).count('id as count').first()
+    const totalResult = await applyFilter(db('users')).count('users.id as count').first()
     const total = Number(totalResult?.count ?? 0)
 
     const users = await applyFilter(db('users'))
-      .select('id', 'steam_id', 'display_name', 'avatar_url', 'is_admin', 'created_at')
-      .orderBy('created_at', 'desc')
+      .leftJoin('subscriptions', 'subscriptions.user_id', 'users.id')
+      .select(
+        'users.id as id',
+        'users.steam_id as steam_id',
+        'users.display_name as display_name',
+        'users.avatar_url as avatar_url',
+        'users.is_admin as is_admin',
+        'users.admin_granted_premium as admin_granted_premium',
+        'users.created_at as created_at',
+        'subscriptions.tier as stripe_tier',
+        'subscriptions.status as stripe_status',
+        'subscriptions.current_period_end as stripe_period_end',
+      )
+      .orderBy('users.created_at', 'desc')
       .limit(limit)
       .offset(offset) as UserRow[]
 
@@ -106,6 +133,8 @@ router.get('/users', async (req: Request, res: Response) => {
         displayName: u.display_name,
         avatarUrl: u.avatar_url,
         isAdmin: u.is_admin,
+        isPremium: computeIsPremium(u),
+        adminGrantedPremium: u.admin_granted_premium,
         createdAt: u.created_at,
       })),
       total,
@@ -142,6 +171,33 @@ router.patch('/users/:id/admin', async (req: Request, res: Response) => {
 
   await db('users').where({ id: targetId }).update({ is_admin: isAdmin })
   authLogger.warn({ userId: req.userId, targetId, isAdmin }, 'admin role changed')
+
+  res.json({ ok: true })
+})
+
+// Grant or revoke admin-granted premium access for a user
+router.patch('/users/:id/premium', async (req: Request, res: Response) => {
+  const targetId = req.params['id']
+  const { isPremium } = req.body as { isPremium?: boolean }
+
+  if (typeof isPremium !== 'boolean') {
+    res.status(400).json({ error: 'validation', message: 'isPremium (boolean) is required' })
+    return
+  }
+
+  const target = await db('users').where({ id: targetId }).first()
+  if (!target) {
+    res.status(404).json({ error: 'not_found', message: 'Utilisateur introuvable' })
+    return
+  }
+
+  await db('users').where({ id: targetId }).update({ admin_granted_premium: isPremium })
+  invalidatePremiumCache(targetId!)
+
+  authLogger.warn(
+    { userId: req.userId, targetId, isPremium },
+    'admin-granted premium changed',
+  )
 
   res.json({ ok: true })
 })

--- a/packages/backend/src/presentation/routes/subscription.routes.ts
+++ b/packages/backend/src/presentation/routes/subscription.routes.ts
@@ -8,12 +8,25 @@ import { logger } from '../../infrastructure/logger/logger.js'
 export const subscriptionRoutes = Router()
 
 // GET /api/subscription/me — current subscription state
+// Admins are reported as active premium so client-side PremiumGate unlocks features.
 subscriptionRoutes.get('/me', async (req: Request, res: Response) => {
   try {
-    const subscription = await db('subscriptions')
-      .where({ user_id: req.userId })
-      .select('tier', 'status', 'current_period_end')
-      .first()
+    const [user, subscription] = await Promise.all([
+      db('users').where({ id: req.userId }).select('is_admin').first(),
+      db('subscriptions')
+        .where({ user_id: req.userId })
+        .select('tier', 'status', 'current_period_end')
+        .first(),
+    ])
+
+    if (user?.is_admin) {
+      res.json({
+        tier: 'premium',
+        status: 'active',
+        currentPeriodEnd: subscription?.current_period_end || null,
+      })
+      return
+    }
 
     res.json({
       tier: subscription?.tier || 'free',

--- a/packages/backend/src/presentation/routes/subscription.routes.ts
+++ b/packages/backend/src/presentation/routes/subscription.routes.ts
@@ -8,18 +8,22 @@ import { logger } from '../../infrastructure/logger/logger.js'
 export const subscriptionRoutes = Router()
 
 // GET /api/subscription/me — current subscription state
-// Admins are reported as active premium so client-side PremiumGate unlocks features.
+// Admins and admin-granted premium users are reported as active premium so
+// the client-side PremiumGate unlocks features regardless of Stripe state.
 subscriptionRoutes.get('/me', async (req: Request, res: Response) => {
   try {
     const [user, subscription] = await Promise.all([
-      db('users').where({ id: req.userId }).select('is_admin').first(),
+      db('users')
+        .where({ id: req.userId })
+        .select('is_admin', 'admin_granted_premium')
+        .first(),
       db('subscriptions')
         .where({ user_id: req.userId })
         .select('tier', 'status', 'current_period_end')
         .first(),
     ])
 
-    if (user?.is_admin) {
+    if (user?.is_admin || user?.admin_granted_premium) {
       res.json({
         tier: 'premium',
         status: 'active',

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -204,7 +204,11 @@ export const api = {
     if (params?.q) search.set('q', params.q)
     const qs = search.toString()
     return request<{
-      data: { id: string; steamId: string; displayName: string; avatarUrl: string; isAdmin: boolean; createdAt: string }[]
+      data: {
+        id: string; steamId: string; displayName: string; avatarUrl: string;
+        isAdmin: boolean; isPremium: boolean; adminGrantedPremium: boolean;
+        createdAt: string;
+      }[]
       total: number
       limit: number
       offset: number
@@ -214,6 +218,11 @@ export const api = {
     request<{ ok: boolean }>(`/admin/users/${userId}/admin`, {
       method: 'PATCH',
       body: JSON.stringify({ isAdmin }),
+    }),
+  setAdminUserPremium: (userId: string, isPremium: boolean) =>
+    request<{ ok: boolean }>(`/admin/users/${userId}/premium`, {
+      method: 'PATCH',
+      body: JSON.stringify({ isPremium }),
     }),
 
   // Subscription

--- a/packages/frontend/src/pages/AdminPage.tsx
+++ b/packages/frontend/src/pages/AdminPage.tsx
@@ -4,7 +4,7 @@ import {
   ArrowLeft, Bot, Users, BarChart3, Save, RefreshCw, ShieldCheck,
   ShieldOff, Theater, Plus, Pencil, Trash2, Lock, Search, X,
   Activity, Zap, Clock, Globe, Terminal, Megaphone, Send,
-  ChevronLeft, ChevronRight,
+  ChevronLeft, ChevronRight, Crown,
 } from 'lucide-react'
 import { toast } from 'sonner'
 import { useTranslation } from 'react-i18next'
@@ -58,6 +58,8 @@ interface AdminUser {
   displayName: string
   avatarUrl: string
   isAdmin: boolean
+  isPremium: boolean
+  adminGrantedPremium: boolean
   createdAt: string
 }
 
@@ -322,12 +324,35 @@ export function AdminPage() {
     const newIsAdmin = !targetUser.isAdmin
     try {
       await api.setAdminUserRole(targetUser.id, newIsAdmin)
-      setUsers(users.map(u => u.id === targetUser.id ? { ...u, isAdmin: newIsAdmin } : u))
+      setUsers(users.map(u => u.id === targetUser.id ? {
+        ...u,
+        isAdmin: newIsAdmin,
+        // Admins implicitly have premium access
+        isPremium: newIsAdmin ? true : u.adminGrantedPremium,
+      } : u))
       // Keep the overview admin count in sync without refetching the full page
       setStats(prev => prev ? { ...prev, admins: prev.admins + (newIsAdmin ? 1 : -1) } : prev)
       toast.success(newIsAdmin ? `${targetUser.displayName} promu admin` : `${targetUser.displayName} n'est plus admin`)
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Erreur lors du changement de rôle')
+    }
+  }
+
+  async function handleTogglePremium(targetUser: AdminUser) {
+    const newGranted = !targetUser.adminGrantedPremium
+    try {
+      await api.setAdminUserPremium(targetUser.id, newGranted)
+      setUsers(users.map(u => u.id === targetUser.id ? {
+        ...u,
+        adminGrantedPremium: newGranted,
+        // Admins keep premium regardless; otherwise reflect the grant
+        isPremium: u.isAdmin ? true : newGranted,
+      } : u))
+      toast.success(newGranted
+        ? `${targetUser.displayName} a reçu l'accès premium`
+        : `Accès premium retiré à ${targetUser.displayName}`)
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Erreur lors du changement du statut premium')
     }
   }
 
@@ -640,6 +665,7 @@ export function AdminPage() {
                 onPrev={handleUsersPrev}
                 onNext={handleUsersNext}
                 onToggleAdmin={handleToggleAdmin}
+                onTogglePremium={handleTogglePremium}
               />
             </motion.div>
           )}
@@ -1488,6 +1514,7 @@ function UsersTab({
   onPrev,
   onNext,
   onToggleAdmin,
+  onTogglePremium,
 }: {
   users: AdminUser[]
   totalUsers: number
@@ -1500,6 +1527,7 @@ function UsersTab({
   onPrev: () => void
   onNext: () => void
   onToggleAdmin: (user: AdminUser) => void
+  onTogglePremium: (user: AdminUser) => void
 }) {
   const rangeStart = totalUsers === 0 ? 0 : offset + 1
   const rangeEnd = Math.min(offset + users.length, totalUsers)
@@ -1576,6 +1604,11 @@ function UsersTab({
                         admin
                       </Badge>
                     )}
+                    {u.isPremium && !u.isAdmin && (
+                      <Badge variant="outline" className="text-[9px] px-1.5 py-0 border-reward/30 text-reward shrink-0">
+                        premium
+                      </Badge>
+                    )}
                     {u.id === currentUserId && (
                       <Badge variant="outline" className="text-[9px] px-1.5 py-0 border-neon/20 text-neon shrink-0">
                         vous
@@ -1595,29 +1628,62 @@ function UsersTab({
                   </div>
                 </div>
 
-                {u.isAdmin ? (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="gap-1.5 text-destructive hover:text-destructive border-destructive/20 hover:border-destructive/40 shrink-0"
-                    onClick={() => onToggleAdmin(u)}
-                    disabled={u.id === currentUserId}
-                    title={u.id === currentUserId ? 'Vous ne pouvez pas révoquer votre propre accès' : undefined}
-                  >
-                    <ShieldOff className="h-3.5 w-3.5" />
-                    <span className="hidden sm:inline">Révoquer</span>
-                  </Button>
-                ) : (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="gap-1.5 shrink-0"
-                    onClick={() => onToggleAdmin(u)}
-                  >
-                    <ShieldCheck className="h-3.5 w-3.5" />
-                    <span className="hidden sm:inline">Promouvoir</span>
-                  </Button>
-                )}
+                <div className="flex items-center gap-2 shrink-0">
+                  {u.isAdmin ? (
+                    <span
+                      className="text-[10px] font-mono text-muted-foreground/40 hidden md:inline"
+                      title="Les admins ont automatiquement accès au premium"
+                    >
+                      premium via admin
+                    </span>
+                  ) : u.adminGrantedPremium ? (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="gap-1.5 text-reward hover:text-reward border-reward/30 hover:border-reward/50"
+                      onClick={() => onTogglePremium(u)}
+                      title="Retirer l'accès premium offert"
+                    >
+                      <Crown className="h-3.5 w-3.5" />
+                      <span className="hidden sm:inline">Retirer premium</span>
+                    </Button>
+                  ) : (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="gap-1.5"
+                      onClick={() => onTogglePremium(u)}
+                      title="Offrir l'accès premium à cet utilisateur"
+                    >
+                      <Crown className="h-3.5 w-3.5 text-reward" />
+                      <span className="hidden sm:inline">Offrir premium</span>
+                    </Button>
+                  )}
+
+                  {u.isAdmin ? (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="gap-1.5 text-destructive hover:text-destructive border-destructive/20 hover:border-destructive/40"
+                      onClick={() => onToggleAdmin(u)}
+                      disabled={u.id === currentUserId}
+                      title={u.id === currentUserId ? 'Vous ne pouvez pas révoquer votre propre accès' : undefined}
+                    >
+                      <ShieldOff className="h-3.5 w-3.5" />
+                      <span className="hidden sm:inline">Révoquer</span>
+                    </Button>
+                  ) : (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="gap-1.5"
+                      onClick={() => onToggleAdmin(u)}
+                    >
+                      <ShieldCheck className="h-3.5 w-3.5" />
+                      <span className="hidden sm:inline">Promouvoir</span>
+                    </Button>
+                  )}
+                </div>
               </div>
             </motion.div>
           ))}


### PR DESCRIPTION
## Summary
- Admins automatically receive premium access (`isUserPremium` and `GET /api/subscription/me` short-circuit on `users.is_admin`)
- New `users.admin_granted_premium` flag lets admins gift premium to any user without going through Stripe — kept on the `users` table so Stripe webhooks on the `subscriptions` row can never clobber it
- New `PATCH /api/admin/users/:id/premium` endpoint flips the flag and invalidates the premium cache
- `GET /api/admin/users` now LEFT JOINs `subscriptions` and returns `isPremium` / `adminGrantedPremium` per user
- Admin → Utilisateurs tab: premium badge on user rows + new Crown-icon "Offrir premium" / "Retirer premium" buttons next to the existing admin role controls

## Test plan
- [ ] Run `npm run db:migrate` to apply `20260413_add_admin_granted_premium`
- [ ] As an admin, verify `PremiumGate` unlocks without any Stripe subscription
- [ ] From Admin → Utilisateurs, click "Offrir premium" on a non-admin user and confirm the badge appears and they can use premium features
- [ ] Click "Retirer premium" and confirm access is revoked (60s cache invalidation kicks in immediately)
- [ ] Verify a user with a real active Stripe subscription still shows as premium even after admin revoke

https://claude.ai/code/session_017P8oBZtkgzD8oCQoRvBUmD