### PR TITLE
feat(pwa): native notifications + install prompt toast

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { DialogTestPage } from '@/pages/DialogTestPage'
 import { useNotificationListener } from '@/hooks/useNotificationListener'
 import { useChallengeListener } from '@/hooks/useChallengeListener'
+import { usePwaInstallPrompt } from '@/hooks/usePwaInstallPrompt'
 import { useNotificationStore } from '@/stores/notification.store'
 
 function App() {
@@ -40,6 +41,10 @@ function App() {
 
   // Global challenge unlock listener
   useChallengeListener()
+
+  // PWA install prompt — captures beforeinstallprompt and surfaces a
+  // sonner toast with a native install action.
+  usePwaInstallPrompt()
 
   // Dev-only dialog test page (no auth required)
   if (import.meta.env.DEV && window.location.pathname === '/test-dialogs') {

--- a/packages/frontend/src/components/notification-bell.tsx
+++ b/packages/frontend/src/components/notification-bell.tsx
@@ -1,9 +1,15 @@
 import { useState, useMemo } from 'react'
-import { Bell, CheckCheck } from 'lucide-react'
+import { Bell, BellRing, CheckCheck } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
 import { useNotificationStore } from '@/stores/notification.store'
+import {
+  getNotificationPermission,
+  requestNotificationPermission,
+  type NotificationPermissionState,
+} from '@/lib/pwa'
 import type { Notification } from '@wawptn/types'
 
 export function NotificationBell() {
@@ -11,7 +17,24 @@ export function NotificationBell() {
   const navigate = useNavigate()
   const [open, setOpen] = useState(false)
   const [now, setNow] = useState(() => Date.now())
+  // Initialise the permission state lazily from the Notification API so
+  // we don't need an effect to seed it (ESLint enforces that pattern).
+  const [permission, setPermission] = useState<NotificationPermissionState>(
+    () => getNotificationPermission(),
+  )
   const { notifications, unreadCount, markAsRead, markAllAsRead } = useNotificationStore()
+
+  const handleEnableNotifications = async () => {
+    const result = await requestNotificationPermission()
+    setPermission(result)
+    if (result === 'granted') {
+      toast.success(t('pwa.notificationsEnabled'))
+    } else if (result === 'denied') {
+      toast.error(t('pwa.notificationsDenied'))
+    } else if (result === 'unsupported') {
+      toast.error(t('pwa.notificationsUnsupported'))
+    }
+  }
 
   // Use unreadCount as animation key so the bell re-animates on each new notification
   const bellAnimationKey = useMemo(() => unreadCount, [unreadCount])
@@ -104,6 +127,20 @@ export function NotificationBell() {
                   </button>
                 )}
               </div>
+
+              {/* Enable native notifications row — appears only when the
+                  browser supports notifications AND the user hasn't
+                  answered the permission prompt yet. Disappears once
+                  they click "Enable" and grant or deny. */}
+              {permission === 'default' && (
+                <button
+                  onClick={handleEnableNotifications}
+                  className="flex items-center gap-2 px-3 py-2 border-b border-border text-xs text-muted-foreground hover:text-foreground hover:bg-accent/30 transition-colors"
+                >
+                  <BellRing className="w-3.5 h-3.5 text-primary" />
+                  {t('pwa.enableNotifications')}
+                </button>
+              )}
 
               {/* Notification list */}
               <div className="overflow-y-auto flex-1">

--- a/packages/frontend/src/hooks/useNotificationListener.ts
+++ b/packages/frontend/src/hooks/useNotificationListener.ts
@@ -1,11 +1,16 @@
 import { useEffect } from 'react'
 import { getSocket } from '@/lib/socket'
 import { useNotificationStore } from '@/stores/notification.store'
+import { showNativeNotification } from '@/lib/pwa'
 
 /**
  * Global hook that listens for notification:new socket events
  * and pushes them into the notification store.
  * Must be mounted once at the app level after authentication.
+ *
+ * When the user has granted native notification permission, the hook also
+ * dispatches a native OS notification via the service worker so the bell
+ * is audible / visible even when the tab is backgrounded.
  */
 export function useNotificationListener() {
   const { addNotification, fetchNotifications } = useNotificationStore()
@@ -18,6 +23,17 @@ export function useNotificationListener() {
 
     const handleNewNotification = (data: Parameters<typeof addNotification>[0]) => {
       addNotification(data)
+
+      // Fire a native OS notification in parallel when the user has opted
+      // in. showNativeNotification() returns false without throwing if
+      // permission is missing or the SW isn't ready, so this call is a
+      // pure enhancement — the in-app bell stays authoritative.
+      const title = data.title || 'WAWPTN'
+      void showNativeNotification(title, {
+        body: data.body || undefined,
+        tag: `notification:${data.id}`,
+        data: data.metadata ?? {},
+      })
     }
 
     socket.on('notification:new', handleNewNotification)

--- a/packages/frontend/src/hooks/usePwaInstallPrompt.ts
+++ b/packages/frontend/src/hooks/usePwaInstallPrompt.ts
@@ -1,0 +1,67 @@
+import { useEffect } from 'react'
+import { toast } from 'sonner'
+import { useTranslation } from 'react-i18next'
+import {
+  installBeforeInstallPromptCapture,
+  subscribeToInstallPrompt,
+  promptInstall,
+} from '@/lib/pwa'
+
+const DISMISSED_KEY = 'pwa-install-dismissed-at'
+// Re-ask at most once per 7 days after a dismissal — we don't want to
+// badger the user, but we shouldn't disappear forever on a single "Not now".
+const COOLDOWN_MS = 7 * 24 * 60 * 60 * 1000
+
+/**
+ * Captures the browser's `beforeinstallprompt` event and, when it fires,
+ * shows a non-blocking sonner toast inviting the user to install the PWA.
+ * The toast has an explicit "Installer" action that triggers the native
+ * install flow. Dismissals are remembered in localStorage and a 7-day
+ * cooldown applies before we'll try again.
+ *
+ * Must be mounted once at the app level. Safe to call in contexts where
+ * the PWA isn't installable (mobile Safari, already-installed PWAs) —
+ * the browser simply never fires `beforeinstallprompt` and nothing shows.
+ */
+export function usePwaInstallPrompt() {
+  const { t } = useTranslation()
+
+  useEffect(() => {
+    // Register the DOM listener once per app session. Idempotent.
+    installBeforeInstallPromptCapture()
+
+    const unsubscribe = subscribeToInstallPrompt((event) => {
+      if (!event) return
+
+      const dismissedAtRaw = localStorage.getItem(DISMISSED_KEY)
+      if (dismissedAtRaw) {
+        const dismissedAt = Number.parseInt(dismissedAtRaw, 10)
+        if (!Number.isNaN(dismissedAt) && Date.now() - dismissedAt < COOLDOWN_MS) {
+          return
+        }
+      }
+
+      toast(t('pwa.installPromptTitle'), {
+        description: t('pwa.installPromptDescription'),
+        duration: 12000,
+        action: {
+          label: t('pwa.installAction'),
+          onClick: () => {
+            void promptInstall().then((outcome) => {
+              if (outcome !== 'accepted') {
+                localStorage.setItem(DISMISSED_KEY, String(Date.now()))
+              }
+            })
+          },
+        },
+        onDismiss: () => {
+          localStorage.setItem(DISMISSED_KEY, String(Date.now()))
+        },
+      })
+    })
+
+    return () => {
+      unsubscribe()
+    }
+  }, [t])
+}

--- a/packages/frontend/src/i18n/locales/en.json
+++ b/packages/frontend/src/i18n/locales/en.json
@@ -355,6 +355,15 @@
     "unlocked": "Unlocked ✓",
     "unlockedToast": "{{icon}} Challenge unlocked: {{title}}"
   },
+  "pwa": {
+    "installPromptTitle": "Install WAWPTN",
+    "installPromptDescription": "Get faster access from your home screen.",
+    "installAction": "Install",
+    "enableNotifications": "Enable notifications",
+    "notificationsEnabled": "Notifications enabled",
+    "notificationsDenied": "Permission denied (check your browser settings)",
+    "notificationsUnsupported": "Not supported in this browser"
+  },
   "notifications": {
     "title": "Notifications",
     "empty": "No notifications",

--- a/packages/frontend/src/i18n/locales/fr.json
+++ b/packages/frontend/src/i18n/locales/fr.json
@@ -392,6 +392,15 @@
   "persona": {
     "today": "Persona du jour"
   },
+  "pwa": {
+    "installPromptTitle": "Installer WAWPTN",
+    "installPromptDescription": "Accédez à l'app plus vite depuis votre écran d'accueil.",
+    "installAction": "Installer",
+    "enableNotifications": "Activer les notifications",
+    "notificationsEnabled": "Notifications activées",
+    "notificationsDenied": "Permission refusée (vérifiez vos paramètres navigateur)",
+    "notificationsUnsupported": "Non supporté sur ce navigateur"
+  },
   "notifications": {
     "title": "Notifications",
     "empty": "Aucune notification",

--- a/packages/frontend/src/lib/pwa.ts
+++ b/packages/frontend/src/lib/pwa.ts
@@ -1,0 +1,155 @@
+/**
+ * Progressive Web App helpers: native notification permission, native
+ * notification delivery via the registered service worker, and the
+ * `beforeinstallprompt` capture for "install to home screen" UX.
+ *
+ * The service worker itself is registered automatically by vite-plugin-pwa
+ * (`registerType: 'autoUpdate'` in vite.config.ts). This module is a thin
+ * wrapper over the browser APIs — it never installs its own SW.
+ */
+
+/** Whether the current browser supports the Notification API at all. */
+export function isNotificationSupported(): boolean {
+  return typeof window !== 'undefined' && 'Notification' in window && 'serviceWorker' in navigator
+}
+
+/** Current permission state, or 'unsupported' when the browser has no Notification API. */
+export type NotificationPermissionState = NotificationPermission | 'unsupported'
+
+export function getNotificationPermission(): NotificationPermissionState {
+  if (!isNotificationSupported()) return 'unsupported'
+  return Notification.permission
+}
+
+/**
+ * Prompt the user for notification permission. Returns the resulting
+ * permission state. Safe to call when permission is already granted or
+ * denied — the browser will short-circuit without re-prompting.
+ */
+export async function requestNotificationPermission(): Promise<NotificationPermissionState> {
+  if (!isNotificationSupported()) return 'unsupported'
+  if (Notification.permission === 'granted' || Notification.permission === 'denied') {
+    return Notification.permission
+  }
+  try {
+    const result = await Notification.requestPermission()
+    return result
+  } catch {
+    return 'default'
+  }
+}
+
+interface NativeNotificationOptions {
+  /** Short body text. Keep it under ~120 characters for mobile OS display. */
+  body?: string
+  /** URL of an icon (uses the PWA icon by default if omitted). */
+  icon?: string
+  /** Opaque tag — reusing a tag replaces the previous notification with
+   * the same tag, so bursts of events (e.g. multiple incoming votes)
+   * don't bury the notification tray. */
+  tag?: string
+  /** Arbitrary data payload the notification click handler can read. */
+  data?: Record<string, unknown>
+  /** `true` to require explicit dismissal, `false` to auto-dismiss. */
+  requireInteraction?: boolean
+}
+
+/**
+ * Show a native OS notification via the registered service worker.
+ *
+ * Returns `false` when the browser doesn't support notifications, the user
+ * hasn't granted permission, or the service worker isn't ready yet — the
+ * caller should keep rendering its in-app fallback UI in that case.
+ */
+export async function showNativeNotification(
+  title: string,
+  options: NativeNotificationOptions = {},
+): Promise<boolean> {
+  if (!isNotificationSupported()) return false
+  if (Notification.permission !== 'granted') return false
+
+  try {
+    const registration = await navigator.serviceWorker.ready
+    await registration.showNotification(title, {
+      body: options.body,
+      icon: options.icon ?? '/pwa-192x192.png',
+      badge: '/pwa-192x192.png',
+      tag: options.tag,
+      data: options.data,
+      requireInteraction: options.requireInteraction ?? false,
+    })
+    return true
+  } catch {
+    // Any failure (SW not ready, permission flipped to denied between the
+    // check and the call, browser quirk) is swallowed — the caller has
+    // already delivered the in-app notification so nothing is lost.
+    return false
+  }
+}
+
+// ─── Install prompt ─────────────────────────────────────────────────────────
+
+/**
+ * Minimal shape of the non-standard `BeforeInstallPromptEvent`. TypeScript's
+ * lib.dom doesn't expose it, so we define what we actually use.
+ */
+export interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>
+}
+
+let capturedInstallEvent: BeforeInstallPromptEvent | null = null
+const installListeners = new Set<(event: BeforeInstallPromptEvent | null) => void>()
+
+/**
+ * Install a one-time listener on `beforeinstallprompt` that captures the
+ * event and broadcasts it to subscribers. Must be called once at app
+ * startup (e.g. from `usePwaInstallPrompt`). Safe to call multiple times —
+ * only the first call wires the DOM listener.
+ */
+let wired = false
+export function installBeforeInstallPromptCapture(): void {
+  if (wired) return
+  wired = true
+  if (typeof window === 'undefined') return
+  window.addEventListener('beforeinstallprompt', (event) => {
+    // Stop Chrome's default mini-infobar so we can surface our own UI
+    event.preventDefault()
+    capturedInstallEvent = event as unknown as BeforeInstallPromptEvent
+    for (const listener of installListeners) {
+      listener(capturedInstallEvent)
+    }
+  })
+  window.addEventListener('appinstalled', () => {
+    capturedInstallEvent = null
+    for (const listener of installListeners) {
+      listener(null)
+    }
+  })
+}
+
+export function getCapturedInstallEvent(): BeforeInstallPromptEvent | null {
+  return capturedInstallEvent
+}
+
+export function subscribeToInstallPrompt(
+  listener: (event: BeforeInstallPromptEvent | null) => void,
+): () => void {
+  installListeners.add(listener)
+  return () => {
+    installListeners.delete(listener)
+  }
+}
+
+/** Fire the browser's native install prompt. Returns the user's choice. */
+export async function promptInstall(): Promise<'accepted' | 'dismissed' | 'unavailable'> {
+  if (!capturedInstallEvent) return 'unavailable'
+  try {
+    await capturedInstallEvent.prompt()
+    const choice = await capturedInstallEvent.userChoice
+    capturedInstallEvent = null
+    return choice.outcome
+  } catch {
+    return 'dismissed'
+  }
+}


### PR DESCRIPTION
## Summary

Implements **Yuki #3** from the multi-persona feature meeting (`docs/feature-meeting-2026-04-13.md`). The PWA manifest was already wired by `vite-plugin-pwa` with `registerType: 'autoUpdate'`, so a service worker was being registered on every load — but no client code was reading from it. Native notifications, install prompt and the opt-in flow were all missing.

## What's in this PR

**`src/lib/pwa.ts`** — pure helpers over the browser APIs
- `isNotificationSupported()` / `getNotificationPermission()`
- `requestNotificationPermission()` — wraps `Notification.requestPermission` with safe handling for already-granted / already-denied states
- `showNativeNotification(title, options)` — uses `navigator.serviceWorker.ready.then(reg => reg.showNotification(...))` so OS-level toasts fire even when the tab is backgrounded. Returns `false` instead of throwing when permission is missing or the SW isn't ready.
- `installBeforeInstallPromptCapture()` / `subscribeToInstallPrompt()` / `promptInstall()` — captures Chrome's `beforeinstallprompt` event so we can surface our own install UI instead of the default mini-infobar.

**`useNotificationListener` extension**
- Now also calls `showNativeNotification` on every `notification:new` socket event. The in-app bell stays authoritative; the native pop is a pure enhancement.

**`usePwaInstallPrompt` hook**
- Subscribes to the captured install event and shows a sonner toast with an "Installer" action that fires the native prompt. Dismissals are remembered in `localStorage` with a 7-day cooldown so we don't badger the user.

**`NotificationBell` "Activer les notifications" row**
- Mounts only when the browser supports notifications **and** the user hasn't answered the permission prompt yet (`permission === 'default'`).
- Clicking it calls `requestNotificationPermission` and feeds back via sonner. Disappears as soon as the user has answered.

**`App.tsx` wiring**
- Mounts `usePwaInstallPrompt` alongside the existing notification and challenge listeners.

**i18n** — new `pwa.*` keys in fr/en (`installPromptTitle`, `installPromptDescription`, `installAction`, `enableNotifications`, `notificationsEnabled`, `notificationsDenied`, `notificationsUnsupported`).

## Test plan

- [x] `npx tsc --noEmit -p packages/frontend` → clean
- [x] `npx eslint` on the touched files → clean
- [x] Backend `npm test` → 22/22 still passing
- [ ] Manual: open the bell, confirm "Activer les notifications" row appears (only on browsers that haven't been asked yet); click it, confirm browser prompt fires
- [ ] Manual: grant permission, trigger a `notification:new` socket event, confirm a native OS notification fires alongside the in-app bell
- [ ] Manual: in Chrome on a desktop install of WAWPTN, wait for the install prompt toast, click "Installer", confirm the native A2HS dialog opens
- [ ] Manual: dismiss the install toast, refresh, confirm the toast doesn't re-appear within 7 days

## Why no web-push / VAPID

The meeting brief was explicit about using `ServiceWorkerRegistration.showNotification()`, which is a **local** notification API — the SW fires the OS toast in response to an in-process call, no push server needed. True remote push (notifications when the tab is closed entirely) would require:
- A `web-push` backend dependency
- VAPID key generation + storage
- A new table for client subscriptions
- A push send path triggered from notifications, scheduler, etc.

That's its own follow-up PR. The current PR ships every piece of value the meeting actually asked for.

https://claude.ai/code/session_011em4KFFeJY36J4Yxad8zeA