### PR TITLE
feat(admin): /api/admin/health endpoint with integration circuit breaker state

### DIFF
--- a/docs/api-architecture.md
+++ b/docs/api-architecture.md
@@ -66,6 +66,7 @@ Routes accessibles uniquement aux utilisateurs ayant `is_admin = true`.
 | DELETE | `/api/admin/personas/:id` | Supprime une persona (sauf celles par défaut) |
 | PATCH | `/api/admin/personas/:id/toggle` | Active ou désactive une persona |
 | GET | `/api/admin/stats` | Statistiques globales (utilisateurs, groupes, sessions) |
+| GET | `/api/admin/health` | Santé des intégrations externes (Steam, Epic, GOG, base de données) |
 
 ### Discord (feature-flagged)
 

--- a/packages/backend/src/infrastructure/epic/epic-client.ts
+++ b/packages/backend/src/infrastructure/epic/epic-client.ts
@@ -65,6 +65,24 @@ function setCache(key: string, data: unknown): void {
   cache.set(key, { data, expiresAt: Date.now() + CACHE_TTL_MS })
 }
 
+/** Health snapshot exposed to /api/admin/health. */
+export function getHealth(): {
+  state: 'closed' | 'open'
+  consecutiveFailures: number
+  circuitOpenUntil: string | null
+  cacheSize: number
+  enabled: boolean
+} {
+  const open = isCircuitOpen()
+  return {
+    state: open ? 'open' : 'closed',
+    consecutiveFailures,
+    circuitOpenUntil: open && circuitOpenUntil > 0 ? new Date(circuitOpenUntil).toISOString() : null,
+    cacheSize: cache.size,
+    enabled: isEpicEnabled(),
+  }
+}
+
 export function isEpicEnabled(): boolean {
   return !!(env.EPIC_CLIENT_ID && env.EPIC_CLIENT_SECRET && env.EPIC_REDIRECT_URI)
 }

--- a/packages/backend/src/infrastructure/gog/gog-client.ts
+++ b/packages/backend/src/infrastructure/gog/gog-client.ts
@@ -66,6 +66,24 @@ function setCache(key: string, data: unknown): void {
   cache.set(key, { data, expiresAt: Date.now() + CACHE_TTL_MS })
 }
 
+/** Health snapshot exposed to /api/admin/health. */
+export function getHealth(): {
+  state: 'closed' | 'open'
+  consecutiveFailures: number
+  circuitOpenUntil: string | null
+  cacheSize: number
+  enabled: boolean
+} {
+  const open = isCircuitOpen()
+  return {
+    state: open ? 'open' : 'closed',
+    consecutiveFailures,
+    circuitOpenUntil: open && circuitOpenUntil > 0 ? new Date(circuitOpenUntil).toISOString() : null,
+    cacheSize: cache.size,
+    enabled: isGogEnabled(),
+  }
+}
+
 export function isGogEnabled(): boolean {
   return !!(env.GOG_CLIENT_ID && env.GOG_CLIENT_SECRET && env.GOG_REDIRECT_URI)
 }

--- a/packages/backend/src/infrastructure/steam/steam-client.ts
+++ b/packages/backend/src/infrastructure/steam/steam-client.ts
@@ -62,6 +62,27 @@ function recordFailure(): void {
   }
 }
 
+/**
+ * Snapshot of the Steam client's current health: circuit breaker state,
+ * cache size, and whether requests are currently being shed. Read by the
+ * /api/admin/health endpoint so admins can see when the integration is
+ * degraded without tailing the logs.
+ */
+export function getHealth(): {
+  state: 'closed' | 'open'
+  consecutiveFailures: number
+  circuitOpenUntil: string | null
+  cacheSize: number
+} {
+  const open = isCircuitOpen()
+  return {
+    state: open ? 'open' : 'closed',
+    consecutiveFailures,
+    circuitOpenUntil: open && circuitOpenUntil > 0 ? new Date(circuitOpenUntil).toISOString() : null,
+    cacheSize: cache.size,
+  }
+}
+
 export interface SteamOwnedGame {
   appid: number
   name: string

--- a/packages/backend/src/presentation/routes/admin.routes.ts
+++ b/packages/backend/src/presentation/routes/admin.routes.ts
@@ -4,6 +4,9 @@ import { authLogger } from '../../infrastructure/logger/logger.js'
 import { invalidatePremiumCache } from '../../domain/subscription-service.js'
 import { recordAdminAction } from '../../domain/admin-audit-log.js'
 import { invalidateAllUserSessions } from '../../domain/auth-service.js'
+import { getHealth as getSteamHealth } from '../../infrastructure/steam/steam-client.js'
+import { getHealth as getEpicHealth } from '../../infrastructure/epic/epic-client.js'
+import { getHealth as getGogHealth } from '../../infrastructure/gog/gog-client.js'
 
 const router = Router()
 
@@ -450,6 +453,49 @@ router.get('/stats', async (_req: Request, res: Response) => {
     authLogger.error({ error: String(error) }, 'failed to get admin stats')
     res.status(500).json({ error: 'internal', message: 'Failed to get admin stats' })
   }
+})
+
+// ─── Health / observability ──────────────────────────────────────────────────
+
+/**
+ * Aggregated health snapshot for ops. Surfaces the state of each external
+ * integration's circuit breaker + cache, plus a database ping. Lets admins
+ * see when an integration is degraded without tailing the logs.
+ *
+ * Mounted under /api/admin so it requires the admin middleware (the handler
+ * itself never throws — every dependency is wrapped in a try/catch so a
+ * single broken integration cannot 500 the whole report).
+ */
+router.get('/health', async (_req: Request, res: Response) => {
+  // Database ping — measures round-trip and reports up/down separately so a
+  // DB outage doesn't make the response itself unreadable.
+  let dbStatus: 'up' | 'down' = 'down'
+  let dbLatencyMs: number | null = null
+  try {
+    const start = Date.now()
+    await db.raw('SELECT 1')
+    dbLatencyMs = Date.now() - start
+    dbStatus = 'up'
+  } catch (error) {
+    authLogger.error({ error: String(error) }, 'admin health: database ping failed')
+  }
+
+  // Each integration getHealth() is synchronous and reads in-memory state.
+  // We still wrap them so a future async refactor (or an unexpected throw)
+  // can't take down the rest of the report.
+  const safe = <T>(fn: () => T, fallback: T): T => {
+    try { return fn() } catch { return fallback }
+  }
+
+  res.json({
+    timestamp: new Date().toISOString(),
+    database: { status: dbStatus, latencyMs: dbLatencyMs },
+    integrations: {
+      steam: safe(getSteamHealth, { state: 'open', consecutiveFailures: -1, circuitOpenUntil: null, cacheSize: 0 }),
+      epic: safe(getEpicHealth, { state: 'open', consecutiveFailures: -1, circuitOpenUntil: null, cacheSize: 0, enabled: false }),
+      gog: safe(getGogHealth, { state: 'open', consecutiveFailures: -1, circuitOpenUntil: null, cacheSize: 0, enabled: false }),
+    },
+  })
 })
 
 export { router as adminRoutes }


### PR DESCRIPTION
## Summary

Implements **Marcus #5** from the multi-persona feature meeting (`docs/feature-meeting-2026-04-13.md`): admins had no way to see the state of the external integrations without tailing the logs. When a Steam, Epic, or GOG circuit breaker tripped, the only signal was a `WARN` log entry that scrolled away.

This PR exposes the in-memory health of every external integration plus a database ping under a single admin-only endpoint.

## What's in this PR

- **`getHealth()` helpers** on `steam-client.ts`, `epic-client.ts`, `gog-client.ts`. Each returns:
  - `state` — `'open'` or `'closed'`
  - `consecutiveFailures` — current failure counter
  - `circuitOpenUntil` — ISO timestamp the breaker reopens at, or `null`
  - `cacheSize` — entries in the per-client in-memory cache
  - `enabled` *(epic/gog)* — whether the integration is actually configured (env vars present)
- **`GET /api/admin/health`** in `admin.routes.ts` that aggregates them and adds:
  - `timestamp` — report wall clock
  - `database` — `{ status: 'up' | 'down', latencyMs }` from a `SELECT 1` round-trip
- Each integration call is wrapped in a small `safe()` helper so a single broken integration cannot 500 the whole report. The DB ping is also isolated — a DB outage downgrades to `status: 'down'` with `latencyMs: null` instead of throwing.
- Mounted under `/api/admin`, so it inherits `requireAuth + requireAdmin`; the admin mutation rate limiter from #117 skips GET requests by design, so reads stay snappy.
- `docs/api-architecture.md` gets a row for the new endpoint.

## Test plan

- [x] `npx tsc --noEmit -p packages/backend` → clean
- [x] `npm test --workspace=@wawptn/backend` → 17/17 passing
- [ ] Manual: `curl -H 'cookie: …admin session…' /api/admin/health` and confirm the JSON shape
- [ ] Manual: stop the database, hit the endpoint, confirm `database.status === 'down'` instead of a 500

## Why hand-rolled in 3 places instead of an interface

The three platform clients share an identical hand-rolled circuit breaker pattern but have no shared base. Refactoring them onto a common `Integration` interface is worth doing but is a separate cleanup — it would touch every method on every client and balloon this PR. The three new `getHealth()` helpers are tiny enough (~12 lines each) to bear the duplication for now.

https://claude.ai/code/session_011em4KFFeJY36J4Yxad8zeA