### PR TITLE
feat(discord): /wawptn-stats command with per-group leaderboard

### DIFF
--- a/docs/api-architecture.md
+++ b/docs/api-architecture.md
@@ -79,6 +79,7 @@ Routes activées uniquement si `DISCORD_BOT_API_SECRET` est configuré. Authenti
 | POST | `/api/discord/link/confirm` | Utilisateur | Confirme la liaison avec un code |
 | POST | `/api/discord/vote` | Bot | Enregistre un vote depuis Discord |
 | GET | `/api/discord/games` | Bot | Liste les jeux communs d'un canal lié |
+| GET | `/api/discord/stats` | Bot | Classement et statistiques d'un groupe (organisateurs, votants, jeux gagnants, séries) |
 | POST | `/api/discord/webhook` | Utilisateur | Configure le webhook Discord d'un groupe |
 
 ### Invitation (public)

--- a/packages/backend/src/presentation/routes/discord.routes.ts
+++ b/packages/backend/src/presentation/routes/discord.routes.ts
@@ -725,6 +725,112 @@ router.get('/linked-channels', async (_req: Request, res: Response) => {
   res.json(channels)
 })
 
+// Group leaderboard: aggregates voting activity into three rankings so the
+// Discord bot can surface "who's the most active in this group". Used by the
+// /wawptn-stats slash command.
+router.get('/stats', async (req: Request, res: Response) => {
+  const userId = req.userId
+
+  if (!userId) {
+    res.status(403).json({ error: 'forbidden', message: 'Discord account not linked. Use /wawptn-link first.' })
+    return
+  }
+
+  const groupId = req.query['groupId'] as string
+  if (!groupId) {
+    res.status(400).json({ error: 'validation', message: 'groupId query parameter required' })
+    return
+  }
+
+  // Verify the requesting user is a member of the group — leaderboards are
+  // group-private and should never leak across groups.
+  const membership = await db('group_members')
+    .where({ group_id: groupId, user_id: userId })
+    .first()
+  if (!membership) {
+    res.status(403).json({ error: 'forbidden', message: 'Vous n\'êtes pas membre de ce groupe' })
+    return
+  }
+
+  const group = await db('groups').where({ id: groupId }).first()
+  if (!group) {
+    res.status(404).json({ error: 'not_found', message: 'Groupe introuvable' })
+    return
+  }
+
+  // ── Top vote launchers — who created the most voting sessions ──────────
+  // Limited to closed sessions so cancelled or stale draft sessions don't
+  // skew the count.
+  const launchers = await db('voting_sessions')
+    .join('users', 'voting_sessions.created_by', 'users.id')
+    .where({ 'voting_sessions.group_id': groupId, 'voting_sessions.status': 'closed' })
+    .groupBy('users.id', 'users.display_name')
+    .select(
+      'users.id as userId',
+      'users.display_name as displayName',
+      db.raw('COUNT(voting_sessions.id)::int as count'),
+    )
+    .orderBy('count', 'desc')
+    .limit(5)
+
+  // ── Most active voters — distinct sessions each member has cast a vote in ──
+  const voters = await db('votes')
+    .join('voting_sessions', 'votes.session_id', 'voting_sessions.id')
+    .join('users', 'votes.user_id', 'users.id')
+    .where({ 'voting_sessions.group_id': groupId, 'voting_sessions.status': 'closed' })
+    .groupBy('users.id', 'users.display_name')
+    .select(
+      'users.id as userId',
+      'users.display_name as displayName',
+      db.raw('COUNT(DISTINCT votes.session_id)::int as count'),
+    )
+    .orderBy('count', 'desc')
+    .limit(5)
+
+  // ── Top winning games — count of times each game won a session ─────────
+  const topGames = await db('voting_sessions')
+    .where({ group_id: groupId, status: 'closed' })
+    .whereNotNull('winning_game_app_id')
+    .groupBy('winning_game_app_id', 'winning_game_name')
+    .select(
+      'winning_game_app_id as steamAppId',
+      'winning_game_name as gameName',
+      db.raw('COUNT(*)::int as wins'),
+    )
+    .orderBy('wins', 'desc')
+    .limit(5)
+
+  // ── Streak leaders — best consecutive participation streak in this group ──
+  const streakLeaders = await db('streaks')
+    .join('users', 'streaks.user_id', 'users.id')
+    .where({ 'streaks.group_id': groupId })
+    .where('streaks.best_streak', '>', 0)
+    .orderBy('streaks.best_streak', 'desc')
+    .orderBy('streaks.current_streak', 'desc')
+    .limit(5)
+    .select(
+      'users.id as userId',
+      'users.display_name as displayName',
+      'streaks.current_streak as currentStreak',
+      'streaks.best_streak as bestStreak',
+    )
+
+  const totalSessionsRow = await db('voting_sessions')
+    .where({ group_id: groupId, status: 'closed' })
+    .count('id as count')
+    .first()
+
+  res.json({
+    groupId,
+    groupName: group.name,
+    totalSessions: Number(totalSessionsRow?.count ?? 0),
+    launchers,
+    voters,
+    topGames,
+    streakLeaders,
+  })
+})
+
 // ─── User-authenticated routes (called from web frontend) ─────────────────────
 
 const userRouter = Router()

--- a/packages/discord/src/commands/stats.ts
+++ b/packages/discord/src/commands/stats.ts
@@ -1,0 +1,41 @@
+import { SlashCommandBuilder, type ChatInputCommandInteraction } from 'discord.js'
+import { backendApi } from '../lib/api.js'
+import { resolveGroup } from '../lib/resolve-group.js'
+import { buildStatsEmbed, type StatsResponse } from '../lib/embeds.js'
+
+export const data = new SlashCommandBuilder()
+  .setName('wawptn-stats')
+  .setDescription('Afficher le classement et les statistiques du groupe')
+
+export async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
+  await interaction.deferReply({ ephemeral: true })
+
+  const group = await resolveGroup(interaction)
+  if (!group) return
+
+  try {
+    const stats = await backendApi<StatsResponse>(
+      `/api/discord/stats?groupId=${group.groupId}`,
+      { discordUserId: interaction.user.id },
+    )
+
+    const embed = buildStatsEmbed(stats)
+
+    // Post the leaderboard publicly so the whole channel sees it. The
+    // ephemeral defer above is upgraded to an in-channel send to match the
+    // pattern used by /wawptn-random.
+    if (interaction.channel && 'send' in interaction.channel) {
+      await interaction.channel.send({ embeds: [embed] })
+    }
+
+    await interaction.editReply({
+      content: `📊 Statistiques de **${group.groupName}** affichées dans le canal !`,
+      components: [],
+    })
+  } catch (error) {
+    await interaction.editReply({
+      content: `❌ ${error instanceof Error ? error.message : 'Erreur lors de la récupération des stats'}`,
+      components: [],
+    })
+  }
+}

--- a/packages/discord/src/index.ts
+++ b/packages/discord/src/index.ts
@@ -25,6 +25,7 @@ import * as gamesCommand from './commands/games.js'
 import * as voteCommand from './commands/vote.js'
 import * as randomCommand from './commands/random.js'
 import * as dailyChallengeCommand from './commands/daily-challenge.js'
+import * as statsCommand from './commands/stats.js'
 
 validateEnv()
 
@@ -43,6 +44,7 @@ const commands = new Map([
   ['wawptn-vote', voteCommand],
   ['wawptn-random', randomCommand],
   ['wawptn-daily-challenge', dailyChallengeCommand],
+  ['wawptn-stats', statsCommand],
 ])
 
 client.once(Events.ClientReady, async (c) => {

--- a/packages/discord/src/lib/embeds.ts
+++ b/packages/discord/src/lib/embeds.ts
@@ -116,6 +116,67 @@ export function buildRandomGameEmbed(
   return embed
 }
 
+export interface StatsResponse {
+  groupName: string
+  totalSessions: number
+  launchers: Array<{ userId: string; displayName: string; count: number }>
+  voters: Array<{ userId: string; displayName: string; count: number }>
+  topGames: Array<{ steamAppId: number; gameName: string; wins: number }>
+  streakLeaders: Array<{ userId: string; displayName: string; currentStreak: number; bestStreak: number }>
+}
+
+const RANK_MEDALS = ['🥇', '🥈', '🥉', '🏅', '🏅']
+
+function formatRankedList<T>(rows: T[], render: (row: T, rank: number) => string): string {
+  if (rows.length === 0) return '_Pas encore de données_'
+  return rows.map((row, i) => `${RANK_MEDALS[i] ?? '•'} ${render(row, i + 1)}`).join('\n')
+}
+
+export function buildStatsEmbed(stats: StatsResponse): EmbedBuilder {
+  const embed = new EmbedBuilder()
+    .setTitle(`📊 Stats — ${stats.groupName}`)
+    .setColor(0x5865F2)
+    .setTimestamp()
+
+  if (stats.totalSessions === 0) {
+    embed.setDescription("Ce groupe n'a pas encore terminé de session de vote. Lancez-en une pour commencer le classement !")
+    return embed
+  }
+
+  embed.setDescription(`**${stats.totalSessions}** session${stats.totalSessions > 1 ? 's' : ''} de vote terminée${stats.totalSessions > 1 ? 's' : ''}.`)
+
+  embed.addFields(
+    {
+      name: '🚀 Top organisateurs',
+      value: formatRankedList(stats.launchers, (l) => `**${l.displayName}** — ${l.count} session${l.count > 1 ? 's' : ''}`),
+      inline: false,
+    },
+    {
+      name: '🗳️ Top votants',
+      value: formatRankedList(stats.voters, (v) => `**${v.displayName}** — ${v.count} vote${v.count > 1 ? 's' : ''}`),
+      inline: false,
+    },
+    {
+      name: '🏆 Jeux gagnants',
+      value: formatRankedList(stats.topGames, (g) => `**${g.gameName}** — ${g.wins} victoire${g.wins > 1 ? 's' : ''}`),
+      inline: false,
+    },
+  )
+
+  if (stats.streakLeaders.length > 0) {
+    embed.addFields({
+      name: '🔥 Séries de participation',
+      value: formatRankedList(stats.streakLeaders, (s) => {
+        const cur = s.currentStreak > 0 ? ` (en cours : ${s.currentStreak})` : ''
+        return `**${s.displayName}** — record ${s.bestStreak}${cur}`
+      }),
+      inline: false,
+    })
+  }
+
+  return embed
+}
+
 export function buildLinkEmbed(linkCode: string, frontendUrl: string): EmbedBuilder[] {
   const embed = new EmbedBuilder()
     .setTitle('🔗 Lier votre compte WAWPTN')


### PR DESCRIPTION
## Summary

Follow-up to #117 — implements **Tom #1** from the multi-persona feature meeting (`docs/feature-meeting-2026-04-13.md`): a Discord slash command that posts a per-group leaderboard so members can see who's the most active and which games keep winning.

## What's in this PR

- **Backend** — new `GET /api/discord/stats?groupId=X` bot-authenticated route in `discord.routes.ts`. Membership is verified before any rows are returned (leaderboards never leak across groups). Four aggregations against existing tables, scoped to closed sessions in the requested group:
  - **Top organisateurs** — `voting_sessions` grouped by `created_by`
  - **Top votants** — distinct sessions each member voted in
  - **Jeux gagnants** — most-frequent winning games
  - **Séries de participation** — best participation streaks (current + record), sourced from the existing `streaks` table
- **Discord bot** — new `commands/stats.ts` (~40 lines) following the `resolveGroup` + `backendApi` + embed pattern from `wawptn-random`. Posts the leaderboard publicly in the channel; reply confirmation is ephemeral.
- **Embed** — new `buildStatsEmbed` helper in `lib/embeds.ts` with a `formatRankedList` utility that renders 🥇🥈🥉🏅🏅 medals and falls back to a "_Pas encore de données_" line for empty rankings. Handles the `totalSessions === 0` edge case with a friendly invite to launch the first vote.
- **Wiring** — `wawptn-stats` registered in `index.ts` next to the other commands; auto-registered on bot startup via the existing slash command sync.
- **Docs** — `docs/api-architecture.md` gets a row for the new endpoint.

## Test plan

- [x] `npx tsc --noEmit -p packages/backend` → clean
- [x] `npx tsc --noEmit -p packages/discord` → clean
- [x] `npm test --workspace=@wawptn/backend` → 17/17 passing
- [ ] Manual: deploy the bot, run `/wawptn-stats` in a channel linked to a group with closed sessions and confirm the embed renders the four ranked sections
- [ ] Manual: run `/wawptn-stats` from a user who isn't a member of the resolved group and confirm the backend returns 403

## Design notes

- The query reuses the indexes already on `voting_sessions(group_id, status)` and `streaks(user_id, group_id)`, so no new indexes are introduced.
- The four leaderboards are all top-5; pagination / "show more" would need buttons and is out of scope for this PR.
- No caching is added — closed sessions are bounded per group and the queries are cheap. Revisit if the bot sees high traffic.

https://claude.ai/code/session_011em4KFFeJY36J4Yxad8zeA