### PR TITLE
feat: multi-persona feature meeting outcome — admin hardening, scheduler durability and UX polish

### DIFF
--- a/docs/feature-meeting-2026-04-13.md
+++ b/docs/feature-meeting-2026-04-13.md
@@ -1,0 +1,127 @@
+# Réunion produit — Amélioration des fonctionnalités
+
+**Date :** 2026-04-13
+**Branche :** `claude/multi-agent-feature-meeting-mKUMa`
+**Format :** Réunion multi-personas (6 profils) passant en revue le code actuel pour proposer des améliorations ciblées.
+
+## Participants
+
+| Persona | Rôle | Angle |
+|---------|------|-------|
+| Sarah | Senior Product Manager | Valeur utilisateur, rétention, virality |
+| Léo | Senior UX/UI Designer | Friction, micro-feedback, mobile/PWA |
+| Marcus | Senior Backend Engineer | Capacités, temps réel, intégrité |
+| Yuki | Senior Frontend Engineer | État client, Socket.io, performance |
+| Priya | Senior QA / Security Engineer | Hardening, audit, intégrité des votes |
+| Tom | Discord Bot & Community Lead | Engagement, viralité Discord |
+
+---
+
+## 1. Sarah — Product
+
+**Constat :** Fondations solides, mais boucles de rétention faibles. Le parcours s'arrête après le premier vote.
+
+1. **Rituel de soirée jeu (recurring vote scheduling)** — automatiser la création d'une session chaque vendredi 21h CET via le cron existant. *Impact: élevé / Effort: S.*
+2. **Aperçu riche des invitations** — l'endpoint `/preview` existe déjà, surfacer avatars + dernier gagnant + compteur sur `JoinPage` pour créer du FOMO.
+3. **Wishlist par jeu** — étoile sur chaque carte, jeux « wishlistés » remontés en priorité lors de la création de session.
+4. **Dashboard / leaderboard de groupe** — stats agrégées (jeu le plus joué, série de votes, jeu le plus clivant).
+5. **Re-queue d'un jeu qui ne se lance pas** — toast à 5 min « le jeu ne démarre pas ? [Réessayer] [Suivant] ».
+
+**Top pick :** #1 — Rituel de soirée jeu récurrent.
+
+## 2. Léo — UX/UI
+
+**Constat :** Palette « Neon Dusk » cohérente, Framer Motion présent, mais le moment « récompense » est sous-exploité et la densité mobile est perfectible.
+
+1. **Feedback micro en direct sur écran d'attente** — réutiliser `CelebrationParticles` (`random-pick-modal.tsx:44-74`) pour déclencher un burst à chaque nouveau vote reçu sur `VotePage.tsx:336`. *[Quick Win]*
+2. **Badge sticky du compteur sélection en mobile** — `VotePage.tsx:409-440`, pill sticky en haut du grid pour ne pas perdre le contexte lors du scroll. *[Quick Win]*
+3. **Carte de breakdown avant le bouton Steam** — `VotePage.tsx:224-310`, barre de distribution des votes animée *avant* l'apparition du CTA de lancement. *[Medium]*
+4. **Deep-link PWA pour invités non authentifiés** — pré-remplir le signup avec « Tu es invité à [Groupe] » et auto-join après Steam OpenID. *[Medium]*
+5. **Banner explicite pour les jeux filtrés par Metacritic** — « X jeux masqués (score <75) » cliquable. *[Big]*
+
+**Top pick :** #1 — Particules + son discret à chaque vote reçu.
+
+## 3. Marcus — Backend
+
+**Constat :** Base Express/Socket.io propre, circuit breakers en place, mais des capacités manquent pour débloquer les features produit.
+
+1. **Service de déduplication multi-plateforme** — remplacer le name-matching fuzzy d'Epic/GOG (`auth.routes.ts:881-891`) par un mapping canonique via IGDB ; colonne `game_igdb_id`, `computeCommonGames` regroupe sur IGDB.
+2. **`vote:progress` et `vote:reminder` via Socket.io** — socket actuel ne broadcast que `vote:cast`. Ajouter présence par participant + relances via la table `vote_reminders`.
+3. **Snapshot/audit trail des participants à la clôture** — table `session_audit_trail`, gèle l'état des votants au `closeSession` pour l'intégrité long terme.
+4. **Executor pour les sessions planifiées** — nouveau `/domain/jobs/` qui scrute toutes les minutes les `scheduledAt` et crée les sessions (`vote.routes.ts:142-165`), avec retry sur échec Steam.
+5. **Endpoint `/admin/api-health`** — agrège circuit breakers Steam/Epic/GOG, dernière synchro, fraîcheur du cache.
+
+**Top pick :** #1 — Déduplication cross-plateforme. Sans cela, Epic/GOG ne délivre pas leur promesse UX.
+
+## 4. Yuki — Frontend
+
+**Constat :** Zustand propre mais la logique Socket.io est dispersée dans les pages, PWA sous-utilisée, pas de code splitting.
+
+1. **`useSocketStore` avec reconnect & queue** — `src/lib/socket.ts` n'a ni reconnection ni état ; `GroupPage.tsx:82-143` remonte les listeners manuellement. Store dédié avec backoff exponentiel.
+2. **Server-state store avec invalidation** — l'auth invalide manuellement l'abonnement (`auth.store.ts:21`), GroupPage triple-fetch au mount. Clés de cache + TTL.
+3. **Push notifications PWA + prompt d'installation** — manifest existe (`vite.config`) mais pas de SW, pas d'install prompt. Câbler Workbox + `beforeinstallprompt`.
+4. **Code splitting des pages lourdes** — `React.lazy()` sur Vote/Admin/Group, images progressives (`blur-up`).
+5. **Lier le store de notifications à Socket.io** — `notification.store.ts` n'est relié à aucun event socket, la cloche n'affiche que du mock.
+
+**Top pick :** #1 — Store Socket.io résilient débloque le PWA offline-first et supprime ~140 lignes de boilerplate par page.
+
+## 5. Priya — QA / Sécurité
+
+**Constat :** La surface admin (PR #116) introduit des élévations de privilège sans filet. À durcir avant toute nouvelle feature.
+
+1. **Audit log + rate limit sur les mutations admin** — `admin.routes.ts:151-203`. Table d'audit tamper-resistant + max 10 mutations / 5min. *[Critical]*
+2. **Validation Zod centralisée au middleware** — schémas pour `CreatePersonaSchema`, `UpdateUserSchema`, etc. sur toutes les routes POST/PATCH. *[High]*
+3. **Unicité DB sur `(session_id, user_id, steam_app_id)`** — `vote.routes.ts:264-276` utilise `onConflict.merge()` sans lock, race-condition possible. *[High]*
+4. **Rotation des sessions lors d'un changement de privilèges** — invalider toutes les sessions d'un user quand son rôle/premium change. *[High]*
+5. **Re-validation périodique de l'auth Socket.io** — `socket/socket.ts:53-94` valide une seule fois à la connexion ; re-check toutes les 30-60 s. *[Medium]*
+
+**Blocker avant nouvelle feature :** #1 — Audit log admin.
+
+## 6. Tom — Discord
+
+**Constat :** 7 personas, cron Friday/Wednesday, mais le bot reste un facilitateur de vote plutôt qu'un moteur de communauté.
+
+1. **`/wawptn-stats` + badges d'achievement** — leaderboard par serveur, cache mensuel dans un message épinglé.
+2. **`/wawptn-config` par guilde** — le scheduler utilise une config globale ; permettre cron + persona rotation par serveur pour toucher d'autres fuseaux.
+3. **Auto-recurring weekly session template** — `/wawptn-auto-vote setup` crée un cron côté backend qui lance une session chaque semaine.
+4. **Diffusion multi-canal des résultats** — envoyer l'embed de clôture sur les canaux d'annonces taggés, pas seulement le canal lié.
+5. **Mentions + chat persona** — `@WawptnBot` répond avec voix de persona + données backend (score Steam, consensus).
+
+**Top pick :** #1 — Leaderboard + badges, direct dans la culture Discord.
+
+---
+
+## Synthèse croisée
+
+### Consensus — ce qui revient dans plusieurs personas
+
+| Thème | Personas convergents | Lecture |
+|-------|----------------------|---------|
+| **Votes récurrents automatisés** | Sarah (#1), Marcus (#4), Tom (#3) | Produit, backend et Discord pointent tous le même manque : il faut un exécuteur de sessions planifiées, exposé côté front et côté bot. |
+| **Temps réel plus riche** | Léo (#1), Marcus (#2), Yuki (#1, #5) | L'écran d'attente est perçu comme mort ; les events Socket.io existants sont pauvres et les listeners clients sont fragiles. Un store socket résilient + events `vote:progress`/`notification:*` débloquent plusieurs features. |
+| **Invitations / onboarding viral** | Sarah (#2), Léo (#4), Tom (#4) | L'invite est un point froid. L'endpoint `/preview` existe déjà — il suffit de le câbler en PWA deep-link et en diffusion multi-canal Discord. |
+| **Confiance / intégrité** | Marcus (#3), Priya (#1, #3, #4) | Surface admin + upsert de vote sans lock + pas d'audit = dette de risque à lever avant de scaler. |
+
+### Plan d'action proposé (à valider en comité)
+
+**Sprint 1 — Fondations de confiance (blocker avant tout nouveau feature flag)**
+1. Audit log + rate limit admin (Priya #1) — *Critical*
+2. Contrainte unique + lock sur votes (Priya #3)
+3. Rotation de session sur changement de privilèges (Priya #4)
+
+**Sprint 2 — Boucle de rétention « Rituel de soirée jeu »**
+4. Executor de sessions planifiées (Marcus #4)
+5. Cron de groupe exposé côté front + `/wawptn-auto-vote` côté Discord (Sarah #1 + Tom #3)
+6. Store Socket.io résilient (Yuki #1) pour encaisser les events de progression
+
+**Sprint 3 — Moment de récompense et virality**
+7. Particules live sur l'écran d'attente (Léo #1)
+8. Carte de breakdown avant le CTA Steam (Léo #3)
+9. `JoinPage` enrichie via `/preview` + deep-link PWA (Sarah #2 + Léo #4)
+10. Diffusion multi-canal des résultats Discord (Tom #4)
+
+**Backlog à séquencer ensuite :** déduplication IGDB (Marcus #1), wishlist (Sarah #3), leaderboard (Sarah #4 + Tom #1), push notifications PWA (Yuki #3), `/admin/api-health` (Marcus #5), personas conversationnelles (Tom #5).
+
+---
+
+*Notes générées automatiquement via 6 sous-agents personas lus en parallèle sur le code à HEAD 62fb3a9.*

--- a/packages/backend/migrations/20260413_b_add_admin_audit_log.ts
+++ b/packages/backend/migrations/20260413_b_add_admin_audit_log.ts
@@ -1,0 +1,41 @@
+import type { Knex } from 'knex'
+
+/**
+ * Admin audit log: records every privileged mutation performed by an admin
+ * (role grants, premium grants, persona CRUD, bot settings updates, etc.).
+ *
+ * Goals:
+ * - Forensic trail for incident response (who changed what, when, from where)
+ * - Deterrent against admin account abuse
+ * - Compliance / accountability for privilege escalation
+ */
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('admin_audit_log', (table) => {
+    table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'))
+    // Actor: the admin who performed the action. Nullable so we never lose a
+    // log entry if the actor row is later deleted (ON DELETE SET NULL).
+    table.uuid('actor_id').nullable().references('id').inTable('users').onDelete('SET NULL')
+    // Target: the user/resource affected (nullable for actions that don't
+    // target a specific user, e.g. bot settings updates).
+    table.uuid('target_user_id').nullable().references('id').inTable('users').onDelete('SET NULL')
+    // Action identifier, e.g. "user.admin.grant", "user.premium.revoke",
+    // "persona.create", "bot_settings.update".
+    table.string('action', 64).notNullable()
+    // Free-form payload describing the change (old/new values, target ids,
+    // arbitrary metadata). Kept as JSONB for easy querying.
+    table.jsonb('metadata').notNullable().defaultTo('{}')
+    // Forensic context.
+    table.string('ip_address', 64).nullable()
+    table.string('user_agent', 512).nullable()
+    table.timestamp('created_at').notNullable().defaultTo(knex.fn.now())
+
+    table.index(['actor_id', 'created_at'])
+    table.index(['target_user_id', 'created_at'])
+    table.index(['action', 'created_at'])
+    table.index('created_at')
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists('admin_audit_log')
+}

--- a/packages/backend/src/domain/admin-audit-log.ts
+++ b/packages/backend/src/domain/admin-audit-log.ts
@@ -1,0 +1,71 @@
+import type { Request } from 'express'
+import { db } from '../infrastructure/database/connection.js'
+import { authLogger } from '../infrastructure/logger/logger.js'
+
+/**
+ * Admin audit log domain service.
+ *
+ * Centralises writes to the `admin_audit_log` table so route handlers have
+ * a single, well-typed call site for recording privileged actions.
+ *
+ * Failures to write the audit log are logged but never thrown — we never want
+ * audit-log issues to break a legitimate admin action. Call sites that need
+ * stronger guarantees should wrap the action and the log call in a transaction.
+ */
+
+/** Allowlist of action identifiers. New actions must be added here so the
+ * shape of the audit log stays predictable for downstream consumers. */
+export type AdminAuditAction =
+  | 'user.admin.grant'
+  | 'user.admin.revoke'
+  | 'user.premium.grant'
+  | 'user.premium.revoke'
+  | 'persona.create'
+  | 'persona.update'
+  | 'persona.delete'
+  | 'persona.toggle'
+  | 'bot_settings.update'
+
+interface RecordAdminActionInput {
+  /** Express request, used to extract the actor id and forensic context. */
+  req: Request
+  /** What the admin did — must match {@link AdminAuditAction}. */
+  action: AdminAuditAction
+  /** The user the action targets, when applicable (e.g. persona/bot
+   * settings actions don't have a target user). */
+  targetUserId?: string | null
+  /** Free-form metadata describing the change. Should be small (a few KiB at
+   * most) and JSON-serialisable. */
+  metadata?: Record<string, unknown>
+}
+
+/**
+ * Insert a single row into `admin_audit_log`. Never throws.
+ */
+export async function recordAdminAction(input: RecordAdminActionInput): Promise<void> {
+  const { req, action, targetUserId, metadata } = input
+  const actorId = req.userId ?? null
+
+  // Express normalises proxy headers when `trust proxy` is set; otherwise
+  // `req.ip` is the socket address. Either is acceptable for forensic intent.
+  const ip = (req.ip ?? req.socket?.remoteAddress ?? null)?.slice(0, 64) ?? null
+  const userAgent = (req.get('user-agent') ?? null)?.slice(0, 512) ?? null
+
+  try {
+    await db('admin_audit_log').insert({
+      actor_id: actorId,
+      target_user_id: targetUserId ?? null,
+      action,
+      metadata: JSON.stringify(metadata ?? {}),
+      ip_address: ip,
+      user_agent: userAgent,
+    })
+  } catch (error) {
+    // Audit-log writes must never break the admin action itself. Log loudly
+    // so ops notice the failure.
+    authLogger.error(
+      { error: String(error), actorId, action, targetUserId },
+      'failed to write admin audit log entry',
+    )
+  }
+}

--- a/packages/backend/src/domain/auth-service.ts
+++ b/packages/backend/src/domain/auth-service.ts
@@ -53,6 +53,21 @@ export async function invalidateSession(token: string): Promise<boolean> {
 }
 
 /**
+ * Invalidate every session owned by a user. Used when the user's privileges
+ * change (admin role granted/revoked, premium toggled by an admin) so that any
+ * in-flight clients are forced to re-authenticate and pick up the new state.
+ *
+ * Returns the number of session rows that were deleted.
+ */
+export async function invalidateAllUserSessions(userId: string): Promise<number> {
+  const deleted = await db('sessions').where({ user_id: userId }).del()
+  if (deleted > 0) {
+    authLogger.info({ userId, sessions: deleted }, 'all user sessions invalidated')
+  }
+  return deleted
+}
+
+/**
  * Find an existing user by Steam ID or create a new one using the supplied
  * Steam profile data. Also ensures the matching row in the `accounts` table
  * linking the Steam provider to the user exists.

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -130,9 +130,23 @@ async function main() {
   // Challenge routes (requires authenticated user)
   app.use('/api/challenges', requireAuth, challengeRoutes)
 
+  // Strict rate limiter for admin mutation endpoints (privilege grants,
+  // persona CRUD, bot settings). Capped well below normal usage so a
+  // compromised admin account cannot mass-mutate state, while leaving plenty
+  // of headroom for legitimate panel use.
+  const adminMutationLimiter = rateLimit({
+    windowMs: 5 * 60 * 1000, // 5 minutes
+    max: 30,
+    standardHeaders: true,
+    legacyHeaders: false,
+    // Only count state-changing requests; reads (GET) stay on the global
+    // apiLimiter so panel browsing stays snappy.
+    skip: (req) => req.method === 'GET' || req.method === 'HEAD' || req.method === 'OPTIONS',
+  })
+
   // Admin routes (requires authenticated admin user)
-  app.use('/api/admin', requireAuth, requireAdmin, adminRoutes)
-  app.use('/api/admin/notifications', requireAuth, requireAdmin, adminNotificationRoutes)
+  app.use('/api/admin', requireAuth, requireAdmin, adminMutationLimiter, adminRoutes)
+  app.use('/api/admin/notifications', requireAuth, requireAdmin, adminMutationLimiter, adminNotificationRoutes)
 
   // Discord user-facing routes (session auth, no bot auth required)
   app.use('/api/discord', discordUserRoutes)

--- a/packages/backend/src/infrastructure/scheduler/__tests__/auto-vote-scheduler.test.ts
+++ b/packages/backend/src/infrastructure/scheduler/__tests__/auto-vote-scheduler.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// vi.hoisted — variables available inside vi.mock factories (which are hoisted)
+// ---------------------------------------------------------------------------
+
+const { mockDb, dbResults, dbCallCounts, scheduledCallbacks, createVotingSessionMock } =
+  vi.hoisted(() => {
+    /**
+     * Chainable mock mimicking a Knex query builder.
+     * Every method returns the same proxy, and `await` resolves to `resolveValue`.
+     */
+    function chain(resolveValue: unknown = undefined): unknown {
+      const proxy: unknown = new Proxy(() => {}, {
+        get(_t, prop: string) {
+          if (prop === 'then') {
+            return (res: (v: unknown) => void, rej: (e: unknown) => void) =>
+              Promise.resolve(resolveValue).then(res, rej)
+          }
+          return (..._a: unknown[]) => proxy
+        },
+        apply() {
+          return proxy
+        },
+      })
+      return proxy
+    }
+
+    const dbResults = new Map<string, unknown[]>()
+    const dbCallCounts = new Map<string, number>()
+
+    function nextResult(table: string): unknown {
+      const idx = dbCallCounts.get(table) ?? 0
+      dbCallCounts.set(table, idx + 1)
+      const arr = dbResults.get(table)
+      if (!arr || arr.length === 0) return undefined
+      return arr[Math.min(idx, arr.length - 1)]
+    }
+
+    const noop = () => {}
+    const mockDb = Object.assign(
+      (table: string) => chain(nextResult(table)),
+      { fn: { now: () => 'NOW()' }, raw: noop },
+    )
+
+    // Records cron callbacks so tests can fire them manually.
+    const scheduledCallbacks: Array<() => Promise<void> | void> = []
+    const createVotingSessionMock = vi.fn()
+
+    return { mockDb, dbResults, dbCallCounts, scheduledCallbacks, createVotingSessionMock }
+  })
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@/infrastructure/database/connection.js', () => ({ db: mockDb }))
+
+vi.mock('@/infrastructure/logger/logger.js', () => {
+  const noop = () => {}
+  const child = () => ({ info: noop, warn: noop, error: noop, debug: noop, child })
+  return { logger: { info: noop, warn: noop, error: noop, debug: noop, child } }
+})
+
+vi.mock('@/domain/create-session.js', () => ({
+  createVotingSession: createVotingSessionMock,
+}))
+
+vi.mock('node-cron', () => {
+  const stop = vi.fn()
+  return {
+    default: {
+      validate: () => true,
+      schedule: (_expr: string, cb: () => Promise<void> | void) => {
+        scheduledCallbacks.push(cb)
+        return { stop }
+      },
+    },
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setDbResult(table: string, ...values: unknown[]) {
+  dbResults.set(table, values)
+}
+
+// ---------------------------------------------------------------------------
+// Import module under test (after mocks)
+// ---------------------------------------------------------------------------
+
+import { updateGroupSchedule } from '../auto-vote-scheduler.js'
+
+describe('auto-vote-scheduler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    dbResults.clear()
+    dbCallCounts.clear()
+    scheduledCallbacks.length = 0
+    createVotingSessionMock.mockReset()
+  })
+
+  it('persists the auto-close target on the session row so it survives a restart', async () => {
+    // Arrange — the cron tick reads members, then existing open session,
+    // then the group owner. Configure the mock db results in that order.
+    setDbResult('group_members', ['user-a', 'user-b', 'user-c']) // member ids
+    setDbResult('voting_sessions', undefined) // no existing open session
+    // Owner lookup: a single row
+    dbResults.set('group_members', ['user-a', 'user-b', 'user-c']) // memberIds.pluck()
+    // The second call to db('group_members') is the owner lookup; we override
+    // by sequencing two distinct results for the same table.
+    dbResults.set('group_members', [
+      ['user-a', 'user-b', 'user-c'], // first call: pluck() returns array
+      { user_id: 'user-a' }, // second call: .first() returns owner row
+    ])
+
+    createVotingSessionMock.mockResolvedValue({
+      session: { id: 'session-1' },
+      games: [],
+    })
+
+    // Pin the clock so we can assert the close target deterministically.
+    const fixedNow = new Date('2026-04-13T20:00:00.000Z').getTime()
+    vi.spyOn(Date, 'now').mockReturnValue(fixedNow)
+
+    // Act — register a schedule (registers a cron callback in our mock),
+    // then fire that callback as if the cron had ticked.
+    updateGroupSchedule('group-1', '0 21 * * 5', 90)
+    expect(scheduledCallbacks.length).toBe(1)
+    const tick = scheduledCallbacks[0]
+    expect(tick).toBeDefined()
+    await tick!()
+
+    // Assert — createVotingSession received scheduledAt = now + 90 minutes.
+    expect(createVotingSessionMock).toHaveBeenCalledTimes(1)
+    const call = createVotingSessionMock.mock.calls[0]?.[0] as {
+      scheduledAt?: Date
+      groupId: string
+      createdBy: string
+      participantIds: string[]
+    }
+    expect(call.groupId).toBe('group-1')
+    expect(call.createdBy).toBe('user-a')
+    expect(call.participantIds).toEqual(['user-a', 'user-b', 'user-c'])
+    expect(call.scheduledAt).toBeInstanceOf(Date)
+    expect(call.scheduledAt?.getTime()).toBe(fixedNow + 90 * 60 * 1000)
+  })
+
+  it('skips when the group has fewer than 2 members', async () => {
+    setDbResult('group_members', ['user-a'])
+
+    updateGroupSchedule('group-2', '0 21 * * 5', 60)
+    const tick = scheduledCallbacks[0]
+    await tick!()
+
+    expect(createVotingSessionMock).not.toHaveBeenCalled()
+  })
+
+  it('skips when an open session already exists', async () => {
+    dbResults.set('group_members', [['user-a', 'user-b']])
+    setDbResult('voting_sessions', { id: 'existing-session' })
+
+    updateGroupSchedule('group-3', '0 21 * * 5', 60)
+    const tick = scheduledCallbacks[0]
+    await tick!()
+
+    expect(createVotingSessionMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/backend/src/infrastructure/scheduler/auto-vote-scheduler.ts
+++ b/packages/backend/src/infrastructure/scheduler/auto-vote-scheduler.ts
@@ -1,16 +1,12 @@
 import cron, { type ScheduledTask } from 'node-cron'
 import { db } from '../database/connection.js'
 import { createVotingSession } from '../../domain/create-session.js'
-import { closeSession } from '../../domain/close-session.js'
 import { logger } from '../logger/logger.js'
 
 const schedulerLogger = logger.child({ module: 'auto-vote-scheduler' })
 
 /** Map of group ID -> scheduled cron task */
 const scheduledTasks = new Map<string, ScheduledTask>()
-
-/** Map of group ID -> auto-close timeout */
-const autoCloseTimeouts = new Map<string, ReturnType<typeof setTimeout>>()
 
 interface GroupSchedule {
   id: string
@@ -20,6 +16,12 @@ interface GroupSchedule {
 
 /**
  * Schedule a cron job for a single group's auto-vote.
+ *
+ * When the cron fires, we create a voting session with `scheduled_at` set to
+ * `now + duration_minutes`. The general-purpose vote scheduler in
+ * `vote-scheduler.ts` polls for sessions past their `scheduled_at` and closes
+ * them, so the auto-close survives a backend restart instead of relying on an
+ * in-process `setTimeout` that would be lost when the node dies.
  */
 function scheduleGroupAutoVote(group: GroupSchedule): void {
   // Stop existing task if any
@@ -27,12 +29,6 @@ function scheduleGroupAutoVote(group: GroupSchedule): void {
   if (existing) {
     existing.stop()
     scheduledTasks.delete(group.id)
-  }
-
-  const existingTimeout = autoCloseTimeouts.get(group.id)
-  if (existingTimeout) {
-    clearTimeout(existingTimeout)
-    autoCloseTimeouts.delete(group.id)
   }
 
   if (!group.auto_vote_schedule || !cron.validate(group.auto_vote_schedule)) {
@@ -73,39 +69,29 @@ function scheduleGroupAutoVote(group: GroupSchedule): void {
         return
       }
 
+      // Compute the auto-close target and persist it on the session row so
+      // the durable vote-scheduler polling closes it even if this process
+      // restarts before the duration elapses.
+      const durationMinutes = group.auto_vote_duration_minutes || 120
+      const closeAt = new Date(Date.now() + durationMinutes * 60 * 1000)
+
       const result = await createVotingSession({
         groupId: group.id,
         createdBy: owner.user_id,
         participantIds: memberIds,
+        scheduledAt: closeAt,
       })
 
       schedulerLogger.info(
-        { groupId: group.id, sessionId: result.session.id, gameCount: result.games.length },
+        {
+          groupId: group.id,
+          sessionId: result.session.id,
+          gameCount: result.games.length,
+          durationMinutes,
+          closeAt: closeAt.toISOString(),
+        },
         'auto-vote session created'
       )
-
-      // Schedule auto-close after the configured duration
-      const durationMs = (group.auto_vote_duration_minutes || 120) * 60 * 1000
-      const timeout = setTimeout(async () => {
-        try {
-          autoCloseTimeouts.delete(group.id)
-          const session = await db('voting_sessions')
-            .where({ id: result.session.id, status: 'open' })
-            .first()
-
-          if (session) {
-            await closeSession(result.session.id, group.id)
-            schedulerLogger.info(
-              { groupId: group.id, sessionId: result.session.id },
-              'auto-vote session auto-closed after duration'
-            )
-          }
-        } catch (err) {
-          schedulerLogger.error({ error: String(err), groupId: group.id }, 'auto-close failed')
-        }
-      }, durationMs)
-
-      autoCloseTimeouts.set(group.id, timeout)
     } catch (err) {
       schedulerLogger.error({ error: String(err), groupId: group.id }, 'auto-vote session creation failed')
     }
@@ -131,11 +117,6 @@ async function syncSchedules(): Promise<void> {
       if (!activeGroupIds.has(groupId)) {
         task.stop()
         scheduledTasks.delete(groupId)
-        const timeout = autoCloseTimeouts.get(groupId)
-        if (timeout) {
-          clearTimeout(timeout)
-          autoCloseTimeouts.delete(groupId)
-        }
         schedulerLogger.info({ groupId }, 'auto-vote unscheduled (schedule removed)')
       }
     }
@@ -178,11 +159,6 @@ export function updateGroupSchedule(groupId: string, schedule: string | null, du
     if (existing) {
       existing.stop()
       scheduledTasks.delete(groupId)
-    }
-    const timeout = autoCloseTimeouts.get(groupId)
-    if (timeout) {
-      clearTimeout(timeout)
-      autoCloseTimeouts.delete(groupId)
     }
     schedulerLogger.info({ groupId }, 'auto-vote unscheduled')
     return

--- a/packages/backend/src/presentation/routes/admin.routes.ts
+++ b/packages/backend/src/presentation/routes/admin.routes.ts
@@ -2,6 +2,8 @@ import { Router, type Request, type Response } from 'express'
 import { db } from '../../infrastructure/database/connection.js'
 import { authLogger } from '../../infrastructure/logger/logger.js'
 import { invalidatePremiumCache } from '../../domain/subscription-service.js'
+import { recordAdminAction } from '../../domain/admin-audit-log.js'
+import { invalidateAllUserSessions } from '../../domain/auth-service.js'
 
 const router = Router()
 
@@ -60,6 +62,11 @@ router.patch('/bot-settings', async (req: Request, res: Response) => {
   }
 
   authLogger.info({ userId: req.userId, keys: Object.keys(updates) }, 'admin updated bot settings')
+  await recordAdminAction({
+    req,
+    action: 'bot_settings.update',
+    metadata: { keys: Object.keys(updates) },
+  })
 
   res.json({ ok: true })
 })
@@ -149,7 +156,7 @@ router.get('/users', async (req: Request, res: Response) => {
 
 // Toggle admin status for a user
 router.patch('/users/:id/admin', async (req: Request, res: Response) => {
-  const targetId = req.params['id']
+  const targetId = String(req.params['id'])
   const { isAdmin } = req.body as { isAdmin?: boolean }
 
   if (typeof isAdmin !== 'boolean') {
@@ -172,12 +179,28 @@ router.patch('/users/:id/admin', async (req: Request, res: Response) => {
   await db('users').where({ id: targetId }).update({ is_admin: isAdmin })
   authLogger.warn({ userId: req.userId, targetId, isAdmin }, 'admin role changed')
 
+  // Force the target to re-authenticate so any in-flight sessions pick up
+  // the new privilege state immediately. Critical when revoking admin: a
+  // lingering session would otherwise keep working until natural expiry.
+  const invalidatedSessions = await invalidateAllUserSessions(targetId)
+
+  await recordAdminAction({
+    req,
+    action: isAdmin ? 'user.admin.grant' : 'user.admin.revoke',
+    targetUserId: targetId,
+    metadata: {
+      previousIsAdmin: !!target.is_admin,
+      newIsAdmin: isAdmin,
+      invalidatedSessions,
+    },
+  })
+
   res.json({ ok: true })
 })
 
 // Grant or revoke admin-granted premium access for a user
 router.patch('/users/:id/premium', async (req: Request, res: Response) => {
-  const targetId = req.params['id']
+  const targetId = String(req.params['id'])
   const { isPremium } = req.body as { isPremium?: boolean }
 
   if (typeof isPremium !== 'boolean') {
@@ -192,12 +215,27 @@ router.patch('/users/:id/premium', async (req: Request, res: Response) => {
   }
 
   await db('users').where({ id: targetId }).update({ admin_granted_premium: isPremium })
-  invalidatePremiumCache(targetId!)
+  invalidatePremiumCache(targetId)
 
   authLogger.warn(
     { userId: req.userId, targetId, isPremium },
     'admin-granted premium changed',
   )
+
+  // Force re-auth so the next session reflects the new tier without waiting
+  // for the in-memory premium cache to expire on every backend instance.
+  const invalidatedSessions = await invalidateAllUserSessions(targetId)
+
+  await recordAdminAction({
+    req,
+    action: isPremium ? 'user.premium.grant' : 'user.premium.revoke',
+    targetUserId: targetId,
+    metadata: {
+      previousAdminGrantedPremium: !!target.admin_granted_premium,
+      newAdminGrantedPremium: isPremium,
+      invalidatedSessions,
+    },
+  })
 
   res.json({ ok: true })
 })
@@ -292,6 +330,11 @@ router.post('/personas', async (req: Request, res: Response) => {
   })
 
   authLogger.info({ userId: req.userId, personaId: id }, 'admin created persona')
+  await recordAdminAction({
+    req,
+    action: 'persona.create',
+    metadata: { personaId: id, name },
+  })
 
   res.status(201).json({ ok: true, id })
 })
@@ -328,6 +371,11 @@ router.patch('/personas/:id', async (req: Request, res: Response) => {
   await db('personas').where({ id: personaId }).update(updates)
 
   authLogger.info({ userId: req.userId, personaId }, 'admin updated persona')
+  await recordAdminAction({
+    req,
+    action: 'persona.update',
+    metadata: { personaId, fields: Object.keys(updates).filter(k => k !== 'updated_at') },
+  })
 
   res.json({ ok: true })
 })
@@ -349,6 +397,11 @@ router.delete('/personas/:id', async (req: Request, res: Response) => {
   await db('personas').where({ id: personaId }).del()
 
   authLogger.info({ userId: req.userId, personaId }, 'admin deleted persona')
+  await recordAdminAction({
+    req,
+    action: 'persona.delete',
+    metadata: { personaId, name: persona.name },
+  })
 
   res.json({ ok: true })
 })
@@ -369,6 +422,11 @@ router.patch('/personas/:id/toggle', async (req: Request, res: Response) => {
   })
 
   authLogger.info({ userId: req.userId, personaId, isActive: newActive }, 'admin toggled persona')
+  await recordAdminAction({
+    req,
+    action: 'persona.toggle',
+    metadata: { personaId, isActive: newActive },
+  })
 
   res.json({ ok: true, isActive: newActive })
 })

--- a/packages/backend/src/presentation/routes/vote.routes.ts
+++ b/packages/backend/src/presentation/routes/vote.routes.ts
@@ -260,6 +260,21 @@ router.post('/:groupId/vote/:sessionId', async (req: Request, res: Response) => 
 
   const gameIdMap = new Map(sessionGames.map(g => [g.steam_app_id, g.game_id]))
 
+  // Reject votes for steam_app_ids that are not part of this session. Without
+  // this check, a malicious client could insert vote rows for arbitrary
+  // app ids, polluting the tally and bypassing session game filters.
+  const invalidAppIds = voteEntries
+    .map(v => v.steamAppId)
+    .filter(id => !gameIdMap.has(id))
+  if (invalidAppIds.length > 0) {
+    res.status(400).json({
+      error: 'validation',
+      message: 'Some games are not part of this voting session',
+      invalidAppIds,
+    })
+    return
+  }
+
   // Upsert all votes in a single transaction
   await db.transaction(async (trx) => {
     for (const entry of voteEntries) {

--- a/packages/frontend/src/components/celebration-particles.tsx
+++ b/packages/frontend/src/components/celebration-particles.tsx
@@ -1,0 +1,57 @@
+import { useState } from 'react'
+import { motion } from 'framer-motion'
+
+interface Particle {
+  id: number
+  x: number
+  delay: number
+  duration: number
+  size: number
+  color: string
+}
+
+interface CelebrationParticlesProps {
+  /** Number of particles per burst (default 18). Pass a smaller value for
+   * more frequent, lighter bursts (e.g. one per incoming vote). */
+  count?: number
+}
+
+function createParticles(count: number): Particle[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: i,
+    x: Math.random() * 100,
+    delay: Math.random() * 0.4,
+    duration: 0.7 + Math.random() * 0.5,
+    size: 4 + Math.random() * 8,
+    color: i % 3 === 0 ? 'bg-primary/60' : i % 3 === 1 ? 'bg-neon/50' : 'bg-ember/50',
+  }))
+}
+
+/**
+ * Sparkle particles that burst upward from the parent's bottom edge.
+ *
+ * Place inside a `relative` container — the particles are absolutely
+ * positioned within `inset-0`. To trigger a fresh burst (e.g. each time a
+ * new vote comes in), pass a changing `key` prop so React remounts the
+ * component and the lazy initializer recomputes random positions.
+ */
+export function CelebrationParticles({ count = 18 }: CelebrationParticlesProps = {}) {
+  // Lazy state initializer so Math.random is only called once on mount
+  // (React Compiler rejects calls to impure functions during render).
+  const [particles] = useState<Particle[]>(() => createParticles(count))
+
+  return (
+    <div className="pointer-events-none absolute inset-0 overflow-hidden">
+      {particles.map(p => (
+        <motion.div
+          key={p.id}
+          className={`absolute rounded-full ${p.color}`}
+          style={{ left: `${p.x}%`, width: p.size, height: p.size }}
+          initial={{ y: '50%', opacity: 1, scale: 0 }}
+          animate={{ y: '-120%', opacity: 0, scale: 1.2 }}
+          transition={{ delay: p.delay, duration: p.duration, ease: 'easeOut' }}
+        />
+      ))}
+    </div>
+  )
+}

--- a/packages/frontend/src/components/random-pick-modal.tsx
+++ b/packages/frontend/src/components/random-pick-modal.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/components/ui/responsive-dialog'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
+import { CelebrationParticles } from '@/components/celebration-particles'
 
 interface Game {
   steamAppId: number
@@ -30,48 +31,6 @@ function shuffleArray<T>(array: T[]): T[] {
     ;[shuffled[i], shuffled[j]] = [shuffled[j]!, shuffled[i]!]
   }
   return shuffled
-}
-
-interface Particle {
-  id: number
-  x: number
-  delay: number
-  duration: number
-  size: number
-  color: string
-}
-
-function createParticles(): Particle[] {
-  return Array.from({ length: 18 }, (_, i) => ({
-    id: i,
-    x: Math.random() * 100,
-    delay: Math.random() * 0.4,
-    duration: 0.7 + Math.random() * 0.5,
-    size: 4 + Math.random() * 8,
-    color: i % 3 === 0 ? 'bg-primary/60' : i % 3 === 1 ? 'bg-neon/50' : 'bg-ember/50',
-  }))
-}
-
-/** Celebration sparkle particles shown on reveal */
-function CelebrationParticles() {
-  // Use lazy state initializer so Math.random is only called once on mount
-  // (React Compiler rejects calls to impure functions during render)
-  const [particles] = useState<Particle[]>(createParticles)
-
-  return (
-    <div className="pointer-events-none absolute inset-0 overflow-hidden">
-      {particles.map(p => (
-        <motion.div
-          key={p.id}
-          className={`absolute rounded-full ${p.color}`}
-          style={{ left: `${p.x}%`, width: p.size, height: p.size }}
-          initial={{ y: '50%', opacity: 1, scale: 0 }}
-          animate={{ y: '-120%', opacity: 0, scale: 1.2 }}
-          transition={{ delay: p.delay, duration: p.duration, ease: 'easeOut' }}
-        />
-      ))}
-    </div>
-  )
 }
 
 function RandomPickContent({ games }: { games: Game[] }) {

--- a/packages/frontend/src/i18n/locales/en.json
+++ b/packages/frontend/src/i18n/locales/en.json
@@ -186,6 +186,7 @@
   "vote": {
     "tonightYouPlay": "Tonight you're playing",
     "votedFor": "{{yes}} out of {{total}} voted for it",
+    "consensusPercent": "{{percent}}% consensus",
     "launchSteam": "Launch on Steam",
     "backToGroup": "Back to group",
     "submitted": "Vote submitted!",

--- a/packages/frontend/src/i18n/locales/fr.json
+++ b/packages/frontend/src/i18n/locales/fr.json
@@ -195,6 +195,7 @@
   "vote": {
     "tonightYouPlay": "Ce soir vous jouez à",
     "votedFor": "{{yes}} sur {{total}} ont voté pour",
+    "consensusPercent": "{{percent}} % de consensus",
     "launchSteam": "Lancer sur Steam",
     "backToGroup": "Retour au groupe",
     "submitted": "Vote soumis !",

--- a/packages/frontend/src/pages/VotePage.tsx
+++ b/packages/frontend/src/pages/VotePage.tsx
@@ -412,8 +412,26 @@ export function VotePage() {
           />
         </div>
 
-        {/* Game grid */}
-        <div role="list" className="grid grid-cols-2 sm:grid-cols-3 gap-3 flex-1 overflow-y-auto pb-24">
+        {/* Scrollable grid area: holds the sticky selection badge so users
+            don't lose track of their pick count while scrolling on mobile. */}
+        <div className="flex-1 overflow-y-auto pb-24">
+          {/* Sticky selection counter — appears at the top of the scroll
+              container as soon as the user picks at least one game. The
+              floating bottom bar still shows the same count and the submit
+              CTA, but on mobile the bottom bar is easily covered by the
+              scrolling thumb, so this pill keeps the context visible at the
+              top of the viewport. */}
+          {selectedGames.size > 0 && (
+            <div
+              aria-hidden="true"
+              className="sticky top-0 z-10 -mx-1 mb-3 flex justify-center pointer-events-none"
+            >
+              <span className="rounded-full border border-primary/40 bg-background/85 px-3 py-1 text-xs font-medium text-foreground shadow-sm backdrop-blur">
+                {t('vote.gamesSelected', { count: selectedGames.size })}
+              </span>
+            </div>
+          )}
+          <div role="list" className="grid grid-cols-2 sm:grid-cols-3 gap-3">
           {filteredGames.map(game => {
             const isSelected = selectedGames.has(game.steamAppId)
             return (
@@ -477,6 +495,7 @@ export function VotePage() {
               </div>
             )
           })}
+          </div>
         </div>
 
         {/* Game detail dialog */}

--- a/packages/frontend/src/pages/VotePage.tsx
+++ b/packages/frontend/src/pages/VotePage.tsx
@@ -24,6 +24,7 @@ import {
   ResponsiveDialogFooter,
 } from '@/components/ui/responsive-dialog'
 import { ShareButton } from '@/components/share-button'
+import { CelebrationParticles } from '@/components/celebration-particles'
 
 interface Game {
   steamAppId: number
@@ -337,7 +338,13 @@ export function VotePage() {
           {t('vote.waiting', { done: voterCount, total: totalMembers })}
         </p>
 
-        <Progress value={voterCount} max={totalMembers} className="w-48 mb-8" />
+        <div className="relative w-48 mb-8">
+          {/* Burst a fresh set of particles each time voterCount increments —
+              the changing key remounts the component so the lazy initializer
+              regenerates random positions and the animation replays. */}
+          {voterCount > 0 && <CelebrationParticles key={voterCount} count={10} />}
+          <Progress value={voterCount} max={totalMembers} />
+        </div>
 
         {canClose && (
           <Button onClick={handleClose} disabled={closing}>

--- a/packages/frontend/src/pages/VotePage.tsx
+++ b/packages/frontend/src/pages/VotePage.tsx
@@ -257,9 +257,42 @@ export function VotePage() {
               </motion.div>
             )}
             <motion.h1 variants={resultFade} className="text-3xl font-heading font-bold mb-2">{result.gameName}</motion.h1>
-            <motion.p variants={resultFade} className="text-muted-foreground mb-8">
+            <motion.p variants={resultFade} className="text-muted-foreground mb-4">
               {t('vote.votedFor', { yes: result.yesCount, total: result.totalVoters })}
             </motion.p>
+
+            {/* Consensus breakdown — animated bar fills from 0 to the win
+                percentage so the magnitude of the agreement feels earned
+                instead of being dropped in as a static line of text. */}
+            {result.totalVoters > 0 && (() => {
+              const percent = Math.round((result.yesCount / result.totalVoters) * 100)
+              return (
+                <motion.div variants={resultFade} className="mb-8 w-full max-w-xs mx-auto">
+                  <div className="flex items-center justify-between text-xs text-muted-foreground mb-1.5">
+                    <span>{t('vote.consensusPercent', { percent })}</span>
+                    <span>{result.yesCount}/{result.totalVoters}</span>
+                  </div>
+                  <div
+                    role="progressbar"
+                    aria-valuenow={percent}
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                    className="h-2 w-full overflow-hidden rounded-full bg-secondary"
+                  >
+                    <motion.div
+                      className="h-full rounded-full bg-reward shadow-[0_0_12px_rgba(255,215,128,0.45)]"
+                      initial={{ width: '0%' }}
+                      animate={{ width: `${percent}%` }}
+                      transition={{
+                        duration: prefersReducedMotion ? 0.2 : 1.1,
+                        delay: prefersReducedMotion ? 0 : 0.5,
+                        ease: [0.22, 1, 0.36, 1],
+                      }}
+                    />
+                  </div>
+                </motion.div>
+              )
+            })()}
 
             <motion.div variants={resultFade}>
               {Number.isInteger(result.steamAppId) && result.steamAppId > 0 && (


### PR DESCRIPTION
## Summary

Outcome of a 6-persona feature meeting (PM, UX, backend, frontend, QA/security, Discord) reviewing the codebase for the next round of improvements. Notes are committed under `docs/feature-meeting-2026-04-13.md`. This PR ships the items that were highest-consensus or unblocked by the meeting:

### Sprint 1 — trust foundations (admin surface hardening)

- **`feat(admin): audit log, rate limit and session rotation on privileged actions`** — new `admin_audit_log` table records actor / target / action / metadata / IP / UA for every privileged mutation. `recordAdminAction()` helper centralises writes and never throws. Admin role and admin-granted premium changes now invalidate every existing session of the target user via `invalidateAllUserSessions()`, forcing immediate re-authentication. New `adminMutationLimiter` caps state-changing `/api/admin` requests at 30/5min (reads stay on the global limiter).
- **`fix(vote): reject votes for games not part of the session`** — the cast-votes endpoint used to silently insert vote rows for any `steam_app_id` supplied by the client. We now reject with 400 + `invalidAppIds` when an appid is not in `voting_session_games`. The DB-level uniqueness constraint already exists; this closes the integrity gap on top of it.

### Sprint 2 — auto-vote reliability

- **`fix(scheduler): persist auto-vote close time so sessions survive a restart`** — `auto-vote-scheduler.ts` used an in-process `setTimeout` to auto-close sessions; if the backend restarted before the timer fired, the session would stay open forever. Auto-vote sessions now set `scheduled_at = now + duration_minutes`, and the existing `vote-scheduler.ts` polling (which already closes overdue scheduled sessions) handles the close durably. Removes the `autoCloseTimeouts` map and adds 3 unit tests (mocks `node-cron` to capture the cron callback and fires it manually).

### UX polish

- **`feat(vote): burst celebration particles on every incoming vote`** — extracts the existing `CelebrationParticles` from `random-pick-modal.tsx` into its own component file and reuses it on the "waiting for votes" screen. Each `vote:cast` socket event triggers a fresh burst keyed on `voterCount`, so the React lazy initializer regenerates random positions and the Framer Motion animation replays. `count={10}` keeps each burst lighter than the reveal celebration.
- **`feat(vote): sticky selection count pill on the mobile vote grid`** — splits the grid's scroll context from the grid itself and adds a sticky `position: sticky` pill at the top of the scroll container so users don't lose track of how many games they've picked when scrolling. `pointer-events-none` so taps fall through; `aria-hidden` so screen readers continue to use the existing canonical `aria-live` announcement on the bottom bar.

## Test plan

- [x] Backend: `npm test --workspace=@wawptn/backend` → 17/17 passing (3 new tests for the auto-vote scheduler durability fix)
- [x] Backend: `npx tsc --noEmit -p packages/backend` → clean
- [x] Frontend: `npx tsc --noEmit -p packages/frontend` → clean
- [x] Frontend: `npx eslint` on touched files → clean (4 pre-existing warnings unchanged)
- [ ] Manual: log in as admin, toggle admin/premium on a test user, verify a row appears in `admin_audit_log` and the target's sessions are gone
- [ ] Manual: configure a group `auto_vote_schedule` with a 2-minute duration, restart the backend mid-session, verify the session still auto-closes via the scheduler poller
- [ ] Manual: open the vote page on a mobile viewport, scroll the game grid, confirm the sticky count pill stays at the top
- [ ] Manual: open the vote waiting screen, confirm a particle burst plays each time a new vote comes in

https://claude.ai/code/session_011em4KFFeJY36J4Yxad8zeA