### PR TITLE
feat(frontend): resilient socket store + connection status toast

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import { DialogTestPage } from '@/pages/DialogTestPage'
 import { useNotificationListener } from '@/hooks/useNotificationListener'
 import { useChallengeListener } from '@/hooks/useChallengeListener'
 import { usePwaInstallPrompt } from '@/hooks/usePwaInstallPrompt'
+import { useSocketConnectionStatus } from '@/hooks/useSocketConnectionStatus'
 import { useNotificationStore } from '@/stores/notification.store'
 
 function App() {
@@ -45,6 +46,12 @@ function App() {
   // PWA install prompt — captures beforeinstallprompt and surfaces a
   // sonner toast with a native install action.
   usePwaInstallPrompt()
+
+  // Socket connection status tracking — binds the socket store to the
+  // socket.io client's lifecycle events and pops a sonner toast on
+  // disconnect / reconnect so users aren't left guessing why events
+  // have stopped arriving.
+  useSocketConnectionStatus()
 
   // Dev-only dialog test page (no auth required)
   if (import.meta.env.DEV && window.location.pathname === '/test-dialogs') {

--- a/packages/frontend/src/hooks/useChallengeListener.ts
+++ b/packages/frontend/src/hooks/useChallengeListener.ts
@@ -1,32 +1,32 @@
-import { useEffect } from 'react'
+import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
-import { getSocket } from '@/lib/socket'
+import { useSocketEvent } from '@/hooks/useSocketEvent'
 import { useChallengeStore } from '@/stores/challenge.store'
 
 /**
  * Global hook that listens for challenge:unlocked socket events
  * and shows a celebratory toast. Refreshes challenge store on unlock.
  * Must be mounted once at the app level after authentication.
+ *
+ * Migrated to useSocketEvent in the Yuki #1 refactor so the
+ * subscribe / unsubscribe lifecycle is handled by the hook instead of
+ * this module's own useEffect. The handler is memoised via useCallback
+ * so a stable dep list avoids churn.
  */
 export function useChallengeListener() {
   const { t } = useTranslation()
   const fetchChallenges = useChallengeStore((s) => s.fetchChallenges)
 
-  useEffect(() => {
-    const socket = getSocket()
-
-    const handleUnlocked = (data: { userId: string; challengeId: string; title: string; icon: string; tier: number }) => {
+  const handleUnlocked = useCallback(
+    (data: { userId: string; challengeId: string; title: string; icon: string; tier: number }) => {
       toast.success(t('challenges.unlockedToast', { icon: data.icon, title: data.title }), {
         duration: 6000,
       })
       fetchChallenges()
-    }
+    },
+    [t, fetchChallenges],
+  )
 
-    socket.on('challenge:unlocked', handleUnlocked)
-
-    return () => {
-      socket.off('challenge:unlocked', handleUnlocked)
-    }
-  }, [t, fetchChallenges])
+  useSocketEvent('challenge:unlocked', handleUnlocked, [handleUnlocked])
 }

--- a/packages/frontend/src/hooks/useSocketConnectionStatus.ts
+++ b/packages/frontend/src/hooks/useSocketConnectionStatus.ts
@@ -1,0 +1,74 @@
+import { useEffect, useRef } from 'react'
+import { toast } from 'sonner'
+import { useTranslation } from 'react-i18next'
+import { useSocketStore } from '@/stores/socket.store'
+
+/**
+ * Mount once at the app shell. Binds the socket store to the socket.io
+ * client's connection events and surfaces user-visible feedback when
+ * the connection drops or recovers.
+ *
+ * We deliberately swallow the initial idle → connecting → connected
+ * transition (no toast on first page load) and only pop a toast on:
+ *   - transition from connected → reconnecting  ("lost connection")
+ *   - transition from reconnecting → connected  ("back online")
+ *   - state == 'error' with a lastError          ("connection error")
+ *
+ * Toasts are identified by a stable id so a flapping connection only
+ * updates the existing toast instead of stacking new ones.
+ */
+export function useSocketConnectionStatus() {
+  const { t } = useTranslation()
+  const bind = useSocketStore((s) => s.bind)
+  const state = useSocketStore((s) => s.state)
+  const lastError = useSocketStore((s) => s.lastError)
+  const previousStateRef = useRef(state)
+
+  // Bind the store on first mount. Idempotent — bind() is a no-op on
+  // subsequent calls so a HMR re-render won't double-wire listeners.
+  useEffect(() => {
+    const teardown = bind()
+    return () => {
+      teardown()
+    }
+  }, [bind])
+
+  useEffect(() => {
+    const previous = previousStateRef.current
+    previousStateRef.current = state
+
+    // Connected → reconnecting: show the "lost connection" toast.
+    if (previous === 'connected' && state === 'reconnecting') {
+      toast.warning(t('socket.lostConnection'), {
+        id: 'socket-status',
+        description: t('socket.tryingToReconnect'),
+        duration: Number.POSITIVE_INFINITY,
+      })
+      return
+    }
+
+    // Reconnecting → connected: celebrate the recovery, dismiss quickly.
+    if (previous === 'reconnecting' && state === 'connected') {
+      toast.success(t('socket.reconnected'), {
+        id: 'socket-status',
+        duration: 2500,
+      })
+      return
+    }
+
+    // Hard error state: show the last error with a manual dismiss.
+    if (state === 'error' && lastError) {
+      toast.error(t('socket.connectionError'), {
+        id: 'socket-status',
+        description: lastError,
+        duration: Number.POSITIVE_INFINITY,
+      })
+      return
+    }
+
+    // Connected from any other state: clear the status toast if it's up.
+    if (state === 'connected' && previous !== 'connected' && previous !== 'idle') {
+      toast.dismiss('socket-status')
+    }
+  }, [state, lastError, t])
+}

--- a/packages/frontend/src/hooks/useSocketEvent.ts
+++ b/packages/frontend/src/hooks/useSocketEvent.ts
@@ -1,0 +1,48 @@
+import { useEffect } from 'react'
+import { getSocket } from '@/lib/socket'
+import type { ServerToClientEvents } from '@wawptn/types'
+
+/**
+ * Thin wrapper over `socket.on(event, handler)` / `socket.off(event, handler)`
+ * with proper React lifecycle hygiene. Replaces the ~8 lines of boilerplate
+ * each page used to write to subscribe to a server event:
+ *
+ *   useEffect(() => {
+ *     const socket = getSocket()
+ *     const handler = (data: X) => { ... }
+ *     socket.on('foo', handler)
+ *     return () => socket.off('foo', handler)
+ *   }, [deps])
+ *
+ * becomes:
+ *
+ *   useSocketEvent('foo', (data: X) => { ... }, [deps])
+ *
+ * The hook is deliberately typed against ServerToClientEvents so the
+ * handler's payload argument is inferred from the event name. The deps
+ * array works like any other hook's — pass a stable handler or list its
+ * dependencies explicitly.
+ *
+ * Note: we intentionally re-subscribe on every render when deps change.
+ * Callers that need referential stability should wrap their handler in
+ * useCallback — this matches the ergonomics of React.useEffect itself.
+ */
+export function useSocketEvent<E extends keyof ServerToClientEvents>(
+  event: E,
+  handler: ServerToClientEvents[E],
+  // Default `[]` mirrors useEffect semantics when called without deps —
+  // the listener attaches once on mount and detaches on unmount.
+  deps: unknown[] = [],
+): void {
+  useEffect(() => {
+    const socket = getSocket()
+    // socket.io's type machinery can't connect the event name string to
+    // the specific handler signature without help — the cast is the
+    // standard socket.io-client generic-typed escape hatch.
+    socket.on(event, handler as never)
+    return () => {
+      socket.off(event, handler as never)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [event, ...deps])
+}

--- a/packages/frontend/src/i18n/locales/en.json
+++ b/packages/frontend/src/i18n/locales/en.json
@@ -355,6 +355,12 @@
     "unlocked": "Unlocked ✓",
     "unlockedToast": "{{icon}} Challenge unlocked: {{title}}"
   },
+  "socket": {
+    "lostConnection": "Connection lost",
+    "tryingToReconnect": "Trying to reconnect...",
+    "reconnected": "Back online",
+    "connectionError": "Connection error"
+  },
   "pwa": {
     "installPromptTitle": "Install WAWPTN",
     "installPromptDescription": "Get faster access from your home screen.",

--- a/packages/frontend/src/i18n/locales/fr.json
+++ b/packages/frontend/src/i18n/locales/fr.json
@@ -392,6 +392,12 @@
   "persona": {
     "today": "Persona du jour"
   },
+  "socket": {
+    "lostConnection": "Connexion perdue",
+    "tryingToReconnect": "Tentative de reconnexion...",
+    "reconnected": "Reconnecté",
+    "connectionError": "Erreur de connexion"
+  },
   "pwa": {
     "installPromptTitle": "Installer WAWPTN",
     "installPromptDescription": "Accédez à l'app plus vite depuis votre écran d'accueil.",

--- a/packages/frontend/src/lib/socket.ts
+++ b/packages/frontend/src/lib/socket.ts
@@ -10,6 +10,18 @@ export function getSocket(): TypedSocket {
     socket = io({
       withCredentials: true,
       autoConnect: false,
+      // Explicit reconnection tuning. socket.io-client has reconnect on
+      // by default, but the defaults are conservative; we want faster
+      // feedback on the first few attempts (500ms / 1s / 2s / 4s ...)
+      // and a ceiling so we don't DoS ourselves on a long outage.
+      reconnection: true,
+      reconnectionAttempts: 10,
+      reconnectionDelay: 500,
+      reconnectionDelayMax: 10_000,
+      // Exponential backoff factor (socket.io multiplies the delay by
+      // a random factor in [1 - randomizationFactor, 1 + randomizationFactor]).
+      randomizationFactor: 0.5,
+      timeout: 20_000,
     })
   }
   return socket

--- a/packages/frontend/src/stores/socket.store.ts
+++ b/packages/frontend/src/stores/socket.store.ts
@@ -1,0 +1,138 @@
+import { create } from 'zustand'
+import { getSocket } from '@/lib/socket'
+
+/**
+ * Connection state machine mirrored from socket.io-client's internal
+ * states. `idle` is a pre-connect bootstrap state — we've not even
+ * attempted yet — which lets the connection-status toast stay silent on
+ * initial page load.
+ */
+export type SocketConnectionState =
+  | 'idle'
+  | 'connecting'
+  | 'connected'
+  | 'reconnecting'
+  | 'disconnected'
+  | 'error'
+
+interface SocketStoreState {
+  state: SocketConnectionState
+  reconnectAttempts: number
+  /** The last transport-level error message, if any. */
+  lastError: string | null
+  /** Number of times the socket has successfully reconnected this session. */
+  reconnectCount: number
+  /** Convenience selector used by UI components that just want a boolean. */
+  isConnected: boolean
+}
+
+interface SocketStoreActions {
+  bind: () => () => void
+  reset: () => void
+}
+
+/**
+ * Zustand store that tracks the live connection state of the shared
+ * socket.io client. The store never *owns* the socket — `getSocket()` still
+ * returns the underlying client and pages can subscribe to individual
+ * events directly. The store only *observes* the built-in connect /
+ * disconnect / reconnect events and exposes them to React components via
+ * a reactive selector.
+ *
+ * Yuki #1 asked for:
+ *   - isConnected / reconnectAttempts / lastError state
+ *   - auto-reconnect feedback in the UI
+ *   - a single bind() call so pages don't have to re-register listeners
+ *
+ * All three are covered by this store + useSocketConnectionStatus.
+ */
+const initialState: SocketStoreState = {
+  state: 'idle',
+  reconnectAttempts: 0,
+  lastError: null,
+  reconnectCount: 0,
+  isConnected: false,
+}
+
+let bound = false
+
+export const useSocketStore = create<SocketStoreState & SocketStoreActions>((set, get) => ({
+  ...initialState,
+
+  /**
+   * Wire the socket.io client's connection events into this store.
+   * Idempotent — calling bind() more than once is a no-op after the
+   * first call, so it's safe to invoke from a top-level mount effect.
+   *
+   * Returns a teardown function that removes the listeners. In practice
+   * we never tear down (the socket is a module-singleton for the app
+   * lifetime), but returning a cleanup keeps the hook lifecycle honest.
+   */
+  bind: () => {
+    if (bound) return () => {}
+    bound = true
+
+    const socket = getSocket()
+
+    const onConnect = () => {
+      const current = get()
+      set({
+        state: 'connected',
+        isConnected: true,
+        reconnectAttempts: 0,
+        lastError: null,
+        reconnectCount: current.state === 'reconnecting' ? current.reconnectCount + 1 : current.reconnectCount,
+      })
+    }
+    const onDisconnect = (reason: string) => {
+      // 'io client disconnect' means we called disconnect() ourselves —
+      // don't enter the reconnect loop in that case, it's a clean exit.
+      if (reason === 'io client disconnect') {
+        set({ state: 'disconnected', isConnected: false })
+        return
+      }
+      set({ state: 'reconnecting', isConnected: false })
+    }
+    const onConnectError = (error: Error) => {
+      set({
+        state: 'error',
+        isConnected: false,
+        lastError: error.message,
+      })
+    }
+    const onReconnectAttempt = (attempt: number) => {
+      set({ state: 'reconnecting', reconnectAttempts: attempt })
+    }
+    const onReconnectError = (error: Error) => {
+      set({ lastError: error.message })
+    }
+
+    socket.on('connect', onConnect)
+    socket.on('disconnect', onDisconnect)
+    socket.on('connect_error', onConnectError)
+    // socket.io's Manager exposes these through the `io` attribute.
+    socket.io.on('reconnect_attempt', onReconnectAttempt)
+    socket.io.on('reconnect_error', onReconnectError)
+    socket.io.on('reconnect_failed', () =>
+      set({ state: 'error', lastError: 'Reconnection failed after max attempts' }),
+    )
+
+    // Seed the state from the current socket status in case bind() runs
+    // after the connection has already been established (rare but
+    // possible on HMR).
+    if (socket.connected) {
+      set({ state: 'connected', isConnected: true })
+    }
+
+    return () => {
+      socket.off('connect', onConnect)
+      socket.off('disconnect', onDisconnect)
+      socket.off('connect_error', onConnectError)
+      socket.io.off('reconnect_attempt', onReconnectAttempt)
+      socket.io.off('reconnect_error', onReconnectError)
+      bound = false
+    }
+  },
+
+  reset: () => set(initialState),
+}))


### PR DESCRIPTION
## Summary

Implements **Yuki #1** from the multi-persona feature meeting (`docs/feature-meeting-2026-04-13.md`). Pages that use the socket.io client had no visibility into connection health — socket.io-client's built-in reconnection runs silently, and when it fails (network hiccup, backend restart, middle-of-nowhere 4G) the user just sees events stop arriving with no feedback. This PR adds a Zustand store that observes the socket lifecycle, a global hook that surfaces a sonner toast on disconnect / reconnect, a `useSocketEvent` convenience hook, and explicit reconnection tuning on the client.

## What's in this PR

**`stores/socket.store.ts`** — new Zustand store
- Connection state machine (`idle` | `connecting` | `connected` | `reconnecting` | `disconnected` | `error`)
- `reconnectAttempts`, `lastError`, `reconnectCount`, `isConnected`
- `bind()` subscribes to the existing shared socket's lifecycle events (`connect`, `disconnect`, `connect_error`, `reconnect_attempt`, `reconnect_error`, `reconnect_failed`) once per session. The store **observes** the existing `getSocket()` singleton; it does **not** own or replace it, so the existing `getSocket()` callers keep working unchanged.

**`hooks/useSocketEvent.ts`** — ergonomic wrapper
- Replaces ~8 lines of per-page boilerplate:
  ```tsx
  const socket = getSocket()
  const handler = (data: X) => { ... }
  socket.on('foo', handler)
  return () => socket.off('foo', handler)
  ```
  with a single `useSocketEvent('foo', handler, [deps])` call.
- Typed against `ServerToClientEvents` so handler payloads are inferred from the event name.

**`hooks/useSocketConnectionStatus.ts`** — global status feedback
- Mount once at the app shell. Binds the socket store and pops sonner toasts on:
  - `connected → reconnecting` — "Connexion perdue" with an indefinite duration
  - `reconnecting → connected` — "Reconnecté", auto-dismiss after 2.5s
  - `error` state — shows `lastError` with manual dismiss
- Toasts share an `id: 'socket-status'` so a flapping connection updates the existing toast instead of stacking new ones.

**`lib/socket.ts`** — explicit reconnection tuning
- `reconnectionAttempts: 10`, `reconnectionDelay: 500`, `reconnectionDelayMax: 10_000`, `randomizationFactor: 0.5`, `timeout: 20_000`
- The existing defaults were conservative and gave poor feedback on the first few attempts.

**`hooks/useChallengeListener.ts`** — showcase migration
- Migrated to `useSocketEvent` as a flagship example of the new pattern. The handler is wrapped in `useCallback` for a stable dep list. `useNotificationListener` and the per-page callers (`VotePage`, `GroupPage`) can move to the same pattern in follow-up PRs; this PR only migrates one caller to keep the review surface small.

**i18n** — new `socket.*` keys in fr/en (`lostConnection`, `tryingToReconnect`, `reconnected`, `connectionError`).

**`App.tsx`** — mounts `useSocketConnectionStatus` alongside the existing notification / challenge / install-prompt hooks.

## Test plan

- [x] `npx tsc --noEmit -p packages/frontend` → clean
- [x] `npx eslint` on all touched files → clean
- [x] Backend `npm test` → 22/22 still passing (no backend changes)
- [ ] Manual: open the app, kill the backend, confirm the "Connexion perdue" toast appears within 1-2s
- [ ] Manual: restart the backend, confirm the "Reconnecté" toast appears and auto-dismisses
- [ ] Manual: trigger a challenge unlock, confirm the celebratory toast still fires (regression check for the migrated `useChallengeListener`)
- [ ] Manual: inspect the socket store via React DevTools, confirm `state` and `reconnectAttempts` update live during a disconnect

## Design notes

- **Why observe the existing `getSocket()` instead of wrapping it?** Changing `getSocket()`'s return type or ownership would force a migration of every call site in one PR. The observer pattern (`bind()` once, update state reactively) lets existing callers keep working and migrations happen incrementally.
- **No offline event queue in this PR.** socket.io-client buffers outgoing emits while reconnecting by default (`volatile: false`). Adding an application-level queue on top would be duplicate effort unless we discover the built-in buffer is insufficient — holding off until there's a real need.
- **`bound` module-level flag, not instance state.** The socket is a module singleton, so `bind()` idempotency is also module-level. A React-instance-scoped flag would double-wire listeners during HMR.

https://claude.ai/code/session_011em4KFFeJY36J4Yxad8zeA