### PR TITLE
fix(discord): resolve group for /wawptn-games when channel is not linked

### DIFF
--- a/packages/backend/src/presentation/routes/discord.routes.ts
+++ b/packages/backend/src/presentation/routes/discord.routes.ts
@@ -207,19 +207,46 @@ router.post('/vote', async (req: Request, res: Response) => {
   res.json({ ok: true })
 })
 
-// Get common games for a channel-linked group
+// Get common games — resolved either by a channel link or an explicit groupId
 router.get('/games', async (req: Request, res: Response) => {
-  const channelId = req.query['channelId'] as string
+  const channelId = req.query['channelId'] as string | undefined
+  const groupId = req.query['groupId'] as string | undefined
 
-  if (!channelId) {
-    res.status(400).json({ error: 'validation', message: 'channelId query parameter required' })
+  if (!channelId && !groupId) {
+    res.status(400).json({ error: 'validation', message: 'channelId or groupId query parameter required' })
     return
   }
 
-  const group = await db('groups').where({ discord_channel_id: channelId }).first()
-  if (!group) {
-    res.status(404).json({ error: 'not_found', message: 'Aucun groupe lié à ce canal Discord' })
-    return
+  let group
+  if (groupId) {
+    // When querying by groupId, the caller must be a linked Discord user
+    // and a member of the group.
+    const userId = req.userId
+    if (!userId) {
+      res.status(403).json({ error: 'forbidden', message: 'Discord account not linked. Use /wawptn-link first.' })
+      return
+    }
+
+    const membership = await db('group_members')
+      .where({ group_id: groupId, user_id: userId })
+      .first()
+
+    if (!membership) {
+      res.status(403).json({ error: 'forbidden', message: 'Vous n\'êtes pas membre de ce groupe' })
+      return
+    }
+
+    group = await db('groups').where({ id: groupId }).first()
+    if (!group) {
+      res.status(404).json({ error: 'not_found', message: 'Group not found' })
+      return
+    }
+  } else {
+    group = await db('groups').where({ discord_channel_id: channelId }).first()
+    if (!group) {
+      res.status(404).json({ error: 'not_found', message: 'Aucun groupe lié à ce canal Discord' })
+      return
+    }
   }
 
   const memberIds = await db('group_members').where({ group_id: group.id }).pluck('user_id')

--- a/packages/discord/src/commands/games.ts
+++ b/packages/discord/src/commands/games.ts
@@ -1,5 +1,6 @@
 import { SlashCommandBuilder, type ChatInputCommandInteraction, EmbedBuilder } from 'discord.js'
 import { backendApi } from '../lib/api.js'
+import { resolveGroup } from '../lib/resolve-group.js'
 
 interface CommonGamesResponse {
   groupName: string
@@ -13,18 +14,25 @@ interface CommonGamesResponse {
 
 export const data = new SlashCommandBuilder()
   .setName('wawptn-games')
-  .setDescription('Afficher les jeux en commun du groupe lié à ce canal')
+  .setDescription('Afficher les jeux en commun du groupe')
 
 export async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
-  const channelId = interaction.channelId
+  await interaction.deferReply({ ephemeral: true })
 
-  await interaction.deferReply()
+  const group = await resolveGroup(interaction)
+  if (!group) return
 
   try {
-    const result = await backendApi<CommonGamesResponse>(`/api/discord/games?channelId=${channelId}`)
+    const result = await backendApi<CommonGamesResponse>(
+      `/api/discord/games?groupId=${group.groupId}`,
+      { discordUserId: interaction.user.id },
+    )
 
     if (result.games.length === 0) {
-      await interaction.editReply({ content: '😕 Aucun jeu en commun trouvé pour ce groupe.' })
+      await interaction.editReply({
+        content: `😕 Aucun jeu en commun trouvé pour **${group.groupName}**.`,
+        components: [],
+      })
       return
     }
 
@@ -39,10 +47,19 @@ export async function execute(interaction: ChatInputCommandInteraction): Promise
       .setColor(0x5865F2)
       .setFooter({ text: `${result.games.length} jeux en commun au total` })
 
-    await interaction.editReply({ embeds: [embed] })
+    // Post the game list publicly in the channel.
+    if (interaction.channel && 'send' in interaction.channel) {
+      await interaction.channel.send({ embeds: [embed] })
+    }
+
+    await interaction.editReply({
+      content: `✅ Jeux en commun affichés pour **${group.groupName}**.`,
+      components: [],
+    })
   } catch (error) {
     await interaction.editReply({
       content: `❌ Erreur : ${error instanceof Error ? error.message : 'Impossible de récupérer les jeux'}`,
+      components: [],
     })
   }
 }


### PR DESCRIPTION
The /wawptn-games command previously required the channel to be linked
to a group via /wawptn-setup and errored with "Aucun groupe lié à ce canal
Discord" otherwise. Align it with /wawptn-vote and /wawptn-random by
using the resolveGroup helper, which falls back to a group-selection
menu when the channel has no link. The backend /games endpoint now
accepts an optional groupId query (with membership verification) in
addition to the existing channelId lookup.