### PR TITLE
Fix reminder scheduling and add manual test trigger

### DIFF
--- a/packages/backend/src/presentation/routes/discord.routes.ts
+++ b/packages/backend/src/presentation/routes/discord.routes.ts
@@ -707,10 +707,26 @@ router.get('/bot-settings', async (_req: Request, res: Response) => {
     .where('key', 'like', 'bot.%')
     .select('key', 'value')
 
+  // app_settings.value is a jsonb column but the seed migration and the
+  // admin PATCH endpoint both call JSON.stringify() before inserting, so
+  // the exact shape that comes back from knex/pg depends on how the row
+  // was written. Defensively unwrap string values so the Discord bot's
+  // scheduler receives a plain cron expression like `0 21 * * 5` instead
+  // of the JSON-encoded `"0 21 * * 5"` with literal quotes — the latter
+  // fails cron.validate() silently and no reminder ever gets scheduled.
+  // This mirrors the parse helper in loadGlobalBotDefaults() below.
   const settings: Record<string, unknown> = {}
   for (const row of rows) {
     const shortKey = row.key.replace(/^bot\./, '')
-    settings[shortKey] = row.value
+    let value: unknown = row.value
+    if (typeof value === 'string') {
+      try {
+        value = JSON.parse(value)
+      } catch {
+        // Not JSON — leave as-is (plain string, already usable).
+      }
+    }
+    settings[shortKey] = value
   }
 
   res.json(settings)

--- a/packages/discord/src/commands/config.ts
+++ b/packages/discord/src/commands/config.ts
@@ -5,6 +5,7 @@ import {
   type ChatInputCommandInteraction,
 } from 'discord.js'
 import { getGuildSettings, updateGuildSettings } from '../lib/api.js'
+import { triggerReminder } from '../scheduler.js'
 
 // Matches a 5-field cron expression loosely enough to reject obvious
 // nonsense while still allowing ranges, lists and step values. The
@@ -55,6 +56,21 @@ export const data = new SlashCommandBuilder()
             { name: 'Rappel du vendredi', value: 'friday_schedule' },
             { name: 'Rappel du milieu de semaine', value: 'wednesday_schedule' },
             { name: 'Fuseau horaire', value: 'schedule_timezone' },
+          ),
+      ),
+  )
+  .addSubcommand((sub) =>
+    sub
+      .setName('test-reminder')
+      .setDescription('Envoie un rappel de test maintenant dans ce canal')
+      .addStringOption((opt) =>
+        opt
+          .setName('type')
+          .setDescription('Quel type de rappel tester')
+          .setRequired(true)
+          .addChoices(
+            { name: 'Rappel du vendredi', value: 'friday' },
+            { name: 'Rappel du milieu de semaine', value: 'weekday' },
           ),
       ),
   )
@@ -149,6 +165,27 @@ export async function execute(interaction: ChatInputCommandInteraction): Promise
       })
 
       await interaction.editReply({ content: `♻️ ${field} réinitialisé à la valeur globale.` })
+      return
+    }
+
+    if (sub === 'test-reminder') {
+      // Ephemeral confirmation, but the reminder itself is a public message
+      // in the current channel so the admin can see exactly what would fire
+      // on the next cron tick (permissions, persona copy, embed style).
+      const kind = interaction.options.getString('type', true) as 'friday' | 'weekday'
+      const label = kind === 'friday' ? 'vendredi' : 'semaine'
+
+      try {
+        const { personaName } = await triggerReminder(interaction.client, interaction.channelId, kind)
+        await interaction.editReply({
+          content: `✅ Rappel de test **${label}** envoyé dans ce canal (persona : ${personaName}).`,
+        })
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Erreur inconnue'
+        await interaction.editReply({
+          content: `❌ Impossible d'envoyer le rappel de test : ${message}`,
+        })
+      }
       return
     }
 

--- a/packages/discord/src/scheduler.ts
+++ b/packages/discord/src/scheduler.ts
@@ -127,6 +127,47 @@ export async function notifyBackOnline(client: Client): Promise<void> {
   await sendToLinkedChannels(client, persona.backOnlineMessages)
 }
 
+// ─── Manual test trigger ──────────────────────────────────────────────────────
+
+/**
+ * Sends a reminder embed to a single channel right now, bypassing the cron
+ * schedule. Used by `/wawptn-config test-reminder` so admins can verify the
+ * persona voice, channel permissions and end-to-end delivery without having
+ * to wait until the next Friday 21:00.
+ *
+ * Throws on any failure so the caller can surface the error back to the
+ * invoking slash command.
+ */
+export async function triggerReminder(
+  client: Client,
+  channelId: string,
+  kind: 'friday' | 'weekday',
+): Promise<{ personaName: string; message: string }> {
+  const persona = getPersona()
+  const pool = kind === 'friday' ? persona.fridayMessages : persona.weekdayMessages
+
+  if (!Array.isArray(pool) || pool.length === 0) {
+    throw new Error(
+      `La persona « ${persona.name} » ne contient pas de message ${kind === 'friday' ? 'vendredi' : 'semaine'}.`,
+    )
+  }
+
+  const message = pickRandom(pool)
+  const embed = buildReminderEmbed(message)
+
+  const channel = await client.channels.fetch(channelId)
+  if (!channel || !channel.isTextBased()) {
+    throw new Error('Ce canal ne peut pas recevoir de messages texte.')
+  }
+
+  await (channel as TextChannel).send({ embeds: [embed] })
+  console.log(
+    `[scheduler] Manual ${kind} reminder sent to channel ${channelId} (persona: ${persona.name})`,
+  )
+
+  return { personaName: persona.name, message }
+}
+
 // ─── Dynamic cron scheduling ──────────────────────────────────────────────────
 
 function stopAllGuildTasks(): void {
@@ -183,13 +224,21 @@ function scheduleGuildReminders(
 }
 
 async function rebuildGuildCrons(client: Client, settings: BotSettings): Promise<void> {
-  stopAllGuildTasks()
-
+  // Fetch channels FIRST. The previous version stopped all existing tasks up
+  // front and then awaited the HTTP call, so any transient backend error left
+  // the bot with zero rappels scheduled until the next settings refresh —
+  // which is exactly the failure mode the user hit ("never once rappel works").
   let channels: LinkedChannel[] = []
   try {
     channels = await getLinkedChannels()
   } catch (err) {
-    console.error('[scheduler] Failed to fetch linked channels for per-guild scheduling:', err)
+    console.error('[scheduler] Failed to fetch linked channels — keeping existing tasks alive:', err)
+    return
+  }
+
+  if (channels.length === 0) {
+    console.log('[scheduler] No linked channels found — clearing reminder schedule')
+    stopAllGuildTasks()
     return
   }
 
@@ -204,9 +253,18 @@ async function rebuildGuildCrons(client: Client, settings: BotSettings): Promise
     else byGuild.set(key, [channel])
   }
 
-  // Fall back to the global defaults whenever a guild has no explicit
-  // override. The backend loadGlobalBotDefaults() endpoint returns the
-  // resolved values already, so each guild call is a single round-trip.
+  // Resolve each guild's effective schedule BEFORE stopping the old tasks so
+  // we spend as little time as possible with no cron scheduled. Per-guild
+  // overrides come from /api/discord/guild-settings which already merges
+  // against the global defaults, so we only hit it when we know a guildId.
+  interface ResolvedGuild {
+    key: string | null
+    channels: LinkedChannel[]
+    friday: string
+    weekday: string
+    timezone: string
+  }
+  const resolved: ResolvedGuild[] = []
   for (const [guildKey, guildChannels] of byGuild) {
     let friday = settings.friday_schedule
     let weekday = settings.wednesday_schedule
@@ -223,15 +281,27 @@ async function rebuildGuildCrons(client: Client, settings: BotSettings): Promise
       }
     }
 
-    scheduleGuildReminders(client, guildKey, guildChannels, friday, weekday, timezone)
+    resolved.push({ key: guildKey, channels: guildChannels, friday, weekday, timezone })
   }
+
+  stopAllGuildTasks()
+  for (const { key, channels: guildChannels, friday, weekday, timezone } of resolved) {
+    scheduleGuildReminders(client, key, guildChannels, friday, weekday, timezone)
+  }
+  console.log(
+    `[scheduler] Reminder schedule rebuilt: ${guildTasks.size} guild(s), ${channels.length} linked channel(s)`,
+  )
 }
 
 function scheduleCrons(client: Client, settings: BotSettings): void {
   // Per-guild reminder crons — rebuilt whenever global or per-guild
-  // settings change. The call is async so we fire-and-forget and let
-  // the old tasks keep running until the new ones take over.
-  void rebuildGuildCrons(client, settings)
+  // settings change. The call is async so we fire-and-forget, but we
+  // attach a catch handler because a bare `void` on a rejected promise
+  // becomes a silent unhandled rejection — which is exactly how rappels
+  // were disappearing from the schedule without a single log line.
+  rebuildGuildCrons(client, settings).catch((err) => {
+    console.error('[scheduler] rebuildGuildCrons failed:', err)
+  })
 
   // Persona change announcement at midnight (global, not per-guild).
   personaAnnounceTask?.stop()


### PR DESCRIPTION
## Summary
This PR fixes a critical bug where reminder crons could disappear from the schedule due to unhandled promise rejections, adds a manual test command for admins to verify reminders, and improves JSON parsing of bot settings from the database.

## Key Changes

- **Fixed reminder scheduling race condition**: Reordered `rebuildGuildCrons()` to fetch channels before stopping existing tasks, preventing a window where no reminders are scheduled if the HTTP call fails. Also added proper error handling with `.catch()` instead of bare `void` to prevent silent unhandled rejections.

- **Added `/wawptn-config test-reminder` command**: New subcommand that allows admins to trigger a reminder immediately in the current channel to verify persona voice, permissions, and end-to-end delivery without waiting for the next scheduled cron.

- **Implemented `triggerReminder()` function**: New scheduler export that sends a test reminder embed to a specified channel, returning the persona name and message used for confirmation feedback.

- **Fixed JSON parsing of bot settings**: Added defensive JSON parsing in the `/bot-settings` endpoint to unwrap string values from the database. Settings like cron expressions were being double-encoded as JSON strings (e.g., `"0 21 * * 5"` instead of `0 21 * * 5`), causing `cron.validate()` to fail silently and reminders to never schedule.

- **Improved scheduling robustness**: Restructured `rebuildGuildCrons()` to resolve all guild settings before stopping old tasks, minimizing the window with no active crons. Added logging to track schedule rebuilds and channel counts.

## Notable Implementation Details

- The test reminder command sends a public message in the channel (not ephemeral) so admins can see the exact output that would appear on scheduled runs
- Error messages are in French to match the bot's persona
- The JSON parsing fix mirrors existing logic in `loadGlobalBotDefaults()` for consistency
- All changes maintain backward compatibility with existing reminder scheduling

https://claude.ai/code/session_01BdAUgth31ZSFWnXZApQTJP