### PR TITLE
feat(vote): per-participant progress dots on the waiting screen

### DIFF
--- a/packages/backend/src/presentation/routes/vote.routes.ts
+++ b/packages/backend/src/presentation/routes/vote.routes.ts
@@ -39,6 +39,14 @@ router.get('/:groupId/vote', async (req: Request, res: Response) => {
     .countDistinct('user_id as count')
     .first()
 
+  // Set of user IDs that have already cast at least one vote in this
+  // session. Used by the frontend to render per-participant progress on
+  // the waiting screen without guessing from a bare count.
+  const votedUserRows = await db('votes')
+    .where({ session_id: session.id })
+    .distinct('user_id')
+    .pluck('user_id')
+
   // Get total participants from junction table, fallback to group_members for legacy sessions
   const participantCount = await db('voting_session_participants')
     .where({ session_id: session.id })
@@ -107,6 +115,7 @@ router.get('/:groupId/vote', async (req: Request, res: Response) => {
     totalMembers,
     isParticipant: !!isParticipant,
     participantIds,
+    votedUserIds: votedUserRows,
   })
 })
 

--- a/packages/frontend/src/i18n/locales/en.json
+++ b/packages/frontend/src/i18n/locales/en.json
@@ -197,6 +197,8 @@
     "backToGroup": "Back to group",
     "submitted": "Vote submitted!",
     "waiting": "Waiting for others... {{done}} out of {{total}} voted",
+    "participantVoted": "Has voted",
+    "participantWaiting": "Hasn't voted yet",
     "closeVote": "Close vote and reveal winner",
     "voteError": "Error while voting",
     "closeError": "Error while closing vote",

--- a/packages/frontend/src/i18n/locales/fr.json
+++ b/packages/frontend/src/i18n/locales/fr.json
@@ -206,6 +206,8 @@
     "backToGroup": "Retour au groupe",
     "submitted": "Vote soumis !",
     "waiting": "En attente des autres... {{done}} sur {{total}} ont voté",
+    "participantVoted": "A déjà voté",
+    "participantWaiting": "N'a pas encore voté",
     "closeVote": "Clôturer le vote et révéler le gagnant",
     "voteError": "Erreur lors du vote",
     "closeError": "Erreur lors de la clôture du vote",

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -136,6 +136,7 @@ export const api = {
     }[];
     myVotes: { steamAppId: number; gameId?: string; vote: boolean }[];
     voterCount: number; totalMembers: number; isParticipant: boolean; participantIds: string[];
+    votedUserIds: string[];
   }>(`/groups/${groupId}/vote`),
   createVoteSession: (groupId: string, participantIds: string[], filter?: string, scheduledAt?: string, filters?: { multiplayer?: boolean; coop?: boolean; free?: boolean }) => request<{
     session: { id: string; groupId: string; status: string; createdBy: string; scheduledAt: string | null; createdAt: string };

--- a/packages/frontend/src/pages/VotePage.tsx
+++ b/packages/frontend/src/pages/VotePage.tsx
@@ -72,6 +72,12 @@ export function VotePage() {
   // Timestamp of the user's most recent click on the Steam launch link.
   // Used to schedule a soft "still here? game not launching?" prompt.
   const [steamLaunchedAt, setSteamLaunchedAt] = useState<number | null>(null)
+  // Set of session participant IDs and the subset that has already cast at
+  // least one vote. Used to render per-participant progress on the waiting
+  // screen so members can see *who* the session is waiting on, not just a
+  // bare count.
+  const [participantIds, setParticipantIds] = useState<string[]>([])
+  const [votedUserIds, setVotedUserIds] = useState<Set<string>>(() => new Set())
 
   useEffect(() => {
     if (!id) return
@@ -89,6 +95,8 @@ export function VotePage() {
         setVoterCount(data.voterCount)
         setTotalMembers(data.totalMembers)
         setIsParticipant(data.isParticipant !== false)
+        setParticipantIds(data.participantIds ?? [])
+        setVotedUserIds(new Set(data.votedUserIds ?? []))
 
         if (data.myVotes.length > 0) {
           setHasVoted(true)
@@ -110,6 +118,17 @@ export function VotePage() {
     socket.on('vote:cast', (data) => {
       setVoterCount(data.voterCount)
       if (data.totalParticipants) setTotalMembers(data.totalParticipants)
+      // Update the per-participant set so the waiting screen can show who
+      // the session is still waiting on. Idempotent — re-receiving the
+      // same userId is a no-op.
+      if (typeof data.userId === 'string') {
+        setVotedUserIds((prev) => {
+          if (prev.has(data.userId)) return prev
+          const next = new Set(prev)
+          next.add(data.userId)
+          return next
+        })
+      }
     })
 
     socket.on('vote:closed', (data) => {
@@ -181,6 +200,8 @@ export function VotePage() {
       setVoterCount(0)
       setTotalMembers(0)
       setIsParticipant(true)
+      setParticipantIds([])
+      setVotedUserIds(new Set())
     } catch (err) {
       toast.error(t('vote.rematchError'))
       console.error('Failed to start rematch:', err)
@@ -403,13 +424,42 @@ export function VotePage() {
           {t('vote.waiting', { done: voterCount, total: totalMembers })}
         </p>
 
-        <div className="relative w-48 mb-8">
+        <div className="relative w-48 mb-3">
           {/* Burst a fresh set of particles each time voterCount increments —
               the changing key remounts the component so the lazy initializer
               regenerates random positions and the animation replays. */}
           {voterCount > 0 && <CelebrationParticles key={voterCount} count={10} />}
           <Progress value={voterCount} max={totalMembers} />
         </div>
+
+        {/* Per-participant progress dots. Each dot represents one participant
+            in the session and lights up once that participant has cast at
+            least one vote. Lets members see *who* the session is waiting on
+            instead of just the bare X/Y count. Hidden when the session has
+            no participant data (legacy sessions before the junction table). */}
+        {participantIds.length > 0 && (
+          <div
+            role="list"
+            aria-label={t('vote.waiting', { done: voterCount, total: totalMembers })}
+            className="mb-8 flex flex-wrap items-center justify-center gap-1.5 max-w-xs"
+          >
+            {participantIds.map((pid) => {
+              const voted = votedUserIds.has(pid)
+              return (
+                <span
+                  key={pid}
+                  role="listitem"
+                  aria-label={voted ? t('vote.participantVoted') : t('vote.participantWaiting')}
+                  className={`h-2.5 w-2.5 rounded-full transition-colors duration-300 ${
+                    voted
+                      ? 'bg-primary shadow-[0_0_8px_rgba(120,200,255,0.45)]'
+                      : 'bg-muted-foreground/30'
+                  }`}
+                />
+              )
+            })}
+          </div>
+        )}
 
         {canClose && (
           <Button onClick={handleClose} disabled={closing}>


### PR DESCRIPTION
## Summary

Implements **Marcus #2** from the multi-persona feature meeting (`docs/feature-meeting-2026-04-13.md`): the waiting screen used to show a bare `X / Y` count, leaving members guessing who the session was waiting on. We now render one dot per session participant, lit up once that participant has cast at least one vote.

This pairs naturally with the celebration particles from #117: members already see *something* happen on every incoming vote — now they also see *who* it was.

## Implementation

**Backend** — `GET /api/groups/:id/vote` now returns `votedUserIds: string[]` (distinct `user_id` from the `votes` table for the open session). The `vote:cast` Socket.io emit already includes `userId`, so the frontend has everything it needs without inventing a richer event payload.

**Frontend** — `VotePage` tracks two new states:
- `participantIds: string[]` — initialised from the GET response
- `votedUserIds: Set<string>` — initialised from the GET response, updated on `vote:cast` (idempotent: re-receiving the same `userId` is a no-op via a `Set.has` guard)

The dots are rendered as a horizontal flex row under the progress bar with a soft `rgba(120,200,255,0.45)` glow on the lit ones, and reset to empty on rematch alongside the existing `voterCount`/`totalMembers` reset. New i18n keys `vote.participantVoted` and `vote.participantWaiting` in fr/en provide accessible per-dot `aria-label`s; the wrapping `role="list"` carries the existing `vote.waiting` summary so screen readers still get the "X out of Y" announcement they did before.

## Test plan

- [x] `npx tsc --noEmit -p packages/backend` → clean
- [x] `npx tsc --noEmit -p packages/frontend` → clean
- [x] `npm test --workspace=@wawptn/backend` → 17/17 passing
- [ ] Manual: create a vote with 4 participants, vote from 2 of them, refresh the third's page, confirm 2 dots are lit on the initial render (not just after the next live event)
- [ ] Manual: vote from a 3rd participant while the 4th is on the waiting screen, confirm a new dot lights up live
- [ ] Manual: trigger a rematch, confirm all dots reset to empty

## Why dots and not avatars

Rendering avatars would require either extending the GET payload with display info or pulling the group member store and joining locally. Dots ship the "who" signal in ~25 lines without any new fetches, and the per-row `aria-label` still gives screen readers the participant status. Richer avatar pills remain a follow-up if there's appetite.

https://claude.ai/code/session_011em4KFFeJY36J4Yxad8zeA