### PR TITLE
feat(discord): magic-link auth + group bans foundation

### DIFF
--- a/packages/backend/migrations/20260414_b_discord_group_unification.ts
+++ b/packages/backend/migrations/20260414_b_discord_group_unification.ts
@@ -1,0 +1,106 @@
+import type { Knex } from 'knex'
+
+/**
+ * Discord ↔ group unification foundation.
+ *
+ * Schema primitives required by the "Le salon Discord EST le groupe" feature
+ * (decisions C1–C4 + D13/D16 from the 2026-04-14 design meeting):
+ *
+ *  1. `groups.archived_at` — soft-archive column for groups whose bound
+ *     Discord channel/guild disappears (bot kicked, channel deleted).
+ *     Legacy Steam-only groups can also be archived via this column.
+ *
+ *  2. `group_bans` — persistent blocklist preventing a kicked member from
+ *     being re-materialized by the implicit enrollment path. Dual-key on
+ *     both `user_id` and `discord_id` so that a ban survives users who
+ *     haven't yet linked a Steam account to their Discord identity.
+ *
+ *  3. `discord_auth_intents` — short-lived one-shot nonces issued by the
+ *     Discord bot when a user runs `/wawptn setup` (or any command that
+ *     leads the user to the web app). The nonce is consumed by the Steam
+ *     OpenID callback to atomically:
+ *       - upsert the `discord_links` row,
+ *       - upsert the `groups` row for the channel,
+ *       - insert a `group_members` row (subject to `group_bans` check).
+ *
+ * Intentionally minimal. See the design meeting compte-rendu for the full
+ * rationale; no additional columns added speculatively.
+ */
+export async function up(knex: Knex): Promise<void> {
+  // 1. Soft-archive column on groups.
+  await knex.schema.alterTable('groups', (table) => {
+    table.timestamp('archived_at').nullable()
+    table.index('archived_at')
+  })
+
+  // 2. Persistent ban list. At least one of `user_id` / `discord_id` must
+  //    be set — enforced at the application layer since partial unique
+  //    constraints with OR conditions don't translate cleanly across
+  //    Postgres and the Knex schema builder.
+  await knex.schema.createTable('group_bans', (table) => {
+    table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'))
+    table.uuid('group_id').notNullable().references('id').inTable('groups').onDelete('CASCADE')
+    // WAWPTN user (nullable: ban may precede account materialisation).
+    table.uuid('user_id').nullable().references('id').inTable('users').onDelete('CASCADE')
+    // Discord identity (nullable: ban may target a web-only user).
+    table.string('discord_id').nullable()
+    // Who issued the ban (group owner or system for automated enforcement).
+    table.uuid('banned_by').nullable().references('id').inTable('users').onDelete('SET NULL')
+    table.text('reason').nullable()
+    table.timestamp('banned_at').notNullable().defaultTo(knex.fn.now())
+
+    table.index(['group_id', 'user_id'])
+    table.index(['group_id', 'discord_id'])
+  })
+
+  // Unique constraints scoped to (group_id, user_id) and (group_id, discord_id)
+  // where the respective column is not null. Prevents duplicate ban rows
+  // without forbidding the dual-null-unset case (which the app layer rejects).
+  await knex.raw(`
+    CREATE UNIQUE INDEX group_bans_group_user_unique
+      ON group_bans (group_id, user_id)
+      WHERE user_id IS NOT NULL
+  `)
+  await knex.raw(`
+    CREATE UNIQUE INDEX group_bans_group_discord_unique
+      ON group_bans (group_id, discord_id)
+      WHERE discord_id IS NOT NULL
+  `)
+
+  // 3. Short-lived auth intents. Consumed once; rows with a non-null
+  //    `consumed_at` are kept briefly for audit then swept.
+  await knex.schema.createTable('discord_auth_intents', (table) => {
+    table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'))
+    // Opaque nonce embedded in the magic link. Unique + indexed so the
+    // lookup in the Steam callback is a single index hit.
+    table.string('nonce', 64).notNullable().unique()
+    // Discord identity that triggered the intent.
+    table.string('discord_id').notNullable()
+    table.string('discord_username').notNullable()
+    // Target Discord channel/guild the user will be enrolled into on
+    // successful Steam auth. Both required — the bot always has them.
+    table.string('discord_channel_id').notNullable()
+    table.string('discord_guild_id').notNullable()
+    // Human-readable channel name captured at intent time for display in
+    // the "Vous avez rejoint #salon" toast without a Discord API round-trip.
+    table.string('channel_name').nullable()
+    // TTL and one-shot guard.
+    table.timestamp('expires_at').notNullable()
+    table.timestamp('consumed_at').nullable()
+    table.timestamp('created_at').notNullable().defaultTo(knex.fn.now())
+
+    table.index('expires_at')
+    table.index(['discord_id', 'consumed_at'])
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists('discord_auth_intents')
+  await knex.raw('DROP INDEX IF EXISTS group_bans_group_discord_unique')
+  await knex.raw('DROP INDEX IF EXISTS group_bans_group_user_unique')
+  await knex.schema.dropTableIfExists('group_bans')
+  await knex.schema.alterTable('groups', (table) => {
+    table.dropIndex('archived_at')
+    table.dropColumn('archived_at')
+  })
+}

--- a/packages/backend/src/domain/discord-auth-intent.ts
+++ b/packages/backend/src/domain/discord-auth-intent.ts
@@ -1,0 +1,283 @@
+import crypto from 'crypto'
+import { db } from '../infrastructure/database/connection.js'
+import { authLogger } from '../infrastructure/logger/logger.js'
+import { getIO } from '../infrastructure/socket/socket.js'
+
+/**
+ * Discord auth-intent domain service.
+ *
+ * Supports the "magic link" flow used by the Discord bot:
+ *   1. Bot issues `/wawptn setup` (or any command that needs a linked
+ *      WAWPTN session). `createDiscordAuthIntent` persists a short-lived,
+ *      one-shot nonce and returns the URL to surface in the bot's reply.
+ *   2. User opens the URL, which hits `GET /api/auth/discord/intent/:nonce`
+ *      and bounces them through Steam OpenID.
+ *   3. The Steam callback consumes the intent via `consumeDiscordAuthIntent`
+ *      then materialises the group membership (`materializeGroupForIntent`).
+ *
+ * Ban enforcement (decision D16) happens in `materializeGroupForIntent`
+ * — not at intent creation — because the ban may target the Discord
+ * identity before any WAWPTN user exists for them.
+ */
+
+const INTENT_TTL_MS = 10 * 60 * 1000 // 10 minutes
+const NONCE_BYTES = 32
+
+export interface DiscordAuthIntent {
+  id: string
+  nonce: string
+  discordId: string
+  discordUsername: string
+  discordChannelId: string
+  discordGuildId: string
+  channelName: string | null
+  expiresAt: Date
+  consumedAt: Date | null
+}
+
+/**
+ * Persist a new intent and return the nonce. The caller is responsible
+ * for turning the nonce into a user-facing URL (typically
+ * `${API_URL}/api/auth/discord/intent/${nonce}`).
+ */
+export async function createDiscordAuthIntent(params: {
+  discordId: string
+  discordUsername: string
+  discordChannelId: string
+  discordGuildId: string
+  channelName?: string | null
+}): Promise<{ nonce: string; expiresAt: Date }> {
+  const nonce = crypto.randomBytes(NONCE_BYTES).toString('hex')
+  const expiresAt = new Date(Date.now() + INTENT_TTL_MS)
+
+  await db('discord_auth_intents').insert({
+    nonce,
+    discord_id: params.discordId,
+    discord_username: params.discordUsername,
+    discord_channel_id: params.discordChannelId,
+    discord_guild_id: params.discordGuildId,
+    channel_name: params.channelName ?? null,
+    expires_at: expiresAt,
+  })
+
+  authLogger.info(
+    {
+      discordId: params.discordId,
+      discordChannelId: params.discordChannelId,
+      discordGuildId: params.discordGuildId,
+    },
+    'discord auth intent created',
+  )
+
+  return { nonce, expiresAt }
+}
+
+/**
+ * Look up an intent by nonce. Returns null if the nonce is unknown,
+ * expired, or already consumed. Does NOT mutate state — callers should
+ * follow this with `consumeDiscordAuthIntent` once the user's identity
+ * is confirmed.
+ */
+export async function findLiveDiscordAuthIntent(
+  nonce: string,
+): Promise<DiscordAuthIntent | null> {
+  const row = await db('discord_auth_intents')
+    .where({ nonce })
+    .where('expires_at', '>', new Date())
+    .whereNull('consumed_at')
+    .first()
+
+  if (!row) return null
+
+  return {
+    id: row.id,
+    nonce: row.nonce,
+    discordId: row.discord_id,
+    discordUsername: row.discord_username,
+    discordChannelId: row.discord_channel_id,
+    discordGuildId: row.discord_guild_id,
+    channelName: row.channel_name,
+    expiresAt: row.expires_at,
+    consumedAt: row.consumed_at,
+  }
+}
+
+/**
+ * Atomically mark an intent as consumed. Returns true if the caller is
+ * the one that won the race (i.e. the row transitioned from not-consumed
+ * to consumed in this call). Any subsequent call with the same nonce
+ * returns false — this is the one-shot guarantee.
+ */
+export async function consumeDiscordAuthIntent(nonce: string): Promise<boolean> {
+  const updated = await db('discord_auth_intents')
+    .where({ nonce })
+    .where('expires_at', '>', new Date())
+    .whereNull('consumed_at')
+    .update({ consumed_at: db.fn.now() })
+
+  return updated > 0
+}
+
+/**
+ * Check whether a given (group, user/discord) pair is banned. Used by
+ * both the invite-token join path and the magic-link materialisation
+ * path to honour decision D16 (kick implies ban, not just removal).
+ *
+ * Returns true when a matching `group_bans` row exists.
+ */
+export async function isBannedFromGroup(params: {
+  groupId: string
+  userId?: string | null
+  discordId?: string | null
+}): Promise<boolean> {
+  const { groupId, userId, discordId } = params
+  if (!userId && !discordId) return false
+
+  const query = db('group_bans').where({ group_id: groupId })
+
+  if (userId && discordId) {
+    query.andWhere((q) => {
+      q.where({ user_id: userId }).orWhere({ discord_id: discordId })
+    })
+  } else if (userId) {
+    query.andWhere({ user_id: userId })
+  } else if (discordId) {
+    query.andWhere({ discord_id: discordId })
+  }
+
+  const ban = await query.first()
+  return !!ban
+}
+
+/**
+ * Materialise a WAWPTN group and membership from a consumed Discord
+ * auth intent. This is the core of the "channel = group" flow:
+ *
+ *   1. Upsert `discord_links (user_id, discord_id)` so the caller's
+ *      WAWPTN identity is linked to their Discord identity.
+ *   2. Look up an existing active group for the channel. If none
+ *      exists, create one with the caller as owner.
+ *   3. Run the ban check; if the caller is banned, abort.
+ *   4. Insert a `group_members` row (no-op on conflict). Emit
+ *      `member:joined` so connected clients see the new member in
+ *      real time, matching the invite-token join path.
+ *
+ * Returns the resolved group ID and whether this call created the group.
+ * Throws `new Error('banned')` if the caller is on the group's ban list
+ * so the HTTP layer can render a clear 403.
+ */
+export async function materializeGroupForIntent(
+  userId: string,
+  intent: Pick<
+    DiscordAuthIntent,
+    'discordId' | 'discordUsername' | 'discordChannelId' | 'discordGuildId' | 'channelName'
+  >,
+): Promise<{ groupId: string; created: boolean; alreadyMember: boolean }> {
+  // 1. Upsert the Discord identity link for this user. Uses the
+  //    (user_id) PK on `discord_links`; `discord_id` is additionally
+  //    unique so a single user can only ever hold one Discord identity.
+  await db('discord_links')
+    .insert({
+      user_id: userId,
+      discord_id: intent.discordId,
+      discord_username: intent.discordUsername,
+    })
+    .onConflict('user_id')
+    .merge({
+      discord_id: intent.discordId,
+      discord_username: intent.discordUsername,
+    })
+
+  // 2. Find or create the group for this channel. We key on
+  //    `discord_channel_id` and ignore archived rows so a reconnected
+  //    channel starts fresh rather than resurrecting stale state.
+  let group = await db('groups')
+    .where({ discord_channel_id: intent.discordChannelId })
+    .whereNull('archived_at')
+    .first()
+
+  let created = false
+
+  if (!group) {
+    const [newGroup] = await db('groups')
+      .insert({
+        name: intent.channelName ?? `#${intent.discordChannelId}`,
+        created_by: userId,
+        discord_channel_id: intent.discordChannelId,
+        discord_guild_id: intent.discordGuildId,
+      })
+      .returning('*')
+    group = newGroup
+    created = true
+
+    // The creator is the owner. Insert immediately so we never have a
+    // group without an owner row — the /join path checks for owner
+    // presence when computing member-limit tiers.
+    await db('group_members').insert({
+      group_id: group.id,
+      user_id: userId,
+      role: 'owner',
+    })
+
+    authLogger.info(
+      { userId, groupId: group.id, discordChannelId: intent.discordChannelId },
+      'group materialised from discord intent',
+    )
+  }
+
+  // 3. Ban check. Owners can't be banned from their own group (we just
+  //    created them as owner above), so only run this on the non-created
+  //    path where the caller is a prospective member.
+  if (!created) {
+    const banned = await isBannedFromGroup({
+      groupId: group.id,
+      userId,
+      discordId: intent.discordId,
+    })
+    if (banned) {
+      authLogger.warn(
+        { userId, groupId: group.id, discordId: intent.discordId },
+        'blocked discord intent materialisation: user is banned from group',
+      )
+      throw new Error('banned')
+    }
+  }
+
+  // 4. Insert membership row. `onConflict` makes this a no-op if the
+  //    user is already a member (returning users re-entering via the
+  //    magic link should not double-insert).
+  const existing = await db('group_members')
+    .where({ group_id: group.id, user_id: userId })
+    .first()
+
+  const alreadyMember = !!existing
+
+  if (!created && !alreadyMember) {
+    await db('group_members').insert({
+      group_id: group.id,
+      user_id: userId,
+      role: 'member',
+    })
+
+    // Mirror the invite-token join path: broadcast member:joined so
+    // the group page updates live for other connected clients.
+    const user = await db('users').where({ id: userId }).first()
+    if (user) {
+      try {
+        getIO().to(`group:${group.id}`).emit('member:joined', {
+          groupId: group.id,
+          user: {
+            id: user.id,
+            displayName: user.display_name,
+            avatarUrl: user.avatar_url,
+          },
+        })
+      } catch (err) {
+        // Socket.io may not be initialised during tests; swallow.
+        authLogger.debug({ error: String(err) }, 'socket emit skipped')
+      }
+    }
+  }
+
+  return { groupId: group.id, created, alreadyMember }
+}

--- a/packages/backend/src/presentation/routes/auth.routes.ts
+++ b/packages/backend/src/presentation/routes/auth.routes.ts
@@ -10,9 +10,15 @@ import { env } from '../../config/env.js'
 import { requireAuth } from '../middleware/auth.middleware.js'
 import { SESSION_COOKIE_NAME, CSRF_COOKIE_NAME } from '../../config/session.js'
 import { createUserSession, getSessionUserId, findOrCreateSteamUser } from '../../domain/auth-service.js'
+import {
+  findLiveDiscordAuthIntent,
+  consumeDiscordAuthIntent,
+  materializeGroupForIntent,
+} from '../../domain/discord-auth-intent.js'
 
 const EPIC_LINK_STATE_COOKIE = 'wawptn.epic_link_state'
 const GOG_LINK_STATE_COOKIE = 'wawptn.gog_link_state'
+const DISCORD_INTENT_COOKIE = 'wawptn.discord_intent'
 
 const router = Router()
 
@@ -21,6 +27,95 @@ function isAllowedReturnPath(path: string): boolean {
   return /^\/join\/[a-f0-9]{64}$/.test(path)
     || /^\/discord\/link\?code=[A-Za-z0-9]+$/.test(path)
 }
+
+/**
+ * Discord magic-link entry point.
+ *
+ * The Discord bot issues a one-shot nonce via POST /api/discord/intent
+ * (see discord.routes.ts) and replies to the user in Discord with a URL
+ * pointing at this endpoint. Flow:
+ *
+ *   1. Validate the nonce exists and is live.
+ *   2. Park it in a signed, short-lived cookie scoped to the Steam
+ *      callback path so the callback can consume it after auth.
+ *   3. Kick off Steam OpenID, reusing the existing CSRF + return flow.
+ *
+ * Nothing is mutated here — the intent is only marked consumed once the
+ * Steam callback successfully materialises a user session.
+ */
+router.get('/discord/intent/:nonce', async (req: Request, res: Response) => {
+  const nonce = String(req.params['nonce'] ?? '')
+  if (!/^[a-f0-9]{64}$/.test(nonce)) {
+    authLogger.warn('discord intent rejected: malformed nonce')
+    res.redirect(`${env.CORS_ORIGIN}/?error=discord_intent_invalid`)
+    return
+  }
+
+  const intent = await findLiveDiscordAuthIntent(nonce)
+  if (!intent) {
+    authLogger.warn({ nonce }, 'discord intent rejected: unknown, expired, or consumed')
+    res.redirect(`${env.CORS_ORIGIN}/?error=discord_intent_expired`)
+    return
+  }
+
+  // Park the nonce in a signed cookie for the Steam callback. We intentionally
+  // do NOT consume the intent here — the one-shot mutation happens inside the
+  // Steam callback so an abandoned Steam login doesn't burn the nonce.
+  res.cookie(DISCORD_INTENT_COOKIE, nonce, {
+    httpOnly: true,
+    signed: true,
+    secure: env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    maxAge: 10 * 60 * 1000,
+    path: '/api/auth/steam/callback',
+  })
+
+  // If the user already has a live WAWPTN session, skip Steam entirely and
+  // materialise the group membership straight away. Returning users should
+  // get a one-tap experience.
+  const existingToken = req.signedCookies?.[SESSION_COOKIE_NAME]
+  if (existingToken) {
+    const existingUserId = await getSessionUserId(existingToken)
+    if (existingUserId) {
+      try {
+        const consumed = await consumeDiscordAuthIntent(nonce)
+        if (!consumed) {
+          res.clearCookie(DISCORD_INTENT_COOKIE, { path: '/api/auth/steam/callback' })
+          res.redirect(`${env.CORS_ORIGIN}/?error=discord_intent_expired`)
+          return
+        }
+        const result = await materializeGroupForIntent(existingUserId, intent)
+        res.clearCookie(DISCORD_INTENT_COOKIE, { path: '/api/auth/steam/callback' })
+        res.redirect(`${env.CORS_ORIGIN}/groups/${result.groupId}`)
+        return
+      } catch (error) {
+        if (error instanceof Error && error.message === 'banned') {
+          res.clearCookie(DISCORD_INTENT_COOKIE, { path: '/api/auth/steam/callback' })
+          res.redirect(`${env.CORS_ORIGIN}/?error=group_banned`)
+          return
+        }
+        authLogger.error({ error: String(error), nonce }, 'discord intent fast-path failed')
+        res.clearCookie(DISCORD_INTENT_COOKIE, { path: '/api/auth/steam/callback' })
+        res.redirect(`${env.CORS_ORIGIN}/?error=discord_intent_failed`)
+        return
+      }
+    }
+  }
+
+  // No live session — set the CSRF cookie and redirect to Steam.
+  const csrfState = crypto.randomBytes(16).toString('hex')
+  res.cookie(CSRF_COOKIE_NAME, csrfState, {
+    httpOnly: true,
+    signed: true,
+    secure: env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    maxAge: 10 * 60 * 1000,
+    path: '/api/auth/steam/callback',
+  })
+
+  const returnUrl = `${env.API_URL}/api/auth/steam/callback`
+  res.redirect(getSteamLoginUrl(returnUrl))
+})
 
 // Initiate Steam OpenID login
 router.get('/steam/login', (req: Request, res: Response) => {
@@ -124,6 +219,41 @@ router.get('/steam/callback', async (req: Request, res: Response) => {
     syncUserLibrary(user.id, steamId).catch(err => {
       steamLogger.error({ error: String(err), steamId }, 'background library sync failed')
     })
+
+    // Discord magic-link flow: if a Discord auth intent was parked in
+    // the cookie before the Steam hop, consume it and materialise the
+    // group membership. This is the one-shot step — any subsequent
+    // replay of the same nonce is rejected by consumeDiscordAuthIntent.
+    const discordIntentNonce = req.signedCookies?.[DISCORD_INTENT_COOKIE]
+    res.clearCookie(DISCORD_INTENT_COOKIE, { path: '/api/auth/steam/callback' })
+    if (typeof discordIntentNonce === 'string' && /^[a-f0-9]{64}$/.test(discordIntentNonce)) {
+      try {
+        const intent = await findLiveDiscordAuthIntent(discordIntentNonce)
+        if (intent) {
+          const consumed = await consumeDiscordAuthIntent(discordIntentNonce)
+          if (consumed) {
+            const result = await materializeGroupForIntent(user.id, intent)
+            // Clear the older invite-return cookie defensively — a
+            // Discord intent always wins over a stale invite redirect.
+            res.clearCookie('wawptn.invite_return', { path: '/api/auth/steam/callback' })
+            res.redirect(`${env.CORS_ORIGIN}/groups/${result.groupId}`)
+            return
+          }
+        }
+        authLogger.warn({ nonce: discordIntentNonce }, 'discord intent not live at callback time')
+      } catch (error) {
+        if (error instanceof Error && error.message === 'banned') {
+          res.redirect(`${env.CORS_ORIGIN}/?error=group_banned`)
+          return
+        }
+        authLogger.error(
+          { error: String(error), nonce: discordIntentNonce },
+          'discord intent materialisation failed at callback',
+        )
+        res.redirect(`${env.CORS_ORIGIN}/?error=discord_intent_failed`)
+        return
+      }
+    }
 
     // Redirect to invite join page if cookie present, otherwise home
     const inviteReturn = req.signedCookies?.['wawptn.invite_return']

--- a/packages/backend/src/presentation/routes/discord.routes.ts
+++ b/packages/backend/src/presentation/routes/discord.routes.ts
@@ -10,6 +10,7 @@ import { isUserPremium } from '../middleware/tier.middleware.js'
 import { createVotingSession } from '../../domain/create-session.js'
 import { domainEvents } from '../../domain/events/event-bus.js'
 import { isLLMEnabled, generateChatResponse, type ChatContext } from '../../infrastructure/llm/client.js'
+import { createDiscordAuthIntent } from '../../domain/discord-auth-intent.js'
 
 /** Check if a group's owner has premium. Returns false if no owner found. */
 async function isGroupOwnerPremium(groupId: string): Promise<boolean> {
@@ -22,7 +23,11 @@ const router = Router()
 
 // ─── Bot-authenticated routes (called by the Discord bot) ─────────────────────
 
-// Setup: Link a Discord channel to a WAWPTN group
+// Setup: Link a Discord channel to a WAWPTN group.
+//
+// Discord channel binding is now part of the base product (design meeting
+// decision C4 — 2026-04-14). The previous premium gate has been removed;
+// every user can bind a channel to their group.
 router.post('/setup', async (req: Request, res: Response) => {
   const { groupId, discordChannelId, discordGuildId } = req.body as {
     groupId: string
@@ -41,13 +46,6 @@ router.post('/setup', async (req: Request, res: Response) => {
     return
   }
 
-  // Discord bot integration requires premium
-  const ownerPremium = await isGroupOwnerPremium(groupId)
-  if (!ownerPremium) {
-    res.status(403).json({ error: 'premium_required', message: 'Discord bot integration requires a premium subscription' })
-    return
-  }
-
   await db('groups').where({ id: groupId }).update({
     discord_channel_id: discordChannelId,
     discord_guild_id: discordGuildId,
@@ -56,6 +54,53 @@ router.post('/setup', async (req: Request, res: Response) => {
   logger.info({ groupId, discordChannelId, discordGuildId }, 'Discord channel linked to group')
 
   res.json({ ok: true, groupName: group.name })
+})
+
+/**
+ * Magic-link intent issuance (bot-auth).
+ *
+ * Called by the Discord bot when a user runs `/wawptn setup` (or any
+ * slash command that needs a linked WAWPTN session). The bot passes
+ * the Discord identity and the target channel/guild; the backend mints
+ * a one-shot nonce and returns the URL the bot should surface in its
+ * ephemeral reply.
+ *
+ * The URL is an absolute API endpoint — the browser hits it directly,
+ * and the backend bounces the user through Steam OpenID before
+ * materialising their `group_members` row.
+ */
+router.post('/intent', async (req: Request, res: Response) => {
+  const { discordUserId, discordUsername, discordChannelId, discordGuildId, channelName } = req.body as {
+    discordUserId?: string
+    discordUsername?: string
+    discordChannelId?: string
+    discordGuildId?: string
+    channelName?: string | null
+  }
+
+  if (!discordUserId || !discordUsername || !discordChannelId || !discordGuildId) {
+    res.status(400).json({
+      error: 'validation',
+      message: 'discordUserId, discordUsername, discordChannelId, and discordGuildId are required',
+    })
+    return
+  }
+
+  try {
+    const { nonce, expiresAt } = await createDiscordAuthIntent({
+      discordId: discordUserId,
+      discordUsername,
+      discordChannelId,
+      discordGuildId,
+      channelName: channelName ?? null,
+    })
+
+    const url = `${env.API_URL}/api/auth/discord/intent/${nonce}`
+    res.json({ nonce, url, expiresAt })
+  } catch (error) {
+    authLogger.error({ error: String(error), discordUserId }, 'failed to create discord auth intent')
+    res.status(500).json({ error: 'internal', message: 'Failed to create auth intent' })
+  }
 })
 
 // Link status: Check if a Discord user is linked

--- a/packages/backend/src/presentation/routes/group.routes.ts
+++ b/packages/backend/src/presentation/routes/group.routes.ts
@@ -9,6 +9,7 @@ import { updateGroupSchedule } from '../../infrastructure/scheduler/auto-vote-sc
 import { logger } from '../../infrastructure/logger/logger.js'
 import { isUserPremium, FREE_TIER_LIMITS, PREMIUM_TIER_LIMITS } from '../middleware/tier.middleware.js'
 import { requireGroupMembership } from '../middleware/group-membership.middleware.js'
+import { isBannedFromGroup } from '../../domain/discord-auth-intent.js'
 
 const router = Router()
 
@@ -319,6 +320,7 @@ router.post('/join', async (req: Request, res: Response) => {
   const group = await db('groups')
     .where({ invite_token_hash: hash })
     .where('invite_expires_at', '>', new Date())
+    .whereNull('archived_at')
     .first()
 
   if (!group) {
@@ -333,6 +335,23 @@ router.post('/join', async (req: Request, res: Response) => {
 
   if (existing) {
     res.json({ id: group.id, name: group.name, alreadyMember: true })
+    return
+  }
+
+  // Ban check (decision D16): a kicked user must not be able to rejoin
+  // via a still-live invite link. Also blocks users whose Discord identity
+  // was banned before a WAWPTN account existed for them.
+  const linkedDiscord = await db('discord_links').where({ user_id: userId }).first()
+  const banned = await isBannedFromGroup({
+    groupId: group.id,
+    userId,
+    discordId: linkedDiscord?.discord_id ?? null,
+  })
+  if (banned) {
+    res.status(403).json({
+      error: 'banned',
+      message: 'Vous avez été retiré de ce salon. Contactez le propriétaire.',
+    })
     return
   }
 


### PR DESCRIPTION
Foundation slice for the "Le salon Discord EST le groupe" feature landed
at the 2026-04-14 design meeting (decisions C1-C4, D13, D16).

Schema (migration 20260414_b_discord_group_unification):
- groups.archived_at for soft-archive on GUILD_DELETE / channel removal
- group_bans persistent blocklist, dual-keyed on user_id and discord_id
  so a ban survives users who haven't yet materialised a WAWPTN account
- discord_auth_intents short-lived one-shot nonces for the magic-link flow

Domain (discord-auth-intent.ts):
- createDiscordAuthIntent, findLiveDiscordAuthIntent, consumeDiscordAuthIntent
- isBannedFromGroup (used by both join paths)
- materializeGroupForIntent: upsert discord_links, find-or-create the
  group for the channel, run the ban check, insert group_members, emit
  member:joined on the existing group:\${id} socket room

Auth routes (auth.routes.ts):
- GET /api/auth/discord/intent/:nonce parks the nonce in a signed cookie
  and bounces through Steam OpenID; fast-path for users with a live
  session that skips Steam entirely
- Steam callback now consumes the parked intent post-login and redirects
  straight to /groups/:id

Discord bot-auth routes (discord.routes.ts):
- New POST /api/discord/intent issued by the bot on /wawptn setup
- Removed premium gate from POST /api/discord/setup per decision C4
  (channel binding is now base product, not premium)

Group routes (group.routes.ts):
- Invite /join flow now checks group_bans (decision D16: kick = ban)
  and ignores archived groups

Follow-ups intentionally deferred: bot slash command wiring, frontend
identity badge + activity feed, premium tier reshuffle (tracked in #143).