### PR TITLE
feat(discord): bidirectional interactive voting with live counts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,12 @@ STEAM_API_KEY=your-steam-web-api-key
 # DISCORD_BOT_TOKEN=
 # DISCORD_APPLICATION_ID=
 # BACKEND_URL=http://localhost:3000
+# URL the backend uses to reach the bot's internal HTTP API (backend → bot).
+# Set this to enable bot-backed interactive vote messages with live counts.
+# DISCORD_BOT_HTTP_URL=http://localhost:3001
+# Port/host the bot listens on for the internal HTTP API (bot side).
+# DISCORD_BOT_HTTP_PORT=3001
+# DISCORD_BOT_HTTP_HOST=127.0.0.1
 
 # ── LLM (optional) ───────────────────────────
 # Enables Discord bot conversational mode (OpenAI-compatible API)

--- a/packages/backend/migrations/20260414_add_discord_message_to_voting_sessions.ts
+++ b/packages/backend/migrations/20260414_add_discord_message_to_voting_sessions.ts
@@ -1,0 +1,28 @@
+import type { Knex } from 'knex'
+
+/**
+ * Adds the columns needed for bidirectional Discord voting.
+ *
+ * - `discord_message_id`: the snowflake of the interactive message the bot
+ *   posted when the session opened. Required so the backend can ask the bot
+ *   to later edit the same message (live vote counts, winner reveal) and to
+ *   disable its vote buttons on close.
+ * - `discord_channel_id`: snapshot of the channel the bot posted to. Cached
+ *   on the session row so that we don't have to re-resolve the group's
+ *   `discord_channel_id` on every live update — the group's linked channel
+ *   may legitimately change mid-session without invalidating in-flight
+ *   messages.
+ */
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('voting_sessions', (table) => {
+    table.string('discord_message_id').nullable()
+    table.string('discord_channel_id').nullable()
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('voting_sessions', (table) => {
+    table.dropColumn('discord_message_id')
+    table.dropColumn('discord_channel_id')
+  })
+}

--- a/packages/backend/src/config/env.ts
+++ b/packages/backend/src/config/env.ts
@@ -30,6 +30,11 @@ export const env = {
 
   // Discord Bot (optional — feature-flagged)
   DISCORD_BOT_API_SECRET: process.env['DISCORD_BOT_API_SECRET'] || '',
+  /** URL of the Discord bot's internal HTTP API. When the bot is colocated
+   *  with the backend this is loopback; in a split deployment it points at
+   *  the bot's private address. Empty string disables bot-backed Discord
+   *  posting (and the backend silently falls back to webhook-only mode). */
+  DISCORD_BOT_HTTP_URL: process.env['DISCORD_BOT_HTTP_URL'] || '',
 
   // LLM (optional — enables Discord bot conversational mode, OpenAI-compatible API)
   LLM_API_KEY: process.env['LLM_API_KEY'] || '',

--- a/packages/backend/src/domain/events/event-bus.ts
+++ b/packages/backend/src/domain/events/event-bus.ts
@@ -17,6 +17,20 @@ export interface SessionClosedEvent {
   participantIds: string[]
 }
 
+/**
+ * Emitted after a vote has been persisted (from either the web UI or the
+ * Discord bot), so subscribers can push a debounced live update out to
+ * whichever channels are listening. Does NOT replace the existing
+ * Socket.io `vote:cast` emission — it's strictly for domain-level
+ * side effects like the Discord live-count updater.
+ */
+export interface VoteCastEvent {
+  sessionId: string
+  groupId: string
+  userId: string
+  source: 'web' | 'discord'
+}
+
 export interface ChallengeUnlockedEvent {
   userId: string
   challengeId: string
@@ -28,6 +42,7 @@ export interface ChallengeUnlockedEvent {
 export interface DomainEventMap {
   'session:created': [SessionCreatedEvent]
   'session:closed': [SessionClosedEvent]
+  'vote:cast': [VoteCastEvent]
   'challenge:unlocked': [ChallengeUnlockedEvent]
 }
 

--- a/packages/backend/src/infrastructure/discord/bot-client.ts
+++ b/packages/backend/src/infrastructure/discord/bot-client.ts
@@ -1,0 +1,122 @@
+import type {
+  DiscordSessionClosedRequest,
+  DiscordSessionCreatedRequest,
+  DiscordSessionCreatedResponse,
+  DiscordSessionUpdateRequest,
+} from '@wawptn/types'
+import { env } from '../../config/env.js'
+import { logger } from '../logger/logger.js'
+
+/**
+ * HTTP client that talks to the Discord bot's internal API.
+ *
+ * This module is a thin transport — it does NO business logic, NO debouncing,
+ * NO persistence. It is the only place in the backend that knows how the
+ * backend ↔ bot wire protocol is shaped, so higher layers (notifier,
+ * live-vote-updater) can be swapped or tested without touching the network.
+ *
+ * The whole module short-circuits to "disabled" when either the URL or the
+ * shared secret are missing. Callers don't need to check — they can always
+ * call these functions and expect a safe no-op in dev.
+ */
+
+const REQUEST_TIMEOUT_MS = 5_000
+
+export function isBotClientEnabled(): boolean {
+  return !!env.DISCORD_BOT_HTTP_URL && !!env.DISCORD_BOT_API_SECRET
+}
+
+interface FetchOptions {
+  body: unknown
+  signal?: AbortSignal
+}
+
+async function postJson<T>(path: string, options: FetchOptions): Promise<T> {
+  const url = `${env.DISCORD_BOT_HTTP_URL}${path}`
+
+  // Per-call abort so a hung bot can never stall a vote write. If the caller
+  // passed in their own signal we chain the two so both fire.
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+  const onExternalAbort = () => controller.abort()
+  options.signal?.addEventListener('abort', onExternalAbort, { once: true })
+
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bot ${env.DISCORD_BOT_API_SECRET}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(options.body),
+      signal: controller.signal,
+    })
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => '')
+      throw new Error(`bot API ${path} returned ${res.status}: ${text.slice(0, 200)}`)
+    }
+
+    return (await res.json()) as T
+  } finally {
+    clearTimeout(timer)
+    options.signal?.removeEventListener('abort', onExternalAbort)
+  }
+}
+
+/**
+ * Ask the bot to post a new interactive voting message. Returns the message
+ * snowflake so the caller can persist it on the voting_session row for
+ * later edits. Returns `null` when the client is disabled or the call
+ * fails — a Discord post must never be load-bearing for session creation.
+ */
+export async function postSessionCreated(
+  payload: DiscordSessionCreatedRequest,
+): Promise<DiscordSessionCreatedResponse | null> {
+  if (!isBotClientEnabled()) return null
+  try {
+    return await postJson<DiscordSessionCreatedResponse>('/internal/session/created', {
+      body: payload,
+    })
+  } catch (err) {
+    logger.warn(
+      { error: String(err), sessionId: payload.sessionId, channelId: payload.channelId },
+      'bot-client: session/created failed',
+    )
+    return null
+  }
+}
+
+/**
+ * Ask the bot to edit an existing voting message with the current live
+ * counts. Errors are logged but never thrown — live updates are best-effort,
+ * the canonical tally lives in Postgres.
+ */
+export async function postSessionUpdate(payload: DiscordSessionUpdateRequest): Promise<void> {
+  if (!isBotClientEnabled()) return
+  try {
+    await postJson('/internal/session/updated', { body: payload })
+  } catch (err) {
+    logger.warn(
+      { error: String(err), sessionId: payload.sessionId, messageId: payload.messageId },
+      'bot-client: session/updated failed',
+    )
+  }
+}
+
+/**
+ * Ask the bot to edit the message into its closed state (winner reveal +
+ * disabled buttons). Also best-effort: a failure here does not block the
+ * session close.
+ */
+export async function postSessionClosed(payload: DiscordSessionClosedRequest): Promise<void> {
+  if (!isBotClientEnabled()) return
+  try {
+    await postJson('/internal/session/closed', { body: payload })
+  } catch (err) {
+    logger.warn(
+      { error: String(err), sessionId: payload.sessionId, messageId: payload.messageId },
+      'bot-client: session/closed failed',
+    )
+  }
+}

--- a/packages/backend/src/infrastructure/discord/live-vote-updater.ts
+++ b/packages/backend/src/infrastructure/discord/live-vote-updater.ts
@@ -1,0 +1,112 @@
+import { db } from '../database/connection.js'
+import { logger } from '../logger/logger.js'
+import { postSessionUpdate, isBotClientEnabled } from './bot-client.js'
+import { buildVoteSummary } from './vote-summary.js'
+
+/**
+ * Debounced live-vote updater.
+ *
+ * Discord's per-message edit rate limit is ~5 edits / 5 s on the same
+ * message bucket. To stay under that comfortably without dropping votes,
+ * we coalesce every incoming "vote was cast" notification for the same
+ * session into a trailing debounce that reads the *current* DB state and
+ * pushes it once per window.
+ *
+ * Two important properties:
+ *
+ *  1. We always read the latest snapshot from Postgres at flush time, so
+ *     web-cast votes and Discord-cast votes end up in the same payload —
+ *     no need for the two flows to agree on an incremental shape.
+ *  2. A flush failure is logged and retried on the *next* scheduled flush
+ *     (driven by the next vote), never a fire-and-forget retry loop,
+ *     because the state is canonical in the DB — a missed edit is
+ *     self-healing.
+ */
+
+const DEBOUNCE_MS = 1_500
+
+interface Pending {
+  timer: NodeJS.Timeout
+  /** Wall-clock ms when we last started a flush, so trailing-edge
+   *  schedules never collapse into rapid-fire edits. */
+  lastFlushedAt: number
+}
+
+const pending = new Map<string, Pending>()
+
+/**
+ * Schedule a trailing-edge update for a session. Safe to call from any code
+ * path that persists a vote; the debouncer coalesces them for you.
+ */
+export function scheduleVoteUpdate(sessionId: string): void {
+  if (!isBotClientEnabled()) return
+
+  const existing = pending.get(sessionId)
+  if (existing) {
+    clearTimeout(existing.timer)
+  }
+
+  const timer = setTimeout(() => {
+    pending.delete(sessionId)
+    flush(sessionId).catch((err) =>
+      logger.warn({ error: String(err), sessionId }, 'live-vote-updater: flush failed'),
+    )
+  }, DEBOUNCE_MS)
+
+  // Detach the timer so it never keeps the process alive on shutdown.
+  timer.unref?.()
+
+  pending.set(sessionId, { timer, lastFlushedAt: existing?.lastFlushedAt ?? 0 })
+}
+
+async function flush(sessionId: string): Promise<void> {
+  const session = await db('voting_sessions').where({ id: sessionId }).first()
+  if (!session) return
+
+  // Nothing to update if the session never got a Discord message (e.g. the
+  // group isn't linked to a channel, or the initial post failed).
+  if (!session.discord_message_id || !session.discord_channel_id) return
+
+  // Stop updating closed sessions — the close handler already pushed the
+  // final state, and further edits would just overwrite the winner embed.
+  if (session.status !== 'open') return
+
+  const group = await db('groups').where({ id: session.group_id }).first()
+  if (!group) return
+
+  const creator = await db('users').where({ id: session.created_by }).first()
+  const summary = await buildVoteSummary(sessionId)
+
+  // Re-materialize the game list in the order the session stored them.
+  // We send the full list (not just tallies) because the embed shows game
+  // names even for zero-vote games.
+  const games = summary.tallies.map((t) => ({
+    steamAppId: t.steamAppId,
+    gameName: t.gameName,
+    headerImageUrl: t.headerImageUrl,
+  }))
+
+  await postSessionUpdate({
+    sessionId,
+    groupName: group.name,
+    channelId: session.discord_channel_id,
+    messageId: session.discord_message_id,
+    creatorName: creator?.display_name ?? 'Un membre',
+    games,
+    summary,
+  })
+}
+
+/**
+ * Force-flush all pending updates (used by the close-session path so the
+ * last in-flight debounce doesn't race with the final close edit).
+ */
+export async function flushPending(sessionId: string): Promise<void> {
+  const existing = pending.get(sessionId)
+  if (!existing) return
+  clearTimeout(existing.timer)
+  pending.delete(sessionId)
+  await flush(sessionId).catch((err) =>
+    logger.warn({ error: String(err), sessionId }, 'live-vote-updater: forced flush failed'),
+  )
+}

--- a/packages/backend/src/infrastructure/discord/notifier.ts
+++ b/packages/backend/src/infrastructure/discord/notifier.ts
@@ -1,6 +1,28 @@
 import { db } from '../database/connection.js'
 import { logger } from '../logger/logger.js'
 import type { VoteResult } from '@wawptn/types'
+import { postSessionClosed, postSessionCreated, isBotClientEnabled } from './bot-client.js'
+import { buildVoteSummary } from './vote-summary.js'
+import { flushPending } from './live-vote-updater.js'
+
+/**
+ * High-level Discord notifications for voting sessions.
+ *
+ * This module is the session-effects facade into Discord: all
+ * `session:created` / `session:closed` side effects flow through here.
+ * Two transports are layered:
+ *
+ *  1. **Bot-backed interactive messages** (primary channel). Uses the
+ *     Discord.js bot via the internal HTTP API so we can send, edit, and
+ *     close messages with interactive buttons. Required for Discord-side
+ *     voting.
+ *  2. **Announcement webhooks** (broadcast channels). Legacy plain-text
+ *     embeds pushed to every `group_announcement_webhooks` row so votes
+ *     announce into #general etc. No buttons — webhooks can't carry them.
+ *
+ * Both transports are best-effort: a Discord failure never blocks the
+ * canonical vote record in Postgres.
+ */
 
 interface WebhookEmbed {
   title: string
@@ -41,7 +63,7 @@ export async function notifySessionCreated(
   games: SessionGame[],
 ): Promise<void> {
   const group = await db('groups').where({ id: groupId }).first()
-  if (!group?.discord_webhook_url) return
+  if (!group) return
 
   const creator = await db('voting_sessions')
     .join('users', 'voting_sessions.created_by', 'users.id')
@@ -49,40 +71,110 @@ export async function notifySessionCreated(
     .select('users.display_name')
     .first()
 
-  const gameList = games
-    .slice(0, 25)
-    .map((g, i) => `**${i + 1}.** ${g.gameName}`)
-    .join('\n')
+  const creatorName = creator?.display_name || 'Un membre'
 
-  await postWebhook(group.discord_webhook_url, {
-    embeds: [{
-      title: '🎮 Nouvelle session de vote !',
-      description: `**${creator?.display_name || 'Un membre'}** a lancé un vote dans **${group.name}**.\n\n${gameList}\n\nVotez sur le site ou utilisez les boutons Discord !`,
-      color: 0x5865F2,
-      timestamp: new Date().toISOString(),
-      thumbnail: games[0]?.headerImageUrl ? { url: games[0].headerImageUrl } : undefined,
-    }],
-  })
+  // ── Primary: bot-backed interactive message ─────────────────────────
+  // Requires a linked channel AND the bot HTTP URL configured. When
+  // either is missing we silently fall back to webhook-only mode.
+  if (group.discord_channel_id && isBotClientEnabled()) {
+    const summary = await buildVoteSummary(sessionId)
+    const response = await postSessionCreated({
+      sessionId,
+      groupId,
+      groupName: group.name,
+      channelId: group.discord_channel_id,
+      creatorName,
+      games: games.map((g) => ({
+        steamAppId: g.steamAppId,
+        gameName: g.gameName,
+        headerImageUrl: g.headerImageUrl,
+      })),
+      summary,
+    })
+
+    if (response?.messageId) {
+      // Persist the returned message ID so later edits (live vote counts,
+      // close reveal) can target the same message. Also cache the channel
+      // ID on the session so a later re-link of the group's channel
+      // doesn't orphan in-flight messages.
+      await db('voting_sessions').where({ id: sessionId }).update({
+        discord_message_id: response.messageId,
+        discord_channel_id: group.discord_channel_id,
+      })
+      logger.info(
+        { sessionId, groupId, messageId: response.messageId, channelId: group.discord_channel_id },
+        'Discord session message posted',
+      )
+    }
+  }
+
+  // ── Fallback: legacy primary webhook ────────────────────────────────
+  // Only used when there is NO linked bot channel. Kept so groups that
+  // configured a webhook URL pre-bot continue to receive notifications.
+  if (!group.discord_channel_id && group.discord_webhook_url) {
+    const gameList = games
+      .slice(0, 25)
+      .map((g, i) => `**${i + 1}.** ${g.gameName}`)
+      .join('\n')
+
+    await postWebhook(group.discord_webhook_url, {
+      embeds: [{
+        title: '🎮 Nouvelle session de vote !',
+        description: `**${creatorName}** a lancé un vote dans **${group.name}**.\n\n${gameList}\n\nVotez sur le site !`,
+        color: 0x5865F2,
+        timestamp: new Date().toISOString(),
+        thumbnail: games[0]?.headerImageUrl ? { url: games[0].headerImageUrl } : undefined,
+      }],
+    })
+  }
 }
 
 export async function notifyVoteClosed(
   groupId: string,
+  sessionId: string,
   result: VoteResult,
 ): Promise<void> {
   const group = await db('groups').where({ id: groupId }).first()
   if (!group) return
 
-  // Extra announcement webhooks registered via POST /api/discord/announcements.
-  // Broadcast the result to every webhook attached to the group so friends
-  // in #general or #announcements see the winner without having to join the
-  // primary group channel. Primary webhook (if set) is broadcast to first
-  // so it keeps its ordering.
+  // ── Primary: edit the bot's interactive message into closed state ───
+  if (isBotClientEnabled()) {
+    // Make sure any in-flight debounced live update lands BEFORE we push
+    // the closed-state edit, so we don't race and overwrite the winner.
+    await flushPending(sessionId)
+
+    const session = await db('voting_sessions').where({ id: sessionId }).first()
+    if (session?.discord_message_id && session.discord_channel_id) {
+      const summary = await buildVoteSummary(sessionId)
+      await postSessionClosed({
+        sessionId,
+        groupName: group.name,
+        channelId: session.discord_channel_id,
+        messageId: session.discord_message_id,
+        result,
+        summary,
+      })
+    }
+  }
+
+  // ── Extra announcement webhooks broadcast ───────────────────────────
+  // Separate list managed via POST /api/discord/announcements. Used to
+  // fan out the winner to #general/#announcements channels beyond the
+  // primary. Webhooks cannot carry interactive buttons, so these are
+  // always plain embeds.
   const extraWebhooks: { webhook_url: string }[] = await db('group_announcement_webhooks')
     .where({ group_id: groupId })
     .select('webhook_url')
 
+  // When the group has no linked channel we also want the legacy
+  // primary webhook (if set) to receive the result — otherwise it is
+  // skipped because the bot already posted a closed state above.
+  const primaryFallback = !group.discord_channel_id && group.discord_webhook_url
+    ? [group.discord_webhook_url]
+    : []
+
   const targets = [
-    ...(group.discord_webhook_url ? [group.discord_webhook_url] : []),
+    ...primaryFallback,
     ...extraWebhooks.map((row) => row.webhook_url),
   ]
 

--- a/packages/backend/src/infrastructure/discord/vote-summary.ts
+++ b/packages/backend/src/infrastructure/discord/vote-summary.ts
@@ -1,0 +1,73 @@
+import type { DiscordVoteSummary, DiscordVoteTally } from '@wawptn/types'
+import { db } from '../database/connection.js'
+
+/**
+ * Build the `DiscordVoteSummary` the bot needs to render a live-count or
+ * closed embed for a voting session.
+ *
+ * Kept as a single query per concern (games / tallies / voter count) instead
+ * of one grand join so each read stays cheap enough to run on every vote
+ * edit without needing a query planner deep-dive. The debouncer upstream
+ * rate-limits how often this runs anyway.
+ */
+export async function buildVoteSummary(sessionId: string): Promise<DiscordVoteSummary> {
+  const games = await db('voting_session_games')
+    .where({ session_id: sessionId })
+    .orderBy('steam_app_id', 'asc')
+    .select(
+      'steam_app_id as steamAppId',
+      'game_name as gameName',
+      'header_image_url as headerImageUrl',
+    )
+
+  const tallyRows: Array<{ steam_app_id: number; vote: boolean; count: string }> = await db('votes')
+    .where({ session_id: sessionId })
+    .groupBy('steam_app_id', 'vote')
+    .select('steam_app_id', 'vote', db.raw('COUNT(*) as count'))
+
+  const tallyMap = new Map<number, { yes: number; no: number }>()
+  for (const row of tallyRows) {
+    const entry = tallyMap.get(row.steam_app_id) ?? { yes: 0, no: 0 }
+    if (row.vote) entry.yes = Number(row.count)
+    else entry.no = Number(row.count)
+    tallyMap.set(row.steam_app_id, entry)
+  }
+
+  const tallies: DiscordVoteTally[] = games.map((g) => ({
+    steamAppId: g.steamAppId,
+    gameName: g.gameName,
+    headerImageUrl: g.headerImageUrl,
+    yesCount: tallyMap.get(g.steamAppId)?.yes ?? 0,
+    noCount: tallyMap.get(g.steamAppId)?.no ?? 0,
+  }))
+
+  const voterCountRow = await db('votes')
+    .where({ session_id: sessionId })
+    .countDistinct('user_id as count')
+    .first()
+
+  // Prefer the participant snapshot over the current group roster so the
+  // denominator can't drift if membership changes mid-session.
+  const participantCountRow = await db('voting_session_participants')
+    .where({ session_id: sessionId })
+    .count('* as count')
+    .first()
+
+  const voterCount = Number(voterCountRow?.count ?? 0)
+  let totalParticipants = Number(participantCountRow?.count ?? 0)
+
+  if (totalParticipants === 0) {
+    // Legacy sessions (pre-participants-table) — fall back to the group's
+    // current member count so the UI still shows a plausible denominator.
+    const session = await db('voting_sessions').where({ id: sessionId }).first()
+    if (session) {
+      const mCount = await db('group_members')
+        .where({ group_id: session.group_id })
+        .count('* as count')
+        .first()
+      totalParticipants = Number(mCount?.count ?? 0)
+    }
+  }
+
+  return { voterCount, totalParticipants, tallies }
+}

--- a/packages/backend/src/infrastructure/effects/session-effects.ts
+++ b/packages/backend/src/infrastructure/effects/session-effects.ts
@@ -4,6 +4,7 @@
 import { domainEvents } from '../../domain/events/event-bus.js'
 import { getIO } from '../socket/socket.js'
 import { notifySessionCreated, notifyVoteClosed } from '../discord/notifier.js'
+import { scheduleVoteUpdate } from '../discord/live-vote-updater.js'
 import { createNotification } from '../notifications/notification-service.js'
 import { logger } from '../logger/logger.js'
 import { db } from '../database/connection.js'
@@ -23,7 +24,7 @@ export function registerSessionEffects(): void {
       logger.warn({ error: String(err), groupId: event.groupId }, 'socket emit session:created failed')
     }
 
-    // Send Discord webhook (non-blocking)
+    // Send Discord notification (bot-backed or webhook fallback). Non-blocking.
     notifySessionCreated(event.groupId, event.sessionId, event.games).catch((err) =>
       logger.warn({ error: String(err), groupId: event.groupId }, 'Discord session notification failed')
     )
@@ -52,6 +53,17 @@ export function registerSessionEffects(): void {
     }
   })
 
+  // Vote cast — drives the debounced Discord live-count updater. Both web
+  // and Discord vote paths emit this event, so any vote from any source
+  // keeps the Discord message in sync with the canonical DB tally.
+  domainEvents.on('vote:cast', (event) => {
+    try {
+      scheduleVoteUpdate(event.sessionId)
+    } catch (err) {
+      logger.warn({ error: String(err), sessionId: event.sessionId }, 'vote:cast live-update schedule failed')
+    }
+  })
+
   domainEvents.on('session:closed', async (event) => {
     // Emit Socket.io event
     try {
@@ -60,8 +72,8 @@ export function registerSessionEffects(): void {
       logger.warn({ error: String(err), groupId: event.groupId }, 'socket emit vote:closed failed')
     }
 
-    // Discord webhook
-    notifyVoteClosed(event.groupId, event.result).catch((err) =>
+    // Discord notification (bot-backed close edit + announcement webhooks)
+    notifyVoteClosed(event.groupId, event.sessionId, event.result).catch((err) =>
       logger.warn({ error: String(err), groupId: event.groupId }, 'Discord notification failed')
     )
 

--- a/packages/backend/src/presentation/routes/auth.routes.ts
+++ b/packages/backend/src/presentation/routes/auth.routes.ts
@@ -364,6 +364,13 @@ router.get('/profile', requireAuth, async (req: Request, res: Response) => {
       .limit(5)
       .select('game_name as gameName', 'steam_app_id as steamAppId', 'header_image_url as headerImageUrl', 'playtime_forever as playtimeForever')
 
+    // Include Discord link status so the profile UI can render a "Link
+    // your Discord" section without a second round-trip.
+    const discordLink = await db('discord_links')
+      .where({ user_id: userId })
+      .select('discord_id', 'discord_username', 'linked_at')
+      .first()
+
     res.json({
       id: user.id,
       steamId: user.steam_id,
@@ -379,6 +386,14 @@ router.get('/profile', requireAuth, async (req: Request, res: Response) => {
         headerImageUrl: g.headerImageUrl,
         playtimeForever: Number(g.playtimeForever),
       })),
+      discord: discordLink
+        ? {
+          linked: true as const,
+          discordId: discordLink.discord_id,
+          discordUsername: discordLink.discord_username,
+          linkedAt: discordLink.linked_at,
+        }
+        : { linked: false as const },
     })
   } catch (error) {
     authLogger.error({ error: String(error) }, 'get profile failed')

--- a/packages/backend/src/presentation/routes/discord.routes.ts
+++ b/packages/backend/src/presentation/routes/discord.routes.ts
@@ -8,6 +8,7 @@ import { env } from '../../config/env.js'
 import { requireAuth } from '../middleware/auth.middleware.js'
 import { isUserPremium } from '../middleware/tier.middleware.js'
 import { createVotingSession } from '../../domain/create-session.js'
+import { domainEvents } from '../../domain/events/event-bus.js'
 import { isLLMEnabled, generateChatResponse, type ChatContext } from '../../infrastructure/llm/client.js'
 
 /** Check if a group's owner has premium. Returns false if no owner found. */
@@ -202,6 +203,16 @@ router.post('/vote', async (req: Request, res: Response) => {
     userId,
     voterCount: Number(voterCount?.count || 0),
     totalParticipants,
+  })
+
+  // Emit a domain event so the Discord live-count updater re-renders the
+  // interactive message with fresh tallies. `source: 'discord'` helps
+  // downstream logging tell web-cast and bot-cast votes apart.
+  domainEvents.emit('vote:cast', {
+    sessionId,
+    groupId: session.group_id,
+    userId,
+    source: 'discord',
   })
 
   res.json({ ok: true })
@@ -995,6 +1006,16 @@ userRouter.post('/link/confirm', requireAuth, async (req: Request, res: Response
   logger.info({ userId, discordId: linkCode.discord_id }, 'Discord account linked')
 
   res.json({ ok: true, discordUsername: linkCode.discord_username })
+})
+
+// Unlink Discord: Remove the linked Discord account for the current user.
+// Safe to call even if the user isn't linked (idempotent) so the frontend
+// doesn't have to special-case the empty state.
+userRouter.delete('/link', requireAuth, async (req: Request, res: Response) => {
+  const userId = req.userId!
+  const deleted = await db('discord_links').where({ user_id: userId }).del()
+  logger.info({ userId, deleted }, 'Discord account unlinked')
+  res.json({ ok: true, wasLinked: deleted > 0 })
 })
 
 // Set webhook URL for a group (group owner only)

--- a/packages/backend/src/presentation/routes/vote.routes.ts
+++ b/packages/backend/src/presentation/routes/vote.routes.ts
@@ -5,6 +5,7 @@ import { closeSession } from '../../domain/close-session.js'
 import { createVotingSession } from '../../domain/create-session.js'
 import { isUserPremium } from '../middleware/tier.middleware.js'
 import { evaluateChallenges } from '../../domain/challenges/challenge-service.js'
+import { domainEvents } from '../../domain/events/event-bus.js'
 import { logger } from '../../infrastructure/logger/logger.js'
 
 const router = Router()
@@ -329,6 +330,10 @@ router.post('/:groupId/vote/:sessionId', async (req: Request, res: Response) => 
     voterCount: Number(voterCount?.count || 0),
     totalParticipants,
   })
+
+  // Emit a domain event so downstream side effects (Discord live-count
+  // updater, etc.) react without the route having to know about them.
+  domainEvents.emit('vote:cast', { sessionId, groupId, userId, source: 'web' })
 
   // Evaluate participation challenges (non-blocking)
   evaluateChallenges(userId, ['participation']).catch(err =>

--- a/packages/discord/src/env.ts
+++ b/packages/discord/src/env.ts
@@ -7,6 +7,11 @@ export const env = {
   DISCORD_APPLICATION_ID: process.env['DISCORD_APPLICATION_ID'] || '',
   DISCORD_BOT_API_SECRET: process.env['DISCORD_BOT_API_SECRET'] || '',
   BACKEND_URL: process.env['BACKEND_URL'] || 'http://localhost:3000',
+  /** Port the bot exposes its internal HTTP API on for backend → bot calls. */
+  BOT_HTTP_PORT: parseInt(process.env['DISCORD_BOT_HTTP_PORT'] || '3001', 10),
+  /** Bind address for the internal HTTP API. Default is loopback so that the
+   *  API is not exposed outside the local network unless explicitly opted in. */
+  BOT_HTTP_HOST: process.env['DISCORD_BOT_HTTP_HOST'] || '127.0.0.1',
 }
 
 export function validateEnv(): void {

--- a/packages/discord/src/http/auth.ts
+++ b/packages/discord/src/http/auth.ts
@@ -1,0 +1,19 @@
+import crypto from 'node:crypto'
+import { env } from '../env.js'
+
+/**
+ * Constant-time comparison of the backend → bot shared secret. Symmetric
+ * with the equivalent check on the backend (`requireBotAuth` middleware),
+ * so both directions use the same `Authorization: Bot <secret>` format.
+ */
+export function isAuthorized(authHeader: string | undefined): boolean {
+  if (!authHeader?.startsWith('Bot ')) return false
+  const provided = authHeader.slice(4)
+  const expected = env.DISCORD_BOT_API_SECRET
+  if (!expected) return false
+
+  const a = Buffer.from(provided)
+  const b = Buffer.from(expected)
+  if (a.length !== b.length) return false
+  return crypto.timingSafeEqual(a, b)
+}

--- a/packages/discord/src/http/handlers.ts
+++ b/packages/discord/src/http/handlers.ts
@@ -1,0 +1,128 @@
+import type { Client, TextBasedChannel } from 'discord.js'
+import type {
+  DiscordSessionClosedRequest,
+  DiscordSessionCreatedRequest,
+  DiscordSessionCreatedResponse,
+  DiscordSessionUpdateRequest,
+} from '@wawptn/types'
+import { buildSessionClosedEmbed, buildSessionEmbed } from '../lib/embeds.js'
+
+/**
+ * Handlers live here (separated from the transport layer in server.ts) so
+ * they can be unit-tested with a fake Client later without any HTTP noise.
+ * Each handler receives an already-parsed, already-authenticated payload.
+ */
+
+export class BotHandlerError extends Error {
+  constructor(public statusCode: number, message: string) {
+    super(message)
+  }
+}
+
+async function resolveSendableChannel(client: Client, channelId: string): Promise<TextBasedChannel> {
+  const channel = await client.channels.fetch(channelId).catch(() => null)
+  if (!channel) {
+    throw new BotHandlerError(404, `Channel ${channelId} not found`)
+  }
+  if (!channel.isTextBased() || !('send' in channel)) {
+    throw new BotHandlerError(400, `Channel ${channelId} is not a sendable text channel`)
+  }
+  return channel as TextBasedChannel
+}
+
+export async function handleSessionCreated(
+  client: Client,
+  body: DiscordSessionCreatedRequest,
+): Promise<DiscordSessionCreatedResponse> {
+  const { channelId, sessionId, groupName, creatorName, games, summary } = body
+
+  if (!channelId || !sessionId || !groupName || !Array.isArray(games)) {
+    throw new BotHandlerError(400, 'Missing required fields')
+  }
+
+  const channel = await resolveSendableChannel(client, channelId)
+  const { embeds, components } = buildSessionEmbed({
+    groupName,
+    creatorName,
+    sessionId,
+    games,
+    summary,
+  })
+
+  // `send` exists on guild text/announcement/thread/DM channels — the
+  // resolveSendableChannel guard above narrows down to those.
+  const sent = await (channel as unknown as { send: (payload: unknown) => Promise<{ id: string }> })
+    .send({ embeds, components })
+
+  return { messageId: sent.id }
+}
+
+export async function handleSessionUpdate(
+  client: Client,
+  body: DiscordSessionUpdateRequest,
+): Promise<{ ok: true }> {
+  const { channelId, messageId, sessionId, groupName, creatorName, games, summary } = body
+
+  if (!channelId || !messageId || !sessionId) {
+    throw new BotHandlerError(400, 'Missing required fields')
+  }
+
+  const channel = await resolveSendableChannel(client, channelId)
+  // `messages` exists on every TextBasedChannel we care about (Guild text,
+  // Announcement, Thread, DM). The narrowing from resolveSendableChannel
+  // guarantees it here.
+  const messages = (channel as unknown as { messages: { fetch: (id: string) => Promise<unknown> } }).messages
+  const message = await messages.fetch(messageId).catch(() => null)
+  if (!message) {
+    throw new BotHandlerError(404, `Message ${messageId} not found`)
+  }
+
+  const { embeds, components } = buildSessionEmbed({
+    groupName,
+    creatorName,
+    sessionId,
+    games,
+    summary,
+  })
+
+  await (message as { edit: (payload: unknown) => Promise<unknown> }).edit({ embeds, components })
+  return { ok: true }
+}
+
+export async function handleSessionClosed(
+  client: Client,
+  body: DiscordSessionClosedRequest,
+): Promise<{ ok: true }> {
+  const { channelId, messageId, sessionId, groupName, result, summary } = body
+
+  if (!channelId || !messageId || !sessionId || !result) {
+    throw new BotHandlerError(400, 'Missing required fields')
+  }
+
+  const channel = await resolveSendableChannel(client, channelId)
+  const messages = (channel as unknown as { messages: { fetch: (id: string) => Promise<unknown> } }).messages
+  const message = await messages.fetch(messageId).catch(() => null)
+  if (!message) {
+    throw new BotHandlerError(404, `Message ${messageId} not found`)
+  }
+
+  // Re-materialize the game list from the tallies so the closed embed can
+  // show every game row that was in the original message even if we don't
+  // re-fetch the source game list.
+  const games = summary.tallies.map((t) => ({
+    steamAppId: t.steamAppId,
+    gameName: t.gameName,
+    headerImageUrl: t.headerImageUrl,
+  }))
+
+  const { embeds, components } = buildSessionClosedEmbed({
+    groupName,
+    sessionId,
+    games,
+    result,
+    summary,
+  })
+
+  await (message as { edit: (payload: unknown) => Promise<unknown> }).edit({ embeds, components })
+  return { ok: true }
+}

--- a/packages/discord/src/http/server.ts
+++ b/packages/discord/src/http/server.ts
@@ -1,0 +1,118 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http'
+import type { Client } from 'discord.js'
+import { env } from '../env.js'
+import { isAuthorized } from './auth.js'
+import {
+  BotHandlerError,
+  handleSessionClosed,
+  handleSessionCreated,
+  handleSessionUpdate,
+} from './handlers.js'
+
+/**
+ * Internal HTTP API exposed by the Discord bot so the backend can ask it
+ * to send/edit/close the interactive vote messages the webhook transport
+ * can't carry. Binds to loopback by default (see env.BOT_HTTP_HOST) so the
+ * only ambient trust boundary is the shared secret.
+ *
+ * Kept deliberately minimal — one route per verb, no router, no middleware
+ * framework. Adding express here would be overkill for four endpoints.
+ */
+
+const MAX_BODY_BYTES = 64 * 1024
+
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+  const payload = JSON.stringify(body)
+  res.writeHead(status, {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Content-Length': Buffer.byteLength(payload),
+  })
+  res.end(payload)
+}
+
+async function readJsonBody(req: IncomingMessage): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    let total = 0
+    const chunks: Buffer[] = []
+    req.on('data', (chunk: Buffer) => {
+      total += chunk.length
+      if (total > MAX_BODY_BYTES) {
+        req.destroy()
+        reject(new BotHandlerError(413, 'Request body too large'))
+        return
+      }
+      chunks.push(chunk)
+    })
+    req.on('end', () => {
+      const raw = Buffer.concat(chunks).toString('utf-8')
+      if (!raw) {
+        resolve({})
+        return
+      }
+      try {
+        resolve(JSON.parse(raw))
+      } catch {
+        reject(new BotHandlerError(400, 'Invalid JSON body'))
+      }
+    })
+    req.on('error', (err) => reject(err))
+  })
+}
+
+type Route = (client: Client, body: unknown) => Promise<unknown>
+
+const routes: Record<string, Route> = {
+  'POST /internal/session/created': (client, body) =>
+    handleSessionCreated(client, body as Parameters<typeof handleSessionCreated>[1]),
+  'POST /internal/session/updated': (client, body) =>
+    handleSessionUpdate(client, body as Parameters<typeof handleSessionUpdate>[1]),
+  'POST /internal/session/closed': (client, body) =>
+    handleSessionClosed(client, body as Parameters<typeof handleSessionClosed>[1]),
+}
+
+export function startHttpApi(client: Client): void {
+  const server = createServer(async (req, res) => {
+    try {
+      if (req.method === 'GET' && req.url === '/internal/health') {
+        sendJson(res, 200, { status: 'ok', ready: client.isReady() })
+        return
+      }
+
+      if (!isAuthorized(req.headers['authorization'])) {
+        sendJson(res, 401, { error: 'unauthorized', message: 'Invalid bot credentials' })
+        return
+      }
+
+      const key = `${req.method ?? ''} ${req.url ?? ''}`
+      const handler = routes[key]
+      if (!handler) {
+        sendJson(res, 404, { error: 'not_found', message: 'No such endpoint' })
+        return
+      }
+
+      if (!client.isReady()) {
+        sendJson(res, 503, { error: 'not_ready', message: 'Bot is not connected to Discord yet' })
+        return
+      }
+
+      const body = await readJsonBody(req)
+      const result = await handler(client, body)
+      sendJson(res, 200, result)
+    } catch (err) {
+      if (err instanceof BotHandlerError) {
+        sendJson(res, err.statusCode, { error: 'handler_error', message: err.message })
+        return
+      }
+      console.error('[bot-http] unexpected error', err)
+      sendJson(res, 500, { error: 'internal', message: 'Internal bot error' })
+    }
+  })
+
+  server.listen(env.BOT_HTTP_PORT, env.BOT_HTTP_HOST, () => {
+    console.log(`[bot-http] listening on ${env.BOT_HTTP_HOST}:${env.BOT_HTTP_PORT}`)
+  })
+
+  server.on('error', (err) => {
+    console.error('[bot-http] server error', err)
+  })
+}

--- a/packages/discord/src/index.ts
+++ b/packages/discord/src/index.ts
@@ -1,6 +1,7 @@
 import { Client, GatewayIntentBits, Events, REST, Routes, type Interaction, type Message } from 'discord.js'
 import { validateEnv, env } from './env.js'
 import { backendApi } from './lib/api.js'
+import { startHttpApi } from './http/server.js'
 import { startScheduler, notifyBackOnline } from './scheduler.js'
 import { getTodayPersona, getDefaultPersona, getPersonaById, type Persona } from './personas.js'
 import { getBotSettings } from './lib/api.js'
@@ -65,6 +66,14 @@ client.once(Events.ClientReady, async (c) => {
     console.log(`Registered ${commandData.length} slash commands`)
   } catch (error) {
     console.error('Failed to register slash commands:', error)
+  }
+
+  // Start the internal HTTP API the backend uses to push session events
+  // (create/update/close) onto the Gateway-connected client.
+  try {
+    startHttpApi(c)
+  } catch (err) {
+    console.error('[startup] Failed to start bot HTTP API:', err)
   }
 
   // Start scheduled reminder messages (fetches settings from backend)

--- a/packages/discord/src/lib/embeds.ts
+++ b/packages/discord/src/lib/embeds.ts
@@ -1,5 +1,5 @@
 import { EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } from 'discord.js'
-import type { VoteResult } from '@wawptn/types'
+import type { DiscordVoteSummary, DiscordVoteTally, VoteResult } from '@wawptn/types'
 
 export interface SessionGame {
   steamAppId: number
@@ -8,20 +8,101 @@ export interface SessionGame {
   headerImageUrl: string | null
 }
 
-export function buildSessionCreatedEmbed(
-  groupName: string,
+/** Discord hard limit: 5 action rows × 5 buttons per row. Two buttons per
+ *  game (👍/👎) means 12 games per message max. We cap early and display a
+ *  "vote on the web" hint when truncation happens so Discord voters know
+ *  the overflow exists. */
+const MAX_GAMES_WITH_BUTTONS = 12
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text
+  return text.slice(0, max - 1) + '…'
+}
+
+function tallyFor(summary: DiscordVoteSummary | undefined, steamAppId: number): DiscordVoteTally | undefined {
+  return summary?.tallies.find((t) => t.steamAppId === steamAppId)
+}
+
+function renderGameLine(index: number, game: SessionGame, tally: DiscordVoteTally | undefined): string {
+  const prefix = `**${index + 1}.** ${game.gameName}`
+  if (!tally || (tally.yesCount === 0 && tally.noCount === 0)) return prefix
+  return `${prefix} — 👍 ${tally.yesCount} · 👎 ${tally.noCount}`
+}
+
+function buildVoteRows(
   games: SessionGame[],
-  creatorName: string,
   sessionId: string,
+  options: { disabled?: boolean } = {},
+): ActionRowBuilder<ButtonBuilder>[] {
+  const visible = games.slice(0, MAX_GAMES_WITH_BUTTONS)
+  const rows: ActionRowBuilder<ButtonBuilder>[] = []
+
+  // Two buttons per game = 2 per row of width 5, so we fit 2 games per row.
+  // Using label "👍 <name>" / "👎 <name>" lets voters tell games apart.
+  for (let i = 0; i < visible.length; i += 2) {
+    const row = new ActionRowBuilder<ButtonBuilder>()
+    const chunk = visible.slice(i, i + 2)
+    for (const game of chunk) {
+      const shortName = truncate(game.gameName, 18)
+      row.addComponents(
+        new ButtonBuilder()
+          .setCustomId(`vote:${sessionId}:${game.steamAppId}:yes`)
+          .setLabel(`👍 ${shortName}`)
+          .setStyle(ButtonStyle.Success)
+          .setDisabled(!!options.disabled),
+        new ButtonBuilder()
+          .setCustomId(`vote:${sessionId}:${game.steamAppId}:no`)
+          .setLabel(`👎 ${shortName}`)
+          .setStyle(ButtonStyle.Danger)
+          .setDisabled(!!options.disabled),
+      )
+    }
+    rows.push(row)
+  }
+  return rows
+}
+
+interface BuildSessionEmbedParams {
+  groupName: string
+  creatorName: string
+  sessionId: string
+  games: SessionGame[]
+  summary?: DiscordVoteSummary
+}
+
+/**
+ * Builds the "vote opened" / "live update" message.
+ * The same function is reused for every update — the only difference
+ * between the initial post and a live edit is the `summary` payload.
+ */
+export function buildSessionEmbed(
+  params: BuildSessionEmbedParams,
 ): { embeds: EmbedBuilder[]; components: ActionRowBuilder<ButtonBuilder>[] } {
+  const { groupName, creatorName, sessionId, games, summary } = params
+
+  const visibleCount = Math.min(games.length, MAX_GAMES_WITH_BUTTONS)
+  const hiddenCount = games.length - visibleCount
+
   const gameList = games
-    .slice(0, 25)
-    .map((g, i) => `**${i + 1}.** ${g.gameName}`)
+    .slice(0, visibleCount)
+    .map((g, i) => renderGameLine(i, g, tallyFor(summary, g.steamAppId)))
     .join('\n')
+
+  const extraLine = hiddenCount > 0
+    ? `\n\n_+${hiddenCount} autre${hiddenCount > 1 ? 's' : ''} jeu${hiddenCount > 1 ? 'x' : ''} — votez sur le site pour les voir tous._`
+    : ''
+
+  const progressLine = summary
+    ? `\n\n🗳️ **${summary.voterCount}/${summary.totalParticipants}** ont voté`
+    : ''
 
   const embed = new EmbedBuilder()
     .setTitle('🗳️ Vote lancé !')
-    .setDescription(`**${creatorName}** a lancé un vote dans le groupe **${groupName}**.\n\nVotez 👍 ou 👎 sur chaque jeu. Faut se décider ce soir !\n\n${gameList}`)
+    .setDescription(
+      `**${creatorName}** a lancé un vote dans **${groupName}**.\n` +
+      `Cliquez 👍 ou 👎 sur chaque jeu. Les votes du site et de Discord comptent ensemble.\n\n` +
+      `${gameList}${extraLine}${progressLine}`,
+    )
     .setColor(0x5865F2)
     .setTimestamp()
 
@@ -29,25 +110,80 @@ export function buildSessionCreatedEmbed(
     embed.setThumbnail(games[0].headerImageUrl)
   }
 
-  // Create vote buttons for each game (max 5 rows of 5 buttons = 25 games)
-  const rows: ActionRowBuilder<ButtonBuilder>[] = []
+  const components = buildVoteRows(games, sessionId)
+  return { embeds: [embed], components }
+}
 
-  for (let i = 0; i < Math.min(games.length, 25); i += 5) {
-    const row = new ActionRowBuilder<ButtonBuilder>()
-    const chunk = games.slice(i, i + 5)
+interface BuildSessionClosedEmbedParams {
+  groupName: string
+  sessionId: string
+  games: SessionGame[]
+  result: VoteResult
+  summary?: DiscordVoteSummary
+}
 
-    for (const game of chunk) {
-      row.addComponents(
-        new ButtonBuilder()
-          .setCustomId(`vote:${sessionId}:${game.steamAppId}:yes`)
-          .setLabel(`👍 ${game.gameName.slice(0, 70)}`)
-          .setStyle(ButtonStyle.Success),
-      )
-    }
-    rows.push(row)
+/**
+ * Final state of the message once the session closes: winner highlighted,
+ * all buttons disabled so nobody keeps clicking, and the per-game tallies
+ * preserved so you can scroll back and see the full picture.
+ */
+export function buildSessionClosedEmbed(
+  params: BuildSessionClosedEmbedParams,
+): { embeds: EmbedBuilder[]; components: ActionRowBuilder<ButtonBuilder>[] } {
+  const { groupName, sessionId, games, result, summary } = params
+
+  const tallies = games
+    .slice(0, MAX_GAMES_WITH_BUTTONS)
+    .map((g, i) => renderGameLine(i, g, tallyFor(summary, g.steamAppId)))
+    .join('\n')
+
+  const winnerEmbed = new EmbedBuilder()
+    .setTitle('🏆 Le groupe a choisi !')
+    .setDescription(
+      `Le groupe **${groupName}** a choisi :\n\n# ${result.gameName}\n\n` +
+      `${result.yesCount} vote${result.yesCount > 1 ? 's' : ''} sur ${result.totalVoters} participant${result.totalVoters > 1 ? 's' : ''}.\n\n` +
+      `**Résultats détaillés :**\n${tallies}`,
+    )
+    .setColor(0x57F287)
+    .setTimestamp()
+
+  if (result.headerImageUrl) {
+    winnerEmbed.setImage(result.headerImageUrl)
+  }
+  if (result.steamAppId) {
+    winnerEmbed.setURL(`https://store.steampowered.com/app/${result.steamAppId}`)
   }
 
-  return { embeds: [embed], components: rows }
+  // Rebuild the vote rows in disabled state so the closed message still
+  // shows every game that was in the vote, but nobody can click them.
+  const rows = buildVoteRows(games, sessionId, { disabled: true })
+
+  // Append the Steam launch link as a separate row if it fits (Discord
+  // allows up to 5 action rows total).
+  if (result.steamAppId && rows.length < 5) {
+    rows.push(
+      new ActionRowBuilder<ButtonBuilder>().addComponents(
+        new ButtonBuilder()
+          .setLabel('Lancer sur Steam')
+          .setStyle(ButtonStyle.Link)
+          .setURL(`steam://run/${result.steamAppId}`)
+          .setEmoji('🚀'),
+      ),
+    )
+  }
+
+  return { embeds: [winnerEmbed], components: rows }
+}
+
+// ── Legacy helpers kept for the existing setup/stats/random commands ───────
+
+export function buildSessionCreatedEmbed(
+  groupName: string,
+  games: SessionGame[],
+  creatorName: string,
+  sessionId: string,
+): { embeds: EmbedBuilder[]; components: ActionRowBuilder<ButtonBuilder>[] } {
+  return buildSessionEmbed({ groupName, creatorName, sessionId, games })
 }
 
 export function buildVoteClosedEmbed(
@@ -79,7 +215,6 @@ export function buildVoteClosedEmbed(
     embed.setURL(`https://store.steampowered.com/app/${result.steamAppId}`)
   }
 
-  // Steam launch button (Link-style buttons work in bot messages)
   const components: ActionRowBuilder<ButtonBuilder>[] = []
   if (result.steamAppId) {
     const row = new ActionRowBuilder<ButtonBuilder>().addComponents(

--- a/packages/frontend/src/i18n/locales/en.json
+++ b/packages/frontend/src/i18n/locales/en.json
@@ -367,7 +367,10 @@
     "topGames": "Most played games",
     "statsGames": "games",
     "statsHours": "hours",
-    "statsPlatforms": "connected"
+    "statsPlatforms": "connected",
+    "discordLinkedAs": "Linked to Discord as {{username}}",
+    "discordLinkInstructions": "Open Discord and run /wawptn-link in a server where the bot is installed to get a code, then paste it on the link page.",
+    "discordUnlinked": "Discord account unlinked."
   },
   "recommendations": {
     "title": "Suggestions",

--- a/packages/frontend/src/i18n/locales/fr.json
+++ b/packages/frontend/src/i18n/locales/fr.json
@@ -376,7 +376,10 @@
     "topGames": "Jeux les plus joués",
     "statsGames": "jeux",
     "statsHours": "heures",
-    "statsPlatforms": "connectées"
+    "statsPlatforms": "connectées",
+    "discordLinkedAs": "Lié à Discord en tant que {{username}}",
+    "discordLinkInstructions": "Ouvre Discord et tape /wawptn-link dans un serveur avec le bot pour recevoir un code, puis colle-le sur la page de liaison.",
+    "discordUnlinked": "Compte Discord délié."
   },
   "recommendations": {
     "title": "Suggestions",

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -43,6 +43,9 @@ export const api = {
       id: string; name: string; connected: boolean; comingSoon?: boolean; linkable?: boolean; needsRelink?: boolean;
       accountId?: string | null; gameCount?: number; lastSyncedAt?: string | null; profileUrl?: string | null;
     }[];
+    discord:
+      | { linked: true; discordId: string; discordUsername: string; linkedAt: string }
+      | { linked: false };
   }>('/auth/profile'),
   syncProfile: () => request<{ ok: boolean }>('/auth/profile/sync', { method: 'POST' }),
   syncPlatform: (platformId: string) => request<{ ok: boolean }>(`/auth/${platformId}/sync`, { method: 'POST' }),
@@ -57,6 +60,9 @@ export const api = {
   confirmDiscordLink: (code: string) => request<{ ok: boolean; discordUsername: string }>('/discord/link/confirm', {
     method: 'POST',
     body: JSON.stringify({ code }),
+  }),
+  unlinkDiscord: () => request<{ ok: boolean; wasLinked: boolean }>('/discord/link', {
+    method: 'DELETE',
   }),
 
   // Invite preview (public, no auth — mounted at /invite, not /api)

--- a/packages/frontend/src/pages/ProfilePage.tsx
+++ b/packages/frontend/src/pages/ProfilePage.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom'
 import { motion, type Variants } from 'framer-motion'
 import {
   ArrowLeft, RefreshCw, ExternalLink, Check, Clock,
-  Gamepad2, Link, Unlink, AlertTriangle, Timer, Trophy, Target,
+  Gamepad2, Link, Unlink, AlertTriangle, Timer, Trophy, Target, MessageCircle,
 } from 'lucide-react'
 import { PlatformIcon } from '@/components/icons/platforms'
 import { useTranslation } from 'react-i18next'
@@ -40,6 +40,10 @@ interface TopGame {
   playtimeForever: number
 }
 
+type DiscordState =
+  | { linked: true; discordId: string; discordUsername: string; linkedAt: string }
+  | { linked: false }
+
 interface Profile {
   id: string
   steamId: string
@@ -50,6 +54,7 @@ interface Profile {
   createdAt: string
   platforms: Platform[]
   topGames?: TopGame[]
+  discord?: DiscordState
 }
 
 /* ── Helpers ── */
@@ -263,6 +268,19 @@ export function ProfilePage() {
     try {
       await api.unlinkPlatform(platformId)
       toast.success(t('profile.platformUnlinked', { platform: PLATFORM_NAMES[platformId] || platformId }))
+      loadProfile()
+    } catch {
+      toast.error(t('profile.unlinkError'))
+    } finally {
+      setUnlinking(null)
+    }
+  }
+
+  async function handleUnlinkDiscord() {
+    setUnlinking('discord')
+    try {
+      await api.unlinkDiscord()
+      toast.success(t('profile.discordUnlinked'))
       loadProfile()
     } catch {
       toast.error(t('profile.unlinkError'))
@@ -538,6 +556,56 @@ export function ProfilePage() {
               </motion.div>
             ))}
           </motion.div>
+        </motion.section>
+
+        {/* ── Discord Link ── */}
+        <motion.section variants={fadeUp}>
+          <h3 className="profile-section-line text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-4">
+            <MessageCircle className="w-4 h-4 shrink-0" />
+            Discord
+          </h3>
+          <div
+            className="flex items-start gap-3 p-3.5 rounded-xl border border-border/50 bg-card/50 backdrop-blur-sm border-l-[3px] transition-all duration-300 hover:bg-card/80"
+            style={{ borderLeftColor: 'oklch(0.55 0.18 270)' }}
+          >
+            <MessageCircle className="w-5 h-5 shrink-0 text-muted-foreground mt-0.5" />
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2 flex-wrap">
+                <span className="font-medium text-sm">Discord</span>
+                {profile.discord?.linked ? (
+                  <span className="flex items-center gap-1 text-[10px] text-success font-medium">
+                    <Check className="w-3 h-3" />
+                    {t('profile.connected')}
+                  </span>
+                ) : (
+                  <span className="text-[10px] text-muted-foreground">
+                    {t('profile.notConnected')}
+                  </span>
+                )}
+              </div>
+              {profile.discord?.linked ? (
+                <p className="text-xs text-muted-foreground mt-1">
+                  {t('profile.discordLinkedAs', { username: profile.discord.discordUsername })}
+                </p>
+              ) : (
+                <p className="text-xs text-muted-foreground mt-1 leading-relaxed">
+                  {t('profile.discordLinkInstructions')}
+                </p>
+              )}
+            </div>
+            {profile.discord?.linked && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleUnlinkDiscord}
+                disabled={unlinking === 'discord'}
+                className="shrink-0 h-8 text-xs text-destructive hover:text-destructive"
+              >
+                <Unlink className="w-3.5 h-3.5 mr-1" />
+                {t('profile.disconnect')}
+              </Button>
+            )}
+          </div>
         </motion.section>
 
         {/* ── Top Games Showcase ── */}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -180,6 +180,68 @@ export interface DiscordGroupConfig {
   discordWebhookUrl: string | null
 }
 
+// ── Bot HTTP contract ──────────────────────────────────────────────────
+// The backend talks to the Discord bot process over HTTP so the bot
+// (which holds the persistent Gateway connection) can send, edit, and
+// close interactive vote messages. These shapes are the wire format.
+
+/** Per-game vote tally used by every live/close message payload. */
+export interface DiscordVoteTally {
+  steamAppId: number
+  gameName: string
+  headerImageUrl: string | null
+  yesCount: number
+  noCount: number
+}
+
+/** Vote summary attached to create/update payloads. */
+export interface DiscordVoteSummary {
+  voterCount: number
+  totalParticipants: number
+  tallies: DiscordVoteTally[]
+}
+
+export interface DiscordSessionCreatedRequest {
+  sessionId: string
+  groupId: string
+  groupName: string
+  channelId: string
+  creatorName: string
+  games: Array<{
+    steamAppId: number
+    gameName: string
+    headerImageUrl: string | null
+  }>
+  summary: DiscordVoteSummary
+}
+
+export interface DiscordSessionCreatedResponse {
+  messageId: string
+}
+
+export interface DiscordSessionUpdateRequest {
+  sessionId: string
+  groupName: string
+  channelId: string
+  messageId: string
+  creatorName: string
+  games: Array<{
+    steamAppId: number
+    gameName: string
+    headerImageUrl: string | null
+  }>
+  summary: DiscordVoteSummary
+}
+
+export interface DiscordSessionClosedRequest {
+  sessionId: string
+  groupName: string
+  channelId: string
+  messageId: string
+  result: VoteResult
+  summary: DiscordVoteSummary
+}
+
 // ============================================
 // Challenges
 // ============================================


### PR DESCRIPTION
Replace the webhook-only session notifier with a bot-backed path that
posts an interactive message when a vote opens, live-updates the vote
counts as they come in from either the web app or Discord, and edits
the message into a closed state with a disabled button grid on close.
Webhooks remain for broadcast announcements since they can't carry
interactive components.

SoC layout:
- packages/discord/src/http is a minimal Node http server the backend
  calls into so the bot (which holds the Gateway connection) sends and
  edits the actual messages. Loopback-bound + shared-secret auth.
- backend bot-client is a pure transport; live-vote-updater is a
  trailing-debounced (1.5s) coordinator that always reads the current
  DB snapshot so web and Discord votes converge on the same payload.
- notifier becomes the session-effects facade into Discord; both
  transports (bot + announcement webhooks) are best-effort and never
  block the canonical Postgres write.
- New domain event vote:cast fires from both vote routes so the
  updater reacts without coupling the HTTP layer to Discord.

Also extends /auth/profile with Discord link status and adds a Link
Discord section to ProfilePage so users can discover and unlink the
integration without leaving the web app.

https://claude.ai/code/session_01VdWuxRKoeNQCSziU4E1kTQ