### PR TITLE
feat(games): cross-platform canonical name dedupe + igdb_id column

### DIFF
--- a/docs/api-architecture.md
+++ b/docs/api-architecture.md
@@ -70,6 +70,7 @@ Routes accessibles uniquement aux utilisateurs ayant `is_admin = true`.
 | DELETE | `/api/auth/me/wishlist/:steamAppId` | Retire un jeu de la wishlist |
 | GET | `/api/admin/stats` | Statistiques globales (utilisateurs, groupes, sessions) |
 | GET | `/api/admin/health` | Santé des intégrations externes (Steam, Epic, GOG, base de données) |
+| POST | `/api/admin/games/dedupe` | Lance une passe de déduplication inter-plateformes des jeux canoniques |
 
 ### Discord (feature-flagged)
 

--- a/packages/backend/migrations/20260413_g_add_games_igdb_id.ts
+++ b/packages/backend/migrations/20260413_g_add_games_igdb_id.ts
@@ -1,0 +1,28 @@
+import type { Knex } from 'knex'
+
+/**
+ * Add `igdb_id` column to the `games` table so a future IGDB integration
+ * can attach the canonical IGDB id to each canonical game row. Leaving the
+ * column nullable for now — this PR does not call the IGDB API, it just
+ * reserves the slot so the follow-up PR that adds the client code only
+ * needs to populate the column.
+ *
+ * Implements the first half of Marcus #1 from the multi-persona feature
+ * meeting. The immediate cross-platform dedupe win ships via the domain
+ * utility in game-dedupe.ts which merges duplicate canonical games by
+ * normalized name; the `igdb_id` column makes that migration safer by
+ * offering a stronger matching signal once the API client exists.
+ */
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('games', (table) => {
+    table.bigInteger('igdb_id').nullable()
+    table.index('igdb_id')
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('games', (table) => {
+    table.dropIndex('igdb_id')
+    table.dropColumn('igdb_id')
+  })
+}

--- a/packages/backend/src/domain/__tests__/game-name.test.ts
+++ b/packages/backend/src/domain/__tests__/game-name.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeGameName } from '../game-name.js'
+
+describe('normalizeGameName', () => {
+  it('is deterministic and lowercase', () => {
+    expect(normalizeGameName('Hades')).toBe('hades')
+    expect(normalizeGameName('HADES')).toBe('hades')
+    expect(normalizeGameName('  Hades  ')).toBe('hades')
+  })
+
+  it('strips trademark symbols and punctuation', () => {
+    expect(normalizeGameName('DARK SOULS™ III')).toBe('dark souls 3')
+    expect(normalizeGameName('The Witcher® 3: Wild Hunt')).toBe('the witcher 3 wild hunt')
+    expect(normalizeGameName('F.E.A.R.')).toBe('f e a r')
+  })
+
+  it('normalises trailing roman numerals to arabic', () => {
+    expect(normalizeGameName('Final Fantasy VII')).toBe('final fantasy 7')
+    expect(normalizeGameName('Grand Theft Auto V')).toBe('grand theft auto 5')
+    expect(normalizeGameName('Dragon Age II')).toBe('dragon age 2')
+  })
+
+  it('drops edition suffixes after a colon', () => {
+    expect(normalizeGameName('Hades: Definitive Edition')).toBe('hades')
+    expect(normalizeGameName('Skyrim: Special Edition')).toBe('skyrim special edition')
+    // Only recognised editions get stripped via the colon shortcut
+  })
+
+  it('drops the common GOTY / Definitive Edition suffixes without a colon', () => {
+    expect(normalizeGameName('The Witcher 3 Game of the Year Edition')).toBe('the witcher 3')
+    expect(normalizeGameName('Hades Definitive Edition')).toBe('hades')
+    expect(normalizeGameName('Borderlands GOTY')).toBe('borderlands')
+  })
+
+  it('treats a non-edition subtitle as part of the title', () => {
+    // "Odyssey Update" is not in the edition list so it stays.
+    const result = normalizeGameName('Hades: Odyssey Update')
+    expect(result).toContain('hades')
+    expect(result).toContain('odyssey update')
+  })
+
+  it('leaves two clearly different games as different keys', () => {
+    const hades = normalizeGameName('Hades')
+    const hades2 = normalizeGameName('Hades II')
+    expect(hades).not.toBe(hades2)
+  })
+
+  it('collapses Steam vs Epic vs GOG title variants to the same key', () => {
+    const steam = normalizeGameName('The Witcher® 3: Wild Hunt - Game of the Year Edition')
+    const epic = normalizeGameName('The Witcher 3: Wild Hunt')
+    const gog = normalizeGameName('The Witcher 3 Wild Hunt GOTY')
+    expect(steam).toBe(epic)
+    expect(epic).toBe(gog)
+  })
+
+  it('returns an empty string for junk-only input', () => {
+    expect(normalizeGameName('   ')).toBe('')
+    expect(normalizeGameName('™®')).toBe('')
+  })
+})

--- a/packages/backend/src/domain/admin-audit-log.ts
+++ b/packages/backend/src/domain/admin-audit-log.ts
@@ -25,6 +25,7 @@ export type AdminAuditAction =
   | 'persona.delete'
   | 'persona.toggle'
   | 'bot_settings.update'
+  | 'games.dedupe'
 
 interface RecordAdminActionInput {
   /** Express request, used to extract the actor id and forensic context. */

--- a/packages/backend/src/domain/game-dedupe.ts
+++ b/packages/backend/src/domain/game-dedupe.ts
@@ -1,0 +1,162 @@
+import { db } from '../infrastructure/database/connection.js'
+import { logger } from '../infrastructure/logger/logger.js'
+import { normalizeGameName } from './game-name.js'
+
+/**
+ * Cross-platform game dedupe pass — part of Marcus #1 from the multi-
+ * persona feature meeting.
+ *
+ * Background: `user_games.game_id` already points at a row in the
+ * canonical `games` table, and `computeCommonGames` groups by that
+ * canonical id. The problem is that the *populators* (the Steam, Epic
+ * and GOG sync paths) used a weak name normalizer, so the same game
+ * coming from two storefronts (Steam "Hades" + Epic "Hades") would
+ * often land on TWO different canonical rows. `computeCommonGames`
+ * then correctly reports that Alice and Bob don't share Hades even
+ * though they do on different platforms.
+ *
+ * This utility does a one-shot idempotent cleanup:
+ *
+ *   1. Walk every row in `games`.
+ *   2. Normalise its `canonical_name` through the shared normaliser.
+ *   3. Group rows with the same normalised key.
+ *   4. For each group with 2+ rows, pick the row with the lowest `id`
+ *      (stable, deterministic) as the winner and merge the others:
+ *        - Update every `user_games` row pointing at a loser to point
+ *          at the winner instead.
+ *        - Update every `game_platform_ids` row likewise.
+ *        - Delete the loser from `games`.
+ *   5. Report how many rows were merged.
+ *
+ * The merge runs inside a single transaction per group so a concurrent
+ * sync can't interleave half-way through. Failures on one group are
+ * logged and skipped — they don't abort the whole pass.
+ *
+ * This is safe to run multiple times. If the first pass merged all
+ * name collisions, the second pass will find nothing to do.
+ */
+
+interface GameRow {
+  id: string
+  canonical_name: string
+}
+
+export interface DedupeResult {
+  scanned: number
+  groupsFound: number
+  gamesMerged: number
+  userGamesUpdated: number
+  errors: number
+}
+
+export async function mergeDuplicateGames(): Promise<DedupeResult> {
+  const result: DedupeResult = {
+    scanned: 0,
+    groupsFound: 0,
+    gamesMerged: 0,
+    userGamesUpdated: 0,
+    errors: 0,
+  }
+
+  const rows: GameRow[] = await db('games').select('id', 'canonical_name')
+  result.scanned = rows.length
+
+  // Group rows by their normalised name. Empty strings (a name that
+  // normalises to nothing) are skipped — we'd rather leave a ghost
+  // canonical row alone than merge every nameless game into one.
+  const buckets = new Map<string, GameRow[]>()
+  for (const row of rows) {
+    const key = normalizeGameName(row.canonical_name)
+    if (!key) continue
+    const bucket = buckets.get(key)
+    if (bucket) bucket.push(row)
+    else buckets.set(key, [row])
+  }
+
+  for (const [key, bucket] of buckets) {
+    if (bucket.length < 2) continue
+    result.groupsFound += 1
+
+    // Deterministic winner: the row with the lexicographically smallest
+    // uuid. Using the smallest id is stable across runs so repeat
+    // invocations produce the same merge even if the DB returned rows
+    // in a different order.
+    bucket.sort((a, b) => a.id.localeCompare(b.id))
+    const winner = bucket[0]!
+    const losers = bucket.slice(1)
+    const loserIds = losers.map((l) => l.id)
+
+    try {
+      await db.transaction(async (trx) => {
+        // Repoint user_games to the winner. We use ON CONFLICT DO NOTHING-
+        // like semantics by catching unique violations per row: if a user
+        // already owns the winner canonical game through Steam and we try
+        // to repoint their Epic copy, the composite unique constraint on
+        // user_games would fire — in that case the Epic row is redundant
+        // and we delete it instead.
+        const userGamesRows: { user_id: string }[] = await trx('user_games')
+          .whereIn('game_id', loserIds)
+          .select('user_id')
+        const affectedUserIds = new Set(userGamesRows.map((r) => r.user_id))
+
+        for (const userId of affectedUserIds) {
+          // If the user already owns the winner, drop the loser rows.
+          const ownsWinner = await trx('user_games')
+            .where({ user_id: userId, game_id: winner.id })
+            .first()
+          if (ownsWinner) {
+            await trx('user_games').where({ user_id: userId }).whereIn('game_id', loserIds).del()
+          } else {
+            // Repoint: keep the loser row but swap its game_id to the
+            // winner. We don't merge playtime across rows — the user
+            // now points at the winner and the losers' playtime is
+            // dropped (rare, minor) rather than summed, to keep the
+            // transaction simple and avoid double-counting.
+            await trx('user_games')
+              .where({ user_id: userId })
+              .whereIn('game_id', loserIds)
+              .update({ game_id: winner.id })
+          }
+        }
+
+        const userGamesUpdateCount = affectedUserIds.size
+        result.userGamesUpdated += userGamesUpdateCount
+
+        // Repoint game_platform_ids — if a platform link already exists
+        // for the winner, drop the duplicate loser link instead.
+        const platformRows: { id: string; platform: string; platform_game_id: string }[] =
+          await trx('game_platform_ids')
+            .whereIn('game_id', loserIds)
+            .select('id', 'platform', 'platform_game_id')
+
+        for (const link of platformRows) {
+          const exists = await trx('game_platform_ids')
+            .where({
+              game_id: winner.id,
+              platform: link.platform,
+              platform_game_id: link.platform_game_id,
+            })
+            .first()
+          if (exists) {
+            await trx('game_platform_ids').where({ id: link.id }).del()
+          } else {
+            await trx('game_platform_ids').where({ id: link.id }).update({ game_id: winner.id })
+          }
+        }
+
+        // Finally, drop the loser canonical rows.
+        await trx('games').whereIn('id', loserIds).del()
+        result.gamesMerged += losers.length
+      })
+    } catch (err) {
+      result.errors += 1
+      logger.error(
+        { error: String(err), key, winnerId: winner.id, loserIds },
+        'game dedupe: failed to merge a group',
+      )
+    }
+  }
+
+  logger.info(result, 'game dedupe: finished')
+  return result
+}

--- a/packages/backend/src/domain/game-name.ts
+++ b/packages/backend/src/domain/game-name.ts
@@ -1,0 +1,104 @@
+/**
+ * Canonical game-name normalization — used by the cross-platform
+ * dedupe utility and the Epic / GOG sync paths to decide whether two
+ * games with different raw names are really the same game.
+ *
+ * The old normalizer (lowercase → strip non-alphanumeric → collapse
+ * whitespace) missed the most common reasons two storefronts disagree
+ * about a title:
+ *
+ *   - "Hades: Definitive Edition" vs "Hades"
+ *   - "DARK SOULS™ III" vs "Dark Souls 3" vs "Dark Souls III"
+ *   - "The Witcher® 3: Wild Hunt - Game of the Year Edition" vs
+ *     "The Witcher 3: Wild Hunt"
+ *
+ * This module layers three passes on top of the old behaviour:
+ *   1. Drop common "edition" / subtitle suffixes ("Definitive Edition",
+ *      "GOTY", "Game of the Year Edition", "Complete Edition", ...).
+ *   2. Normalize trailing Roman numerals to Arabic (III → 3, IV → 4).
+ *   3. Collapse multiple spaces and trim.
+ *
+ * The result is a stable comparison key: two games are "the same"
+ * when normalizeGameName(a) === normalizeGameName(b). The result is
+ * lowercase and not meant to be shown to users.
+ *
+ * This is part of Marcus #1 from the multi-persona feature meeting.
+ * A richer dedupe signal (IGDB external id lookup) is the long-term
+ * plan and its column already exists on `games.igdb_id`; this module
+ * ships the immediate, offline dedupe win.
+ */
+
+const EDITION_SUFFIXES = [
+  "game of the year edition",
+  "game of the year",
+  "goty edition",
+  "goty",
+  "definitive edition",
+  "complete edition",
+  "ultimate edition",
+  "deluxe edition",
+  "standard edition",
+  "enhanced edition",
+  "remastered",
+  "anniversary edition",
+  "directors cut",
+  "gold edition",
+  "platinum edition",
+]
+
+const ROMAN_TO_ARABIC: Record<string, string> = {
+  i: '1',
+  ii: '2',
+  iii: '3',
+  iv: '4',
+  v: '5',
+  vi: '6',
+  vii: '7',
+  viii: '8',
+  ix: '9',
+  x: '10',
+}
+
+/**
+ * Normalise a raw game title into a stable lowercase comparison key.
+ */
+export function normalizeGameName(name: string): string {
+  let out = name.toLowerCase()
+
+  // Strip anything that isn't a letter, digit, space, or colon. Colons are
+  // preserved until the edition-suffix pass so "Hades: Definitive Edition"
+  // can anchor its suffix on the colon boundary.
+  out = out.replace(/[^a-z0-9\s:]/g, ' ')
+
+  // Drop everything after a colon if the tail matches a known edition
+  // marker — e.g. "Hades: Definitive Edition" → "Hades". We run this
+  // before the generic suffix strip so titles whose subtitle isn't an
+  // edition marker ("Hades: Odyssey Update") are preserved.
+  out = out.replace(/\s*:\s*(.*)$/u, (_full, tail: string) => {
+    const trimmedTail = tail.trim()
+    if (EDITION_SUFFIXES.some((suffix) => trimmedTail.startsWith(suffix))) {
+      return ''
+    }
+    return ` ${trimmedTail}`
+  })
+
+  // Strip any lingering edition suffixes that appear without a colon
+  // boundary ("Hades Definitive Edition").
+  for (const suffix of EDITION_SUFFIXES) {
+    const escaped = suffix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    out = out.replace(new RegExp(`\\s+${escaped}$`), '')
+  }
+
+  // Normalise trailing Roman numerals to Arabic digits. Only the final
+  // token is considered — we don't want to mangle "Vice City" into
+  // "6ice City".
+  out = out.replace(/\s+([ivx]+)$/u, (match, numeral: string) => {
+    const arabic = ROMAN_TO_ARABIC[numeral.toLowerCase()]
+    return arabic ? ` ${arabic}` : match
+  })
+
+  // Drop the colon + any remaining special characters, collapse whitespace.
+  out = out.replace(/:/g, ' ').replace(/\s+/g, ' ').trim()
+
+  return out
+}

--- a/packages/backend/src/infrastructure/epic/epic-client.ts
+++ b/packages/backend/src/infrastructure/epic/epic-client.ts
@@ -280,10 +280,9 @@ export async function getOwnedGames(userId: string): Promise<EpicOwnedGame[] | n
   }
 }
 
-export function normalizeGameName(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9\s]/g, '')
-    .replace(/\s+/g, ' ')
-    .trim()
-}
+// Re-export the shared canonical name normaliser. The old location kept
+// its own copy of a weak lowercase-strip normaliser; Marcus #1 centralised
+// the logic in domain/game-name.ts so the cross-platform dedupe and the
+// Epic/GOG sync paths stay in lockstep. Callers can keep importing
+// `normalizeGameName` from here.
+export { normalizeGameName } from '../../domain/game-name.js'

--- a/packages/backend/src/infrastructure/gog/gog-client.ts
+++ b/packages/backend/src/infrastructure/gog/gog-client.ts
@@ -273,10 +273,8 @@ export async function getOwnedGames(userId: string): Promise<GogOwnedGame[] | nu
   }
 }
 
-export function normalizeGameName(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9\s]/g, '')
-    .replace(/\s+/g, ' ')
-    .trim()
-}
+// Re-export the shared canonical name normaliser. See Marcus #1 notes
+// on epic-client.ts — the logic lives in domain/game-name.ts so the
+// dedupe and sync paths agree on what "two different titles mean the
+// same game" looks like.
+export { normalizeGameName } from '../../domain/game-name.js'

--- a/packages/backend/src/presentation/routes/admin.routes.ts
+++ b/packages/backend/src/presentation/routes/admin.routes.ts
@@ -8,6 +8,7 @@ import { invalidateAllUserSessions } from '../../domain/auth-service.js'
 import { getHealth as getSteamHealth } from '../../infrastructure/steam/steam-client.js'
 import { getHealth as getEpicHealth } from '../../infrastructure/epic/epic-client.js'
 import { getHealth as getGogHealth } from '../../infrastructure/gog/gog-client.js'
+import { mergeDuplicateGames } from '../../domain/game-dedupe.js'
 import { validateBody } from '../middleware/validate.middleware.js'
 
 // ─── Zod schemas ──────────────────────────────────────────────────────────────
@@ -504,6 +505,30 @@ router.get('/health', async (_req: Request, res: Response) => {
       gog: safe(getGogHealth, { state: 'open', consecutiveFailures: -1, circuitOpenUntil: null, cacheSize: 0, enabled: false }),
     },
   })
+})
+
+// ─── Cross-platform game dedupe (Marcus #1) ──────────────────────────────
+// One-shot idempotent pass that merges canonical games whose normalised
+// names collide. Useful to run after a big normalizer change or when
+// cross-platform "not seeing my friend's game" reports come in.
+//
+// The utility in domain/game-dedupe.ts is safe to re-run; a second call
+// after the first merged everything it could will be a no-op. We record
+// the invocation in the admin audit log with the summary stats so admins
+// can see who triggered the last pass.
+router.post('/games/dedupe', async (req: Request, res: Response) => {
+  try {
+    const result = await mergeDuplicateGames()
+    await recordAdminAction({
+      req,
+      action: 'games.dedupe',
+      metadata: { ...result },
+    })
+    res.json(result)
+  } catch (error) {
+    authLogger.error({ error: String(error) }, 'admin games dedupe failed')
+    res.status(500).json({ error: 'internal', message: 'Failed to run game dedupe pass' })
+  }
 })
 
 export { router as adminRoutes }


### PR DESCRIPTION
## Summary

Implements **Marcus #1** from the multi-persona feature meeting (`docs/feature-meeting-2026-04-13.md`). The old name normaliser used by the Epic and GOG sync paths was a weak `lowercase → strip-non-alnum → trim` pass that missed the most common reasons two storefronts disagree about a title. Players with "Hades" on Steam and "Hades: Definitive Edition" on Epic would land on two different canonical game rows, and `computeCommonGames` would correctly report (given its data) that they don't share the game.

This PR ships the **immediate cross-platform dedupe win** + schema groundwork for a future IGDB integration.

## What's in this PR

**1. Shared `domain/game-name.ts`** — richer normaliser
- Drops trademark symbols and punctuation
- Strips common edition suffixes (`Definitive Edition`, `GOTY`, `Game of the Year Edition`, `Complete Edition`, `Ultimate Edition`, …)
- Normalises trailing Roman numerals to Arabic (`Final Fantasy VII` → `final fantasy 7`, `Grand Theft Auto V` → `grand theft auto 5`)
- Handles the colon-subtitle shortcut (`Hades: Definitive Edition` → `hades`) while leaving non-edition subtitles alone (`Hades: Odyssey Update` stays distinct)
- 9 unit tests covering every equivalence class and edge case

**2. Epic & GOG clients re-export from the shared module** so the sync paths and the new dedupe utility agree on what "two different titles mean the same game" looks like. Existing imports in `auth.routes.ts` keep working — no rename needed.

**3. `domain/game-dedupe.ts` — `mergeDuplicateGames()`**

A one-shot, **idempotent** pass that:
- Walks every row in `games`
- Groups by normalised `canonical_name`
- For each group with 2+ rows, picks the **lowest-id row as the deterministic winner** and merges the losers:
  - `user_games` rows are repointed to the winner, or **deleted if the user already owned the winner** (avoids unique-constraint violations)
  - `game_platform_ids` links are repointed, or dropped on duplicate
  - Loser rows in `games` are deleted
- Each group merges inside its own transaction so a failure on one group doesn't abort the whole pass
- Returns a `DedupeResult` with `scanned`, `groupsFound`, `gamesMerged`, `userGamesUpdated`, `errors` counters

**Safe to run multiple times.** The first pass merges every current name collision; subsequent passes are no-ops unless new collisions have accumulated.

**4. `POST /api/admin/games/dedupe`** — admin-only endpoint that invokes the utility and records the result in the admin audit log via a new `games.dedupe` action. Protected by the existing `adminMutationLimiter`.

**5. Migration** — `20260413_g_add_games_igdb_id.ts` adds a nullable `igdb_id` (`bigInteger` + index) column on the `games` table. This PR does **not** call the IGDB API, but the column is there so a follow-up can just fill it in without another migration.

## Test plan

- [x] `npx tsc --noEmit -p packages/backend` → clean
- [x] `npm test --workspace=@wawptn/backend` → 31/31 passing (9 new `normalizeGameName` tests)
- [ ] Manual: on staging, run `POST /api/admin/games/dedupe` and confirm the returned `DedupeResult` stats + an `admin_audit_log` row with `action: 'games.dedupe'`
- [ ] Manual: create two canonical games with colliding names through Steam + Epic sync, run the dedupe, confirm both users now share the same `game_id` and `computeCommonGames` returns the game
- [ ] Manual: re-run the dedupe immediately after, confirm `groupsFound: 0`, `gamesMerged: 0` (idempotent)

## Scope notes

- **No live IGDB integration in this PR.** IGDB requires Twitch OAuth, rate-limited external calls, and a backfill strategy — that's its own follow-up PR. The normalizer + dedupe pass ships the immediate dedupe win (fewer false negatives on cross-platform common games) *without* the external-API risk. The `igdb_id` column is there for when that PR lands.
- **Playtime is not summed across merged rows.** When a loser's `user_games` row is repointed to the winner, the playtime that was on the loser is kept as-is on that row. We don't attempt to sum playtime across two rows for the same (user, canonical game) pair — the logic would need to handle conflicts with a user who already owns the winner, and the risk of double-counting felt worse than the tiny fidelity loss.
- **`mergeDuplicateGames()` is not currently wired into the Steam/Epic/GOG sync paths.** It's a one-shot admin action, not a per-sync hook. Running it on every library sync would be wasted work — the dedupe only needs to run when the normaliser improves or when new storefronts are added.

https://claude.ai/code/session_011em4KFFeJY36J4Yxad8zeA