### PR TITLE
feat(backend): zod validation middleware + schemas on admin routes

### DIFF
--- a/packages/backend/src/presentation/middleware/__tests__/validate.middleware.test.ts
+++ b/packages/backend/src/presentation/middleware/__tests__/validate.middleware.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi } from 'vitest'
+import { z } from 'zod'
+
+// Mock the logger before importing the module under test so the import
+// graph doesn't pull in the real pino logger and its env-dependent setup.
+vi.mock('@/infrastructure/logger/logger.js', () => {
+  const noop = () => {}
+  const child = () => ({ info: noop, warn: noop, error: noop, debug: noop, child })
+  return { logger: { info: noop, warn: noop, error: noop, debug: noop, child } }
+})
+
+import { validateBody, validateQuery } from '../validate.middleware.js'
+
+function mockRes() {
+  const res: {
+    statusCode: number
+    body: unknown
+    status: (n: number) => typeof res
+    json: (b: unknown) => typeof res
+  } = {
+    statusCode: 200,
+    body: undefined,
+    status(n: number) {
+      this.statusCode = n
+      return this
+    },
+    json(b: unknown) {
+      this.body = b
+      return this
+    },
+  }
+  return res
+}
+
+describe('validateBody', () => {
+  const Schema = z.object({
+    name: z.string().min(1),
+    count: z.number().int().min(0),
+  })
+
+  it('calls next() and replaces req.body with the parsed value on success', () => {
+    const middleware = validateBody(Schema)
+    const req = { path: '/test', body: { name: 'Alice', count: 3 } }
+    const res = mockRes()
+    const next = vi.fn()
+
+    middleware(req as unknown as Parameters<typeof middleware>[0], res as unknown as Parameters<typeof middleware>[1], next)
+
+    expect(next).toHaveBeenCalledTimes(1)
+    expect(res.statusCode).toBe(200)
+    expect(req.body).toEqual({ name: 'Alice', count: 3 })
+  })
+
+  it('returns 400 with a structured issue list when validation fails', () => {
+    const middleware = validateBody(Schema)
+    const req = { path: '/test', body: { name: '', count: -1 } }
+    const res = mockRes()
+    const next = vi.fn()
+
+    middleware(req as unknown as Parameters<typeof middleware>[0], res as unknown as Parameters<typeof middleware>[1], next)
+
+    expect(next).not.toHaveBeenCalled()
+    expect(res.statusCode).toBe(400)
+    const body = res.body as { error: string; issues: Array<{ path: string }> }
+    expect(body.error).toBe('validation')
+    expect(body.issues.length).toBeGreaterThanOrEqual(2)
+    expect(body.issues.map((i) => i.path).sort()).toEqual(['count', 'name'])
+  })
+
+  it('reports (root) for path-less issues', () => {
+    const middleware = validateBody(z.string())
+    const req = { path: '/test', body: 42 }
+    const res = mockRes()
+    const next = vi.fn()
+
+    middleware(req as unknown as Parameters<typeof middleware>[0], res as unknown as Parameters<typeof middleware>[1], next)
+
+    expect(res.statusCode).toBe(400)
+    const body = res.body as { issues: Array<{ path: string }> }
+    expect(body.issues[0]?.path).toBe('(root)')
+  })
+})
+
+describe('validateQuery', () => {
+  const Schema = z.object({
+    limit: z.coerce.number().int().min(1).max(100),
+  })
+
+  it('attaches parsed query to req.validatedQuery on success', () => {
+    const middleware = validateQuery(Schema)
+    const req = { path: '/test', query: { limit: '25' } } as unknown as {
+      validatedQuery?: unknown
+    }
+    const res = mockRes()
+    const next = vi.fn()
+
+    middleware(req as unknown as Parameters<typeof middleware>[0], res as unknown as Parameters<typeof middleware>[1], next)
+
+    expect(next).toHaveBeenCalledTimes(1)
+    expect(req.validatedQuery).toEqual({ limit: 25 })
+  })
+
+  it('returns 400 when query validation fails', () => {
+    const middleware = validateQuery(Schema)
+    const req = { path: '/test', query: { limit: 'nope' } }
+    const res = mockRes()
+    const next = vi.fn()
+
+    middleware(req as unknown as Parameters<typeof middleware>[0], res as unknown as Parameters<typeof middleware>[1], next)
+
+    expect(next).not.toHaveBeenCalled()
+    expect(res.statusCode).toBe(400)
+    const body = res.body as { error: string; issues: unknown[] }
+    expect(body.error).toBe('validation')
+    expect(body.issues.length).toBe(1)
+  })
+})

--- a/packages/backend/src/presentation/middleware/validate.middleware.ts
+++ b/packages/backend/src/presentation/middleware/validate.middleware.ts
@@ -1,0 +1,76 @@
+import type { Request, Response, NextFunction } from 'express'
+import type { ZodType, ZodError, z } from 'zod'
+import { logger } from '../../infrastructure/logger/logger.js'
+
+/**
+ * Zod validation middleware factory.
+ *
+ * Usage:
+ *   const CreatePersonaSchema = z.object({ ... })
+ *   router.post('/personas', validateBody(CreatePersonaSchema), (req, res) => {
+ *     // req.body is now typed as z.infer<typeof CreatePersonaSchema>
+ *   })
+ *
+ * On success the middleware replaces `req.body` with the Zod-parsed output
+ * (which may coerce / strip unknown keys depending on how the schema is
+ * declared) and calls next(). Handlers downstream get a strongly-typed
+ * object without having to re-validate or cast from `unknown`.
+ *
+ * On failure it returns 400 with a stable shape:
+ *   { error: 'validation', message, issues: [{ path, message }] }
+ *
+ * Failures are logged at debug level so repeat bad requests don't spam the
+ * logs, but the issue list is always surfaced to the client so the web UI
+ * can render field-level hints when the server rejects a payload.
+ */
+export function validateBody<TSchema extends ZodType>(schema: TSchema) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const result = schema.safeParse(req.body)
+    if (!result.success) {
+      const issues = formatIssues(result.error)
+      logger.debug({ path: req.path, issues }, 'request body validation failed')
+      res.status(400).json({
+        error: 'validation',
+        message: 'Invalid request body',
+        issues,
+      })
+      return
+    }
+    // Replace req.body so downstream handlers see the parsed value instead
+    // of the raw express.json() output. Cast is safe — Express types the
+    // body as `any` at the framework layer.
+    req.body = result.data as z.infer<TSchema>
+    next()
+  }
+}
+
+/** Same pattern but for query parameters. Query values are always strings
+ * or string arrays out of Express, so the schema is responsible for any
+ * necessary coercion (e.g. `z.coerce.number()`). */
+export function validateQuery<TSchema extends ZodType>(schema: TSchema) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const result = schema.safeParse(req.query)
+    if (!result.success) {
+      const issues = formatIssues(result.error)
+      logger.debug({ path: req.path, issues }, 'request query validation failed')
+      res.status(400).json({
+        error: 'validation',
+        message: 'Invalid query parameters',
+        issues,
+      })
+      return
+    }
+    // We don't overwrite req.query because Express 5 treats it as
+    // read-only on some platforms. Attach the parsed value on a
+    // dedicated property instead.
+    ;(req as Request & { validatedQuery: unknown }).validatedQuery = result.data
+    next()
+  }
+}
+
+function formatIssues(error: ZodError): Array<{ path: string; message: string }> {
+  return error.issues.map((issue) => ({
+    path: issue.path.map(String).join('.') || '(root)',
+    message: issue.message,
+  }))
+}

--- a/packages/backend/src/presentation/routes/admin.routes.ts
+++ b/packages/backend/src/presentation/routes/admin.routes.ts
@@ -1,4 +1,5 @@
 import { Router, type Request, type Response } from 'express'
+import { z } from 'zod'
 import { db } from '../../infrastructure/database/connection.js'
 import { authLogger } from '../../infrastructure/logger/logger.js'
 import { invalidatePremiumCache } from '../../domain/subscription-service.js'
@@ -7,6 +8,51 @@ import { invalidateAllUserSessions } from '../../domain/auth-service.js'
 import { getHealth as getSteamHealth } from '../../infrastructure/steam/steam-client.js'
 import { getHealth as getEpicHealth } from '../../infrastructure/epic/epic-client.js'
 import { getHealth as getGogHealth } from '../../infrastructure/gog/gog-client.js'
+import { validateBody } from '../middleware/validate.middleware.js'
+
+// ─── Zod schemas ──────────────────────────────────────────────────────────────
+
+const ToggleAdminSchema = z.object({
+  isAdmin: z.boolean(),
+})
+
+const TogglePremiumSchema = z.object({
+  isPremium: z.boolean(),
+})
+
+const CreatePersonaSchema = z.object({
+  // kebab-case identifier, max 50 chars — matches the previous inline regex
+  id: z
+    .string()
+    .min(1)
+    .max(50)
+    .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, "L'identifiant doit être en kebab-case (ex: mon-persona)"),
+  name: z.string().min(1).max(64),
+  systemPromptOverlay: z.string().min(1),
+  fridayMessages: z.array(z.string().min(1)).min(1),
+  weekdayMessages: z.array(z.string().min(1)).min(1),
+  backOnlineMessages: z.array(z.string().min(1)).min(1),
+  emptyMentionReply: z.string().min(1),
+  introMessage: z.string().min(1),
+  embedColor: z.number().int().min(0).max(0xffffff),
+})
+
+// All fields optional for PATCH; at least one must be provided.
+const UpdatePersonaSchema = z
+  .object({
+    name: z.string().min(1).max(64),
+    systemPromptOverlay: z.string().min(1),
+    fridayMessages: z.array(z.string().min(1)).min(1),
+    weekdayMessages: z.array(z.string().min(1)).min(1),
+    backOnlineMessages: z.array(z.string().min(1)).min(1),
+    emptyMentionReply: z.string().min(1),
+    introMessage: z.string().min(1),
+    embedColor: z.number().int().min(0).max(0xffffff),
+  })
+  .partial()
+  .refine((data) => Object.keys(data).length > 0, {
+    message: 'Aucun champ à mettre à jour',
+  })
 
 const router = Router()
 
@@ -158,14 +204,9 @@ router.get('/users', async (req: Request, res: Response) => {
 })
 
 // Toggle admin status for a user
-router.patch('/users/:id/admin', async (req: Request, res: Response) => {
+router.patch('/users/:id/admin', validateBody(ToggleAdminSchema), async (req: Request, res: Response) => {
   const targetId = String(req.params['id'])
-  const { isAdmin } = req.body as { isAdmin?: boolean }
-
-  if (typeof isAdmin !== 'boolean') {
-    res.status(400).json({ error: 'validation', message: 'isAdmin (boolean) is required' })
-    return
-  }
+  const { isAdmin } = req.body as z.infer<typeof ToggleAdminSchema>
 
   // Prevent self-demotion
   if (targetId === req.userId && !isAdmin) {
@@ -202,14 +243,9 @@ router.patch('/users/:id/admin', async (req: Request, res: Response) => {
 })
 
 // Grant or revoke admin-granted premium access for a user
-router.patch('/users/:id/premium', async (req: Request, res: Response) => {
+router.patch('/users/:id/premium', validateBody(TogglePremiumSchema), async (req: Request, res: Response) => {
   const targetId = String(req.params['id'])
-  const { isPremium } = req.body as { isPremium?: boolean }
-
-  if (typeof isPremium !== 'boolean') {
-    res.status(400).json({ error: 'validation', message: 'isPremium (boolean) is required' })
-    return
-  }
+  const { isPremium } = req.body as z.infer<typeof TogglePremiumSchema>
 
   const target = await db('users').where({ id: targetId }).first()
   if (!target) {
@@ -273,48 +309,24 @@ router.get('/personas', async (_req: Request, res: Response) => {
   }
 })
 
-router.post('/personas', async (req: Request, res: Response) => {
-  const body = req.body as {
-    id?: string
-    name?: string
-    systemPromptOverlay?: string
-    fridayMessages?: string[]
-    weekdayMessages?: string[]
-    backOnlineMessages?: string[]
-    emptyMentionReply?: string
-    introMessage?: string
-    embedColor?: number
-  }
+router.post('/personas', validateBody(CreatePersonaSchema), async (req: Request, res: Response) => {
+  const {
+    id,
+    name,
+    systemPromptOverlay,
+    fridayMessages,
+    weekdayMessages,
+    backOnlineMessages,
+    emptyMentionReply,
+    introMessage,
+    embedColor,
+  } = req.body as z.infer<typeof CreatePersonaSchema>
 
-  // Validate required fields
-  const { id, name, systemPromptOverlay, fridayMessages, weekdayMessages, backOnlineMessages, emptyMentionReply, introMessage, embedColor } = body
-
-  if (!id || !name || !systemPromptOverlay || !fridayMessages || !weekdayMessages || !backOnlineMessages || !emptyMentionReply || !introMessage || embedColor === undefined) {
-    res.status(400).json({ error: 'validation', message: 'Tous les champs sont requis : id, name, systemPromptOverlay, fridayMessages, weekdayMessages, backOnlineMessages, emptyMentionReply, introMessage, embedColor' })
-    return
-  }
-
-  // Validate id format (kebab-case)
-  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(id)) {
-    res.status(400).json({ error: 'validation', message: "L'identifiant doit être en kebab-case (ex: mon-persona)" })
-    return
-  }
-
-  if (id.length > 50) {
-    res.status(400).json({ error: 'validation', message: "L'identifiant ne doit pas dépasser 50 caractères" })
-    return
-  }
-
-  // Check for duplicate id
+  // Check for duplicate id (uniqueness is a domain concern, not a shape
+  // concern, so it stays in the handler instead of moving into the schema)
   const existing = await db('personas').where({ id }).first()
   if (existing) {
     res.status(409).json({ error: 'conflict', message: 'Un persona avec cet identifiant existe déjà' })
-    return
-  }
-
-  // Validate arrays
-  if (!Array.isArray(fridayMessages) || !Array.isArray(weekdayMessages) || !Array.isArray(backOnlineMessages)) {
-    res.status(400).json({ error: 'validation', message: 'fridayMessages, weekdayMessages et backOnlineMessages doivent être des tableaux' })
     return
   }
 
@@ -342,9 +354,9 @@ router.post('/personas', async (req: Request, res: Response) => {
   res.status(201).json({ ok: true, id })
 })
 
-router.patch('/personas/:id', async (req: Request, res: Response) => {
+router.patch('/personas/:id', validateBody(UpdatePersonaSchema), async (req: Request, res: Response) => {
   const personaId = req.params['id']
-  const body = req.body as Record<string, unknown>
+  const body = req.body as z.infer<typeof UpdatePersonaSchema>
 
   const persona = await db('personas').where({ id: personaId }).first()
   if (!persona) {
@@ -352,9 +364,10 @@ router.patch('/personas/:id', async (req: Request, res: Response) => {
     return
   }
 
-  // Build update object from allowed fields
+  // Build update object from the validated fields. The schema's .refine()
+  // already guaranteed at least one field, so we can map straight from
+  // body to column names without re-checking emptiness.
   const updates: Record<string, unknown> = {}
-
   if (body.name !== undefined) updates.name = body.name
   if (body.systemPromptOverlay !== undefined) updates.system_prompt_overlay = body.systemPromptOverlay
   if (body.fridayMessages !== undefined) updates.friday_messages = JSON.stringify(body.fridayMessages)
@@ -363,11 +376,6 @@ router.patch('/personas/:id', async (req: Request, res: Response) => {
   if (body.emptyMentionReply !== undefined) updates.empty_mention_reply = body.emptyMentionReply
   if (body.introMessage !== undefined) updates.intro_message = body.introMessage
   if (body.embedColor !== undefined) updates.embed_color = body.embedColor
-
-  if (Object.keys(updates).length === 0) {
-    res.status(400).json({ error: 'validation', message: 'Aucun champ à mettre à jour' })
-    return
-  }
 
   updates.updated_at = db.fn.now()
 


### PR DESCRIPTION
## Summary

Implements **Priya #2** from the multi-persona feature meeting (`docs/feature-meeting-2026-04-13.md`), starting with the highest-value admin surfaces. Zod was already a backend dependency but nothing was using it — route handlers were doing ad-hoc validation with type guards, string checks and a hand-rolled regex for persona id format, which is the pattern Priya flagged as the riskiest for subtle type-confusion bugs on the admin surface.

## What's in this PR

**New middleware — `presentation/middleware/validate.middleware.ts`**
- `validateBody(schema)` — parses `req.body` with a Zod schema, replaces `req.body` with the parsed output on success, returns `400 { error: 'validation', message, issues: [{ path, message }] }` on failure.
- `validateQuery(schema)` — same pattern for query parameters, attaches the parsed value to `req.validatedQuery` instead of overwriting `req.query` (Express 5 treats it as read-only on some platforms).
- Failures are logged at `debug` level so repeat bad requests don't spam the logs; the issue list is always surfaced to the client so the web UI can render field-level hints.

**Schemas applied to admin routes — `routes/admin.routes.ts`**
- `ToggleAdminSchema` / `TogglePremiumSchema` — `z.object({ isAdmin: boolean })` / `z.object({ isPremium: boolean })`. Replaces the inline `typeof isAdmin !== 'boolean'` checks on `PATCH /users/:id/admin` and `PATCH /users/:id/premium`.
- `CreatePersonaSchema` — full object shape with the kebab-case regex, 50-char id cap, `min(1)` array lengths and `embedColor` bounds (`0..0xffffff`). Replaces ~30 lines of inline validation with a single middleware call.
- `UpdatePersonaSchema` — `.partial()` on the same shape with a `.refine()` that enforces "at least one field". Replaces the old `Object.keys(updates).length === 0` check.

**Unit tests** — `middleware/__tests__/validate.middleware.test.ts` (5 tests)
- Happy-path `validateBody` passes through and replaces `req.body` with the parsed value
- Multi-field failure returns 400 with a structured issue list covering every invalid path
- Scalar-schema failures report `(root)` for path-less issues
- `validateQuery` happy path coerces and attaches `validatedQuery`
- `validateQuery` failure returns 400 with a single-issue list

## Test plan

- [x] `npx tsc --noEmit -p packages/backend` → clean
- [x] `npm test --workspace=@wawptn/backend` → 22/22 passing (5 new)
- [ ] Manual: `curl -X PATCH /api/admin/users/:id/admin -d '{}'` → expect 400 with `issues: [{ path: 'isAdmin' }]`
- [ ] Manual: `curl -X POST /api/admin/personas -d '{"id":"Bad Id"}'` → expect 400 with `issues` pointing at `id` with the kebab-case message
- [ ] Manual: `curl -X POST /api/admin/personas -d '{...valid body}'` → expect 201
- [ ] Manual: `curl -X PATCH /api/admin/personas/existing-id -d '{}'` → expect 400 `'Aucun champ à mettre à jour'`

## Why only admin routes in this PR

The meeting proposal was "schemas for all POST/PATCH payloads" — a full sweep across `admin`, `group`, `vote` and `discord` routes. That's a much larger diff with real behavioural risk (the current ad-hoc checks tolerate some subtly-different shapes that well-typed Zod schemas would now reject). Landing the **pattern** with the **highest-risk surface** (admin, per Priya's severity ranking) lets the team validate the middleware contract in production before sweeping the rest of the routes.

Follow-up PRs should apply the same pattern to:
- `vote.routes.ts` — cast-votes body (single vs batch union), create-session body (`scheduledAt` date validation)
- `group.routes.ts` — invite token generation, membership updates, auto-vote schedule settings
- `discord.routes.ts` — webhook creation, announcement channel create/list/delete

https://claude.ai/code/session_011em4KFFeJY36J4Yxad8zeA