### PR TITLE
feat(wishlist): per-user game wishlist with star toggle on game cards

### DIFF
--- a/docs/api-architecture.md
+++ b/docs/api-architecture.md
@@ -65,6 +65,9 @@ Routes accessibles uniquement aux utilisateurs ayant `is_admin = true`.
 | PATCH | `/api/admin/personas/:id` | Modifie une persona existante |
 | DELETE | `/api/admin/personas/:id` | Supprime une persona (sauf celles par défaut) |
 | PATCH | `/api/admin/personas/:id/toggle` | Active ou désactive une persona |
+| GET | `/api/auth/me/wishlist` | Liste des jeux dans la wishlist de l'utilisateur courant |
+| POST | `/api/auth/me/wishlist` | Ajoute un jeu à la wishlist (idempotent) |
+| DELETE | `/api/auth/me/wishlist/:steamAppId` | Retire un jeu de la wishlist |
 | GET | `/api/admin/stats` | Statistiques globales (utilisateurs, groupes, sessions) |
 | GET | `/api/admin/health` | Santé des intégrations externes (Steam, Epic, GOG, base de données) |
 

--- a/packages/backend/migrations/20260413_f_add_game_wishlists.ts
+++ b/packages/backend/migrations/20260413_f_add_game_wishlists.ts
@@ -1,0 +1,30 @@
+import type { Knex } from 'knex'
+
+/**
+ * Game wishlist: lets a user mark games they want to play soon without
+ * committing to a vote yes. Surfaces as a filter / sort signal on the
+ * group game grid and will later feed the vote session setup dialog as
+ * a "suggested games" hint (Sarah #3 from the multi-persona meeting).
+ *
+ * Scoped per-user, not per-group — a user's wishlist is a personal
+ * preference that applies to every group they're a member of.
+ */
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('game_wishlists', (table) => {
+    table.uuid('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE')
+    // We key the wishlist on steam_app_id because it's the canonical game
+    // identifier already used by user_games / voting_session_games. Epic
+    // and GOG games surface through the same steam_app_id mapping once
+    // the Marcus #1 IGDB dedup ships, so the wishlist will naturally
+    // cover cross-platform libraries without schema changes.
+    table.integer('steam_app_id').notNullable()
+    table.timestamp('created_at').notNullable().defaultTo(knex.fn.now())
+
+    table.primary(['user_id', 'steam_app_id'])
+    table.index('user_id')
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists('game_wishlists')
+}

--- a/packages/backend/src/presentation/routes/auth.routes.ts
+++ b/packages/backend/src/presentation/routes/auth.routes.ts
@@ -208,6 +208,68 @@ router.get('/me/referrals', requireAuth, async (req: Request, res: Response) => 
   }
 })
 
+// ─── Wishlist (Sarah #3) ──────────────────────────────────────────────────
+
+/**
+ * List the current user's wishlist. Returns lightweight steam_app_ids
+ * keyed on createdAt so the frontend can render star state on game
+ * cards without a second round-trip per card. The frontend stores this
+ * as a Set<number> for O(1) lookup during render.
+ */
+router.get('/me/wishlist', requireAuth, async (req: Request, res: Response) => {
+  try {
+    const userId = req.userId!
+    const rows = await db('game_wishlists')
+      .where({ user_id: userId })
+      .orderBy('created_at', 'desc')
+      .select('steam_app_id as steamAppId', 'created_at as createdAt')
+    res.json({ data: rows })
+  } catch (error) {
+    authLogger.error({ error: String(error) }, 'get wishlist failed')
+    res.status(500).json({ error: 'internal', message: 'Failed to get wishlist' })
+  }
+})
+
+router.post('/me/wishlist', requireAuth, async (req: Request, res: Response) => {
+  const userId = req.userId!
+  const { steamAppId } = req.body as { steamAppId?: unknown }
+  if (typeof steamAppId !== 'number' || !Number.isInteger(steamAppId) || steamAppId <= 0) {
+    res.status(400).json({ error: 'validation', message: 'steamAppId must be a positive integer' })
+    return
+  }
+
+  try {
+    // Idempotent upsert — calling POST for a game that's already in the
+    // wishlist is a no-op, not a 409. Matches the "toggle star" UX on
+    // the client: pressing the star twice from two tabs shouldn't error.
+    await db('game_wishlists')
+      .insert({ user_id: userId, steam_app_id: steamAppId })
+      .onConflict(['user_id', 'steam_app_id'])
+      .ignore()
+    res.status(201).json({ ok: true })
+  } catch (error) {
+    authLogger.error({ error: String(error), steamAppId }, 'add to wishlist failed')
+    res.status(500).json({ error: 'internal', message: 'Failed to add to wishlist' })
+  }
+})
+
+router.delete('/me/wishlist/:steamAppId', requireAuth, async (req: Request, res: Response) => {
+  const userId = req.userId!
+  const steamAppId = Number.parseInt(String(req.params['steamAppId'] ?? ''), 10)
+  if (!Number.isInteger(steamAppId) || steamAppId <= 0) {
+    res.status(400).json({ error: 'validation', message: 'steamAppId must be a positive integer' })
+    return
+  }
+
+  try {
+    await db('game_wishlists').where({ user_id: userId, steam_app_id: steamAppId }).del()
+    res.json({ ok: true })
+  } catch (error) {
+    authLogger.error({ error: String(error), steamAppId }, 'remove from wishlist failed')
+    res.status(500).json({ error: 'internal', message: 'Failed to remove from wishlist' })
+  }
+})
+
 // Get full profile with platform connections
 router.get('/profile', requireAuth, async (req: Request, res: Response) => {
   try {

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -19,6 +19,7 @@ import { useChallengeListener } from '@/hooks/useChallengeListener'
 import { usePwaInstallPrompt } from '@/hooks/usePwaInstallPrompt'
 import { useSocketConnectionStatus } from '@/hooks/useSocketConnectionStatus'
 import { useNotificationStore } from '@/stores/notification.store'
+import { useWishlistStore } from '@/stores/wishlist.store'
 
 function App() {
   const { user, loading, fetchUser } = useAuthStore()
@@ -30,9 +31,13 @@ function App() {
   useEffect(() => {
     if (user) {
       connectSocket()
+      // Seed the wishlist store for authenticated users so every game
+      // card renders with the correct star state on first paint.
+      void useWishlistStore.getState().fetch()
     } else {
       disconnectSocket()
       useNotificationStore.getState().clear()
+      useWishlistStore.getState().clear()
     }
     return () => disconnectSocket()
   }, [user])

--- a/packages/frontend/src/components/game-grid.tsx
+++ b/packages/frontend/src/components/game-grid.tsx
@@ -8,6 +8,7 @@ import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { EmptyState } from '@/components/empty-state'
+import { useWishlistStore } from '@/stores/wishlist.store'
 
 interface Game {
   steamAppId: number
@@ -456,6 +457,19 @@ export function GameGrid({ games, loading, filters, onToggleMultiplayer, onToggl
 }
 
 function GameCard({ game, t }: { game: Game; t: (key: string, options?: Record<string, unknown>) => string }) {
+  // Subscribe only to our own steamAppId's wishlist state so siblings
+  // don't re-render when unrelated cards are starred. Zustand bails out
+  // when the selected boolean hasn't actually changed, which keeps the
+  // grid cheap even with hundreds of cards.
+  const isWishlisted = useWishlistStore((s) => s.ids.has(game.steamAppId))
+  const toggleWishlist = useWishlistStore((s) => s.toggle)
+
+  const handleWishlistClick = (e: React.MouseEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    void toggleWishlist(game.steamAppId)
+  }
+
   return (
     <div role="listitem" className="relative group rounded-lg overflow-hidden ring-1 ring-white/[0.06] hover:ring-primary/20 transition-all duration-300" style={{ transition: 'opacity 150ms ease, box-shadow 0.3s, ring-color 0.3s' }}>
       <Tooltip>
@@ -509,6 +523,27 @@ function GameCard({ game, t }: { game: Game; t: (key: string, options?: Record<s
           </TooltipContent>
         </Tooltip>
       )}
+      {/* Wishlist star — positioned below the owner-count badge when that
+          badge is present, otherwise top-right. Click swallows the event
+          so taps don't also trigger the underlying tooltip trigger. */}
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={handleWishlistClick}
+            aria-label={isWishlisted ? t('wishlist.removeLabel') : t('wishlist.addLabel')}
+            aria-pressed={isWishlisted}
+            className={`absolute ${game.ownerCount < game.totalMembers ? 'top-8' : 'top-1'} right-1 flex h-7 w-7 items-center justify-center rounded-full bg-black/60 backdrop-blur-sm transition-all hover:bg-black/80 ${
+              isWishlisted ? 'text-reward' : 'text-white/60 hover:text-white'
+            }`}
+          >
+            <Star className={`w-3.5 h-3.5 ${isWishlisted ? 'fill-current' : ''}`} />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="left" className="text-xs">
+          {isWishlisted ? t('wishlist.inList') : t('wishlist.addTooltip')}
+        </TooltipContent>
+      </Tooltip>
       <div className="absolute bottom-7 right-1 flex gap-0.5">
         {game.isFree && (
           <span className="text-xs font-bold bg-score-good text-white px-1.5 py-0.5 rounded">

--- a/packages/frontend/src/i18n/locales/en.json
+++ b/packages/frontend/src/i18n/locales/en.json
@@ -361,6 +361,12 @@
     "reconnected": "Back online",
     "connectionError": "Connection error"
   },
+  "wishlist": {
+    "addLabel": "Add to wishlist",
+    "removeLabel": "Remove from wishlist",
+    "addTooltip": "Add to wishlist",
+    "inList": "In your wishlist"
+  },
   "pwa": {
     "installPromptTitle": "Install WAWPTN",
     "installPromptDescription": "Get faster access from your home screen.",

--- a/packages/frontend/src/i18n/locales/fr.json
+++ b/packages/frontend/src/i18n/locales/fr.json
@@ -398,6 +398,12 @@
     "reconnected": "Reconnecté",
     "connectionError": "Erreur de connexion"
   },
+  "wishlist": {
+    "addLabel": "Ajouter à ma liste d'envies",
+    "removeLabel": "Retirer de ma liste d'envies",
+    "addTooltip": "Ajouter à ma liste",
+    "inList": "Dans ma liste"
+  },
   "pwa": {
     "installPromptTitle": "Installer WAWPTN",
     "installPromptDescription": "Accédez à l'app plus vite depuis votre écran d'accueil.",

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -197,6 +197,16 @@ export const api = {
       method: 'PATCH',
       body: JSON.stringify(settings),
     }),
+  // Wishlist — Sarah #3
+  getWishlist: () => request<{ data: { steamAppId: number; createdAt: string }[] }>('/auth/me/wishlist'),
+  addToWishlist: (steamAppId: number) =>
+    request<{ ok: true }>('/auth/me/wishlist', {
+      method: 'POST',
+      body: JSON.stringify({ steamAppId }),
+    }),
+  removeFromWishlist: (steamAppId: number) =>
+    request<{ ok: true }>(`/auth/me/wishlist/${steamAppId}`, { method: 'DELETE' }),
+
   getAdminStats: () => request<{ users: number; admins: number; groups: number; votingSessions: number }>('/admin/stats'),
   getAdminHealth: () => request<{
     timestamp: string;

--- a/packages/frontend/src/stores/wishlist.store.ts
+++ b/packages/frontend/src/stores/wishlist.store.ts
@@ -1,0 +1,74 @@
+import { create } from 'zustand'
+import { api } from '@/lib/api'
+
+/**
+ * User's personal game wishlist — a set of steam_app_ids the user has
+ * starred so the UI can render "I want to play this soon" state on
+ * every game card without a round-trip per card.
+ *
+ * Implements Sarah #3 from the multi-persona feature meeting.
+ *
+ * Toggle is optimistic: the local set is updated immediately, then the
+ * API call goes out, and we roll back on failure. This matches the
+ * "tap the star and it lights up" ergonomic users expect from every
+ * other app.
+ */
+interface WishlistState {
+  /** Stable snapshot — callers should not mutate. */
+  ids: Set<number>
+  loaded: boolean
+  loading: boolean
+  fetch: () => Promise<void>
+  toggle: (steamAppId: number) => Promise<void>
+  has: (steamAppId: number) => boolean
+  clear: () => void
+}
+
+export const useWishlistStore = create<WishlistState>((set, get) => ({
+  ids: new Set<number>(),
+  loaded: false,
+  loading: false,
+
+  fetch: async () => {
+    if (get().loading) return
+    set({ loading: true })
+    try {
+      const { data } = await api.getWishlist()
+      set({ ids: new Set(data.map((r) => r.steamAppId)), loaded: true, loading: false })
+    } catch {
+      set({ loading: false })
+    }
+  },
+
+  toggle: async (steamAppId: number) => {
+    const current = get().ids
+    const isInList = current.has(steamAppId)
+
+    // Optimistic update — replace the set rather than mutating it so
+    // Zustand's reference-equality check fires and subscribed components
+    // re-render.
+    const next = new Set(current)
+    if (isInList) next.delete(steamAppId)
+    else next.add(steamAppId)
+    set({ ids: next })
+
+    try {
+      if (isInList) {
+        await api.removeFromWishlist(steamAppId)
+      } else {
+        await api.addToWishlist(steamAppId)
+      }
+    } catch {
+      // Roll back on failure. We still use a fresh Set rather than
+      // mutating to avoid splitting references.
+      const rollback = new Set(get().ids)
+      if (isInList) rollback.add(steamAppId)
+      else rollback.delete(steamAppId)
+      set({ ids: rollback })
+    }
+  },
+
+  has: (steamAppId: number) => get().ids.has(steamAppId),
+
+  clear: () => set({ ids: new Set<number>(), loaded: false }),
+}))


### PR DESCRIPTION
## Summary

Implements **Sarah #3** from the multi-persona feature meeting (`docs/feature-meeting-2026-04-13.md`). Users had no way to mark games they want to play soon without committing to a vote yes, so long-tail gems in a shared library got lost in the grid. This PR ships a per-user wishlist keyed on `steam_app_id` with a star toggle on every game card.

## What's in this PR

**Schema** — new `game_wishlists` table (`20260413_f_add_game_wishlists.ts`)
- `user_id` → `users` (CASCADE on delete)
- `steam_app_id` (integer)
- `created_at` (timestamp)
- Composite PK on `(user_id, steam_app_id)` + index on `user_id` for the "list my wishlist" query

**Backend** — three new endpoints under `/api/auth/me/wishlist` (all `requireAuth`)
- `GET /api/auth/me/wishlist` — returns the user's starred `steam_app_id`s sorted by `createdAt` desc for the frontend's initial seed
- `POST /api/auth/me/wishlist` — **idempotent** via `onConflict.ignore()` so double-tap doesn't error out (matches the "tap the star twice" UX)
- `DELETE /api/auth/me/wishlist/:steamAppId` — removes a single entry
- All three validate that `steamAppId` is a positive integer before touching the DB

**Frontend**
- **`stores/wishlist.store.ts`** — new Zustand store with an `ids: Set<number>`, a `fetch()` for the initial seed, and an optimistic `toggle()` that updates the set immediately, calls the API, and rolls back on failure. Uses fresh `Set` references on every update so Zustand's reference-equality check fires and subscribed components rerender.
- **`App.tsx`** — seeds the store when a user is authenticated and clears it on logout, mirroring the existing notification-store lifecycle.
- **`GameCard`** in `game-grid.tsx` — subscribes to its **own** `steamAppId`'s entry in the set via a fine-grained selector (`useWishlistStore((s) => s.ids.has(game.steamAppId))`). Zustand bails out when the selected boolean hasn't changed, so toggling one card doesn't rerender every other card in the grid.
- New star button overlay in the top-right corner of every card, positioned below the owner-count badge when that's present to avoid overlap. Uses the existing `reward` color for the filled state. Click handler `stopPropagation()`s so tapping the star doesn't also trigger the parent tooltip.
- New `wishlist.*` i18n keys in fr/en (`addLabel`, `removeLabel`, `addTooltip`, `inList`) for accessible `aria-label`s and tooltip text.

**Docs** — `api-architecture.md` gets rows for the three new endpoints.

## Test plan

- [x] `npx tsc --noEmit -p packages/backend` → clean
- [x] `npx tsc --noEmit -p packages/frontend` → clean
- [x] `npm test --workspace=@wawptn/backend` → 22/22 still passing
- [x] `npx eslint` on touched files → only the pre-existing TanStack Virtual warning
- [ ] Manual: star a game, reload the page, confirm the star is still lit (persisted round-trip)
- [ ] Manual: double-tap the star quickly from two tabs, confirm both tabs converge on the same state with no 409
- [ ] Manual: sign out and back in, confirm the store clears + re-seeds
- [ ] Manual: kill the backend mid-toggle, confirm the star rolls back to its previous state

## Scope notes

- The **"surface wishlisted games as suggestions when starting a vote session"** part of Sarah #3 is a follow-up — the underlying data is there, the `vote-setup-dialog` just needs to read it. Keeping this PR focused on the core toggle infrastructure.
- **No "My wishlist" page yet** — the star state is visible from inside each group's game grid. A dedicated profile-level view can come later.
- **Why `steam_app_id` and not a canonical game id?** The existing `user_games`, `voting_session_games`, and every other game reference uses `steam_app_id`, so the wishlist fits naturally into the existing query surface. When Marcus #1 (IGDB cross-platform dedup) ships, the wishlist will naturally cover cross-platform libraries without a schema change — games mapped to the same canonical id will share a single wishlist entry.

https://claude.ai/code/session_011em4KFFeJY36J4Yxad8zeA