### PR TITLE
feat(vote): session_audit_trail table + create/close lifecycle events

### DIFF
--- a/packages/backend/migrations/20260413_c_add_session_audit_trail.ts
+++ b/packages/backend/migrations/20260413_c_add_session_audit_trail.ts
@@ -1,0 +1,41 @@
+import type { Knex } from 'knex'
+
+/**
+ * Session audit trail: records key lifecycle events on a voting session
+ * (created, closed, participant added/removed) so we can later answer "who
+ * was eligible to vote when this session closed?" and reconstruct exactly
+ * what the participant set looked like at close time.
+ *
+ * Goals:
+ * - Forensic replay for dispute resolution ("Alice swears she voted")
+ * - Stable snapshots for analytics that survive subsequent membership churn
+ * - Foundation for richer per-session reporting in the admin UI
+ */
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('session_audit_trail', (table) => {
+    table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'))
+    // Session this event belongs to. CASCADE on delete so admin-deleted
+    // sessions take their audit trail with them — the trail is per-session
+    // forensic detail, not a system-wide log.
+    table.uuid('session_id').notNullable().references('id').inTable('voting_sessions').onDelete('CASCADE')
+    // Identifier for the event. Add new event types here as the lifecycle
+    // grows (vote_recorded, session_cancelled, etc.).
+    table.string('event_type', 32).notNullable()
+    // Optional actor (user that triggered the event). Nullable for system-
+    // initiated events (auto-vote scheduler, scheduled close, etc.) and
+    // SET NULL on user delete so we never lose a row to a vanished user.
+    table.uuid('actor_id').nullable().references('id').inTable('users').onDelete('SET NULL')
+    // Free-form payload describing the event. For session_created it holds
+    // the participant snapshot; for session_closed it holds the winner +
+    // tally + the participant snapshot at close time.
+    table.jsonb('metadata').notNullable().defaultTo('{}')
+    table.timestamp('created_at').notNullable().defaultTo(knex.fn.now())
+
+    table.index(['session_id', 'created_at'])
+    table.index(['event_type', 'created_at'])
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists('session_audit_trail')
+}

--- a/packages/backend/src/domain/close-session.ts
+++ b/packages/backend/src/domain/close-session.ts
@@ -3,6 +3,7 @@ import { logger } from '../infrastructure/logger/logger.js'
 import { evaluateChallenges } from './challenges/challenge-service.js'
 import { updateStreak } from './streaks.js'
 import { domainEvents } from './events/event-bus.js'
+import { recordSessionEvent } from './session-audit-trail.js'
 import type { VoteResult } from '@wawptn/types'
 
 /**
@@ -81,6 +82,25 @@ export async function closeSession(sessionId: string, groupId: string): Promise<
   const participantIds: string[] = await db('voting_session_participants')
     .where({ session_id: sessionId })
     .pluck('user_id')
+
+  // Pin a snapshot of who was eligible to vote at close time + the final
+  // tally to the session_audit_trail. This is the canonical record for
+  // dispute resolution: even if a member is later removed from the group
+  // or the session is purged, the closed-state evidence stays intact (the
+  // row CASCADEs on session delete by design — that's a deliberate scope
+  // choice; system-wide retention belongs in a separate ETL).
+  await recordSessionEvent({
+    sessionId,
+    event: 'session_closed',
+    metadata: {
+      groupId,
+      participantIds,
+      winnerAppId,
+      winnerName,
+      yesCount: result.yesCount,
+      totalVoters: result.totalVoters,
+    },
+  })
 
   // Emit domain event — side effects (Socket.io, Discord, in-app notifs) are
   // handled by subscribers registered in infrastructure/effects/session-effects.ts

--- a/packages/backend/src/domain/create-session.ts
+++ b/packages/backend/src/domain/create-session.ts
@@ -2,6 +2,7 @@ import { db } from '../infrastructure/database/connection.js'
 import { computeCommonGames, type GameFilters } from '../infrastructure/database/common-games.js'
 import { logger } from '../infrastructure/logger/logger.js'
 import { domainEvents } from './events/event-bus.js'
+import { recordSessionEvent } from './session-audit-trail.js'
 
 export interface CreateSessionParams {
   groupId: string
@@ -147,6 +148,24 @@ export async function createVotingSession(params: CreateSessionParams): Promise<
         header_image_url: g.headerImageUrl,
       }))
     )
+
+    // Snapshot the participant list at creation time so we can later answer
+    // "who was eligible to vote when this session was opened?" even after
+    // the underlying group_members table churns. Pinned to the same
+    // transaction so the audit row lives or dies with the session itself.
+    await recordSessionEvent({
+      sessionId: sess.id,
+      event: 'session_created',
+      actorId: createdBy,
+      metadata: {
+        groupId,
+        participantIds: validMembers,
+        gameCount: selectedGames.length,
+        scheduledAt: scheduledAt ? scheduledAt.toISOString() : null,
+        filter: filter ?? null,
+      },
+      trx,
+    })
 
     return sess
   })

--- a/packages/backend/src/domain/session-audit-trail.ts
+++ b/packages/backend/src/domain/session-audit-trail.ts
@@ -1,0 +1,59 @@
+import type { Knex } from 'knex'
+import { db } from '../infrastructure/database/connection.js'
+import { logger } from '../infrastructure/logger/logger.js'
+
+/**
+ * Session audit trail domain helper. Centralises writes to
+ * `session_audit_trail` so domain code (createVotingSession, closeSession,
+ * future per-vote / per-participant events) has a single typed call site.
+ *
+ * Failures to write are logged but never thrown — audit-log issues must
+ * never break the underlying voting flow. Callers that need the row to
+ * land atomically with the surrounding write can pass a Knex transaction
+ * via `trx`.
+ */
+
+/** Allowlist of event identifiers. New events must be added here so the
+ * shape of the trail stays predictable for downstream consumers. */
+export type SessionAuditEvent =
+  | 'session_created'
+  | 'session_closed'
+  | 'participant_added'
+  | 'participant_removed'
+
+interface RecordSessionEventInput {
+  /** ID of the voting session this event belongs to. */
+  sessionId: string
+  /** What happened — must match {@link SessionAuditEvent}. */
+  event: SessionAuditEvent
+  /** Optional actor (user that triggered the event). Pass null for
+   * system-initiated events (auto-vote scheduler, scheduled close). */
+  actorId?: string | null
+  /** Free-form payload describing the event. Should be small (a few KiB
+   * at most) and JSON-serialisable. */
+  metadata?: Record<string, unknown>
+  /** Optional Knex transaction to pin the insert to a surrounding write
+   * (e.g. createVotingSession's atomic check-and-create). */
+  trx?: Knex.Transaction
+}
+
+/**
+ * Insert a single row into `session_audit_trail`. Never throws.
+ */
+export async function recordSessionEvent(input: RecordSessionEventInput): Promise<void> {
+  const { sessionId, event, actorId, metadata, trx } = input
+  const conn = trx ?? db
+  try {
+    await conn('session_audit_trail').insert({
+      session_id: sessionId,
+      event_type: event,
+      actor_id: actorId ?? null,
+      metadata: JSON.stringify(metadata ?? {}),
+    })
+  } catch (error) {
+    logger.error(
+      { error: String(error), sessionId, event, actorId },
+      'failed to write session audit trail entry',
+    )
+  }
+}


### PR DESCRIPTION
## Summary

Implements **Marcus #3** from the multi-persona feature meeting (`docs/feature-meeting-2026-04-13.md`): voting sessions had no forensic record of who was eligible to vote when they opened or closed. If a member was added or removed mid-session, or the group churned after closure, we lost the ability to answer "Alice swears she voted, who was actually in the session?" for dispute resolution. This PR introduces a per-session audit trail and wires the create/close lifecycle into it.

## What's in this PR

**New table — `session_audit_trail`** (`20260413_c_add_session_audit_trail.ts`)
- `id` (uuid pk)
- `session_id` → `voting_sessions` (CASCADE on delete — the trail is per-session forensic detail, not a system-wide log)
- `event_type` (32 chars, allowlisted)
- `actor_id` → `users` (nullable, SET NULL on user delete so we never lose a row)
- `metadata` (JSONB, default `'{}'`)
- `created_at` (timestamp, default now)
- Indexes on `(session_id, created_at)` and `(event_type, created_at)`

**New helper — `domain/session-audit-trail.ts`**
- `recordSessionEvent(input)` with a typed `SessionAuditEvent` allowlist (`'session_created' | 'session_closed' | 'participant_added' | 'participant_removed'`)
- Never throws — audit-log issues must never break the underlying voting flow
- Accepts an optional Knex `trx` so callers can pin the insert atomically with the surrounding write

**Wiring**
- `createVotingSession()` now writes a `'session_created'` row **inside its existing `forUpdate` transaction**, with a snapshot of the participant list, game count, `scheduledAt`, and filter. The audit row therefore lives or dies with the session itself.
- `closeSession()` writes a `'session_closed'` row right after the result is built, capturing the participant snapshot at close time + the winner + the tally. This is the canonical record for dispute resolution.

## Test plan

- [x] `npx tsc --noEmit -p packages/backend` → clean
- [x] `npm test --workspace=@wawptn/backend` → 17/17 passing
- [ ] Manual: create a vote, query `SELECT * FROM session_audit_trail WHERE session_id = ?` and confirm one `session_created` row with the participant list in `metadata`
- [ ] Manual: close that vote, confirm a second `session_closed` row appears with the winner + tally
- [ ] Manual: delete the session via the existing admin/owner endpoint, confirm both audit rows are CASCADE-removed

## Design notes

- `session_audit_trail` is **per-session**: it CASCADEs with the session by design. System-wide retention (e.g. for compliance) belongs in a separate ETL pipeline that copies rows to cold storage before the session is deleted — that's out of scope for this PR.
- The `participant_added` / `participant_removed` event types are reserved in the allowlist for the upcoming session participant-change endpoints. The schema and helper are ready for them; the call sites land when those endpoints do.
- I did **not** add a "validate every voter was a participant at close time" check (mentioned in Marcus's original proposal). The DB-level `voting_session_participants` membership check in `vote.routes.ts` already prevents non-participants from casting a vote, so post-hoc validation would be redundant. The audit row remains the durable record for the same purpose.

https://claude.ai/code/session_011em4KFFeJY36J4Yxad8zeA