### PR TITLE
refactor(persona): move daily persona from header to GroupsPage greeting card

### DIFF
--- a/packages/frontend/src/components/app-header.tsx
+++ b/packages/frontend/src/components/app-header.tsx
@@ -15,7 +15,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
-import { PersonaBadge } from '@/components/persona-badge'
 import {
   ResponsiveDialog,
   ResponsiveDialogContent,
@@ -65,9 +64,6 @@ export function AppHeader({ children, className, maxWidth = 'narrow' }: AppHeade
           <span className={cn('font-heading font-bold text-lg tracking-[-0.03em]', children ? 'hidden sm:inline' : 'inline')}>WAWPTN</span>
         </button>
         <div className={cn('flex-1', children && 'hidden sm:block')} />
-
-        {/* Today's bot persona */}
-        {user && <PersonaBadge />}
 
         {/* Notifications */}
         {user && <NotificationBell />}

--- a/packages/frontend/src/components/persona-badge.tsx
+++ b/packages/frontend/src/components/persona-badge.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { motion } from 'framer-motion'
-import { Badge } from '@/components/ui/badge'
-import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
+import { Sparkles } from 'lucide-react'
 import { api } from '@/lib/api'
 
 interface PersonaData {
@@ -15,6 +14,14 @@ function colorIntToHex(color: number): string {
   return `#${color.toString(16).padStart(6, '0')}`
 }
 
+/**
+ * Daily persona greeting card.
+ *
+ * Displays the rotating Discord-bot persona of the day with its name and
+ * full intro message visible (no hover tooltip). Intended to live at the
+ * top of the groups list — a welcoming "your friend just said hi" moment
+ * on daily return to the app.
+ */
 export function PersonaBadge() {
   const { t } = useTranslation()
   const [persona, setPersona] = useState<PersonaData | null>(null)
@@ -27,29 +34,43 @@ export function PersonaBadge() {
 
   if (!persona) return null
 
+  const color = colorIntToHex(persona.embedColor)
+
   return (
-    <motion.div
-      initial={{ opacity: 0, scale: 0.9 }}
-      animate={{ opacity: 1, scale: 1 }}
-      transition={{ duration: 0.3 }}
+    <motion.section
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
+      aria-label={t('persona.today')}
+      className="relative overflow-hidden rounded-lg border border-white/[0.06] bg-card/40 p-4 mb-6"
+      style={{
+        backgroundImage: `linear-gradient(135deg, ${color}14 0%, transparent 60%)`,
+        borderLeft: `3px solid ${color}`,
+      }}
     >
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Badge variant="outline" className="gap-1.5 cursor-default text-xs">
-            <span
-              className="w-2.5 h-2.5 rounded-full shrink-0"
-              style={{ backgroundColor: colorIntToHex(persona.embedColor) }}
-            />
-            <span className="hidden sm:inline truncate max-w-[120px]">
+      <div className="flex items-start gap-3">
+        <div
+          className="flex items-center justify-center w-9 h-9 rounded-full shrink-0 mt-0.5"
+          style={{ backgroundColor: `${color}26`, color }}
+          aria-hidden="true"
+        >
+          <Sparkles className="w-4 h-4" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <span className="text-[11px] uppercase tracking-wider font-medium text-muted-foreground">
+              {t('persona.today')}
+            </span>
+            <span className="text-muted-foreground/30">·</span>
+            <span className="text-sm font-semibold truncate" style={{ color }}>
               {persona.name}
             </span>
-          </Badge>
-        </TooltipTrigger>
-        <TooltipContent side="bottom" className="max-w-[250px]">
-          <p className="font-medium text-xs">{t('persona.today')}</p>
-          <p className="text-xs text-muted-foreground mt-0.5">{persona.introMessage}</p>
-        </TooltipContent>
-      </Tooltip>
-    </motion.div>
+          </div>
+          <p className="text-sm text-foreground/80 leading-relaxed">
+            {persona.introMessage}
+          </p>
+        </div>
+      </div>
+    </motion.section>
   )
 }

--- a/packages/frontend/src/pages/GroupsPage.tsx
+++ b/packages/frontend/src/pages/GroupsPage.tsx
@@ -21,6 +21,7 @@ import {
 import { AppHeader } from '@/components/app-header'
 import { AppFooter } from '@/components/app-footer'
 import { InviteLink } from '@/components/invite-link'
+import { PersonaBadge } from '@/components/persona-badge'
 
 const fadeUp: Variants = {
   hidden: { opacity: 0, y: 16 },
@@ -184,6 +185,9 @@ export function GroupsPage() {
             </Button>
           </div>
         </div>
+
+        {/* Today's bot persona — greeting card */}
+        <PersonaBadge />
 
         {/* Search Groups */}
         {groups.length > 3 && (


### PR DESCRIPTION
## Summary

Multi-persona design review (Léo / Sarah / Priya / Tom / Yuki) concluded 4-to-1 that the daily Discord-bot persona doesn't belong in the header: it's flavor, not navigation, and the header pill was hiding its intro message behind a hover-only tooltip with mobile-only colored-dot state.

- Rewrites `PersonaBadge` as an accented greeting card — color-dynamic border/gradient derived from `embedColor`, persona name + **full intro message visible**, `motion.section` fadeUp entrance, `aria-label` for screen readers.
- Removes `PersonaBadge` from `AppHeader` (freeing a cramped top-right slot on mobile).
- Mounts the card on `GroupsPage` between the title/actions row and the list — the daily return moment where "your sarcastic friend just said hi" actually lands.

### A11y fixes

| Before (`persona-badge.tsx` @ `app-header.tsx:70`) | After |
|---|---|
| Intro message hover-only (keyboard/touch blind) | Intro in permanent text |
| `hidden sm:inline` name → mobile had only a colored dot | Name + intro always visible, `aria-label` set |
| Color-only differentiation (WCAG fail) | Color + text together |
| 4 hit-targets in header | Header back to 3 (logo, bell, avatar) |

### Meeting notes

| Persona | Top pick |
|---|---|
| Léo (UX/UI) | Greeting card on GroupsPage before the list |
| Tom (Community) | "Persona says" bubble — make the intro *audible* |
| Priya (A11y) | Dedicated block with always-visible intro |
| Sarah (Product) | GroupsPage entry moment (option #1) |
| Yuki (Frontend) | Dissent: keep in header + Zustand store |

Yuki's dissent only applies if the component needs to appear on multiple pages; here it lives in one place, so the existing lazy-fetch in the component suffices.

## Test plan

- [ ] Desktop: land on `/groups`, confirm persona card appears between title and list with colored accent border/gradient, name, and intro message
- [ ] Mobile (<640px): same card full-width, all text visible, no cramped header
- [ ] Header no longer shows the persona pill on any page
- [ ] Screen reader announces the `aria-label` ("Persona du jour") and reads name + intro message
- [ ] Card entrance uses Framer Motion fadeUp without jank on route entry
- [ ] Card gracefully hidden when `api.getCurrentPersona()` fails (existing `.catch(() => {})`)

https://claude.ai/code/session_01UVpdNvMKp4zSRABUmGAFxs