### PR TITLE
Decode HTML entities in game descriptions

### DIFF
--- a/packages/frontend/src/components/game-grid.tsx
+++ b/packages/frontend/src/components/game-grid.tsx
@@ -18,6 +18,7 @@ import {
 import type { CommonGame } from '@wawptn/types'
 import { EmptyState } from '@/components/empty-state'
 import { useWishlistStore } from '@/stores/wishlist.store'
+import { decodeHtmlEntities } from '@/lib/utils'
 
 // Reuse the shared wire type so we don't drift from the API shape. The
 // grid previously redeclared a subset inline, which silently allowed the
@@ -748,7 +749,7 @@ function GameCard({ game, t }: { game: Game; t: (key: string, options?: Record<s
         </TooltipTrigger>
         {game.shortDescription && (
           <TooltipContent side="bottom" className="max-w-xs text-xs">
-            {game.shortDescription}
+            {decodeHtmlEntities(game.shortDescription)}
           </TooltipContent>
         )}
       </Tooltip>

--- a/packages/frontend/src/components/tonight-pick-hero.tsx
+++ b/packages/frontend/src/components/tonight-pick-hero.tsx
@@ -7,6 +7,7 @@ import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
+import { decodeHtmlEntities } from '@/lib/utils'
 
 interface Member {
   id: string
@@ -229,7 +230,7 @@ export function TonightPickHero({
             </div>
             {game.shortDescription && (
               <p className="text-sm text-muted-foreground mt-2 line-clamp-2 hidden sm:block">
-                {game.shortDescription}
+                {decodeHtmlEntities(game.shortDescription)}
               </p>
             )}
           </div>

--- a/packages/frontend/src/lib/utils.ts
+++ b/packages/frontend/src/lib/utils.ts
@@ -4,3 +4,15 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/**
+ * Decode HTML entities (e.g. `&quot;`, `&amp;`, `&#39;`) in a string.
+ * Steam Store API returns descriptions with HTML-encoded characters which
+ * React renders literally — decode them before display.
+ */
+export function decodeHtmlEntities(str: string): string {
+  if (!str) return str
+  const textarea = document.createElement("textarea")
+  textarea.innerHTML = str
+  return textarea.value
+}

--- a/packages/frontend/src/pages/VotePage.tsx
+++ b/packages/frontend/src/pages/VotePage.tsx
@@ -26,6 +26,7 @@ import {
 } from '@/components/ui/responsive-dialog'
 import { ShareButton } from '@/components/share-button'
 import { CelebrationParticles } from '@/components/celebration-particles'
+import { decodeHtmlEntities } from '@/lib/utils'
 
 interface Game {
   steamAppId: number
@@ -783,7 +784,7 @@ function GameDetailDialog({ game, isSelected, onOpenChange, onToggle, t }: GameD
         {/* Short description */}
         {game.shortDescription && (
           <p className="text-sm text-muted-foreground leading-relaxed">
-            {game.shortDescription}
+            {decodeHtmlEntities(game.shortDescription)}
           </p>
         )}
 


### PR DESCRIPTION
## Summary
Fix rendering of HTML-encoded characters in game descriptions from the Steam Store API. The API returns descriptions with HTML entities (e.g., `&quot;`, `&amp;`, `&#39;`) that were being displayed literally instead of decoded.

## Changes
- Added `decodeHtmlEntities()` utility function to decode HTML entities using a textarea element's innerHTML/value behavior
- Applied the decoder to game short descriptions in three components:
  - `game-grid.tsx`: GameCard tooltip content
  - `tonight-pick-hero.tsx`: Hero section game description
  - `VotePage.tsx`: Game detail dialog description

## Implementation Details
The `decodeHtmlEntities()` function leverages the browser's HTML parser by creating a temporary textarea element, setting its innerHTML to the encoded string, and reading back the decoded value. This approach handles all standard HTML entities without requiring external dependencies or manual entity mappings.

https://claude.ai/code/session_01GboBAuJRsKDuPV5mvaBhLh