### PR TITLE
feat(premium): tier reshuffle for Discord-first product

### DIFF
--- a/packages/backend/src/domain/subscription-service.ts
+++ b/packages/backend/src/domain/subscription-service.ts
@@ -1,14 +1,24 @@
 import { db } from '../infrastructure/database/connection.js'
 
-/** Tier limits for free users */
+/** Tier limits for free users.
+ *
+ * Raised on 2026-04-14 alongside the "Le salon Discord EST le groupe"
+ * feature (decision C2: implicit enrollment from Discord channel
+ * presence means typical group sizes float up beyond invite-link era).
+ * Free tier now comfortably covers a Discord-native friend group who
+ * bind one channel per crew. */
 export const FREE_TIER_LIMITS = {
-  maxGroups: 2,
-  maxMembersPerGroup: 8,
+  maxGroups: 3,
+  maxMembersPerGroup: 10,
 } as const
 
-/** Tier limits for premium users */
+/** Tier limits for premium users.
+ *
+ * Member cap raised 20 → 30 on 2026-04-14 for the same reason as
+ * FREE_TIER_LIMITS above. Premium groups (multi-channel broadcasts,
+ * auto-vote cron) skew toward larger, more active communities. */
 export const PREMIUM_TIER_LIMITS = {
-  maxMembersPerGroup: 20,
+  maxMembersPerGroup: 30,
 } as const
 
 /** In-memory cache for premium status with TTL */

--- a/packages/backend/src/presentation/routes/discord.routes.ts
+++ b/packages/backend/src/presentation/routes/discord.routes.ts
@@ -1106,7 +1106,17 @@ userRouter.delete('/link', requireAuth, async (req: Request, res: Response) => {
   res.json({ ok: true, wasLinked: deleted > 0 })
 })
 
-// Set webhook URL for a group (group owner only)
+// Set the primary webhook URL for a group (group owner only).
+//
+// The primary webhook is what the bot uses to post vote result
+// announcements back into the bound Discord channel. It is now part of
+// the base product (free) because without it the "Le salon Discord EST
+// le groupe" experience silently breaks: a user binds a channel, votes
+// close, and nothing ever appears in the channel. See design meeting
+// decision C4 (2026-04-14) and issue #143 for the tier reshuffle
+// rationale. Multi-channel broadcasting via `group_announcement_webhooks`
+// remains premium — this free tier only covers ONE webhook per group,
+// enforced by the single `discord_webhook_url` column on `groups`.
 userRouter.post('/webhook', requireAuth, async (req: Request, res: Response) => {
   const userId = req.userId!
   const { groupId, webhookUrl } = req.body as { groupId: string; webhookUrl: string }
@@ -1122,13 +1132,6 @@ userRouter.post('/webhook', requireAuth, async (req: Request, res: Response) => 
 
   if (!membership) {
     res.status(403).json({ error: 'forbidden', message: 'Only group owners can set the webhook URL' })
-    return
-  }
-
-  // Discord webhook requires premium
-  const premium = await isUserPremium(userId)
-  if (!premium) {
-    res.status(403).json({ error: 'premium_required', message: 'Discord webhook requires a premium subscription' })
     return
   }
 


### PR DESCRIPTION
Resolves #143. Closes the revenue gap opened by #144 (Discord channel binding moved to free tier in the "Le salon Discord EST le groupe" feature) by moving one leaky gate to free and raising the implicit-enrollment caps that now flow through Discord channel presence.

## Summary

- **Primary Discord webhook moved to FREE** (`discord.routes.ts` `/webhook`). Without this, a free user could bind a channel but never see vote results posted in it — silently breaking the C4 promise. Multi-channel broadcasting via `group_announcement_webhooks` stays premium.
- **Tier limit bumps** in `subscription-service.ts`:
  - `FREE_TIER_LIMITS.maxGroups` 2 → 3
  - `FREE_TIER_LIMITS.maxMembersPerGroup` 8 → 10
  - `PREMIUM_TIER_LIMITS.maxMembersPerGroup` 20 → 30
- **Rationale**: decision C2 makes Discord channel presence the source of membership, which pushes average group sizes up vs. the invite-link era that set the original caps. Bumping both tiers preserves the paywall position while reducing friction for the Discord-native acquisition funnel.

## Unchanged (still premium)

Correctness preserved — these walls remain in place:
- Unlimited groups beyond cap
- Auto-vote cron scheduling (`PATCH /groups/:id/auto-vote`)
- Scheduled voting (`POST /votes` with `scheduledAt`)
- AI game recommendations (`GET /groups/:id/recommendations`)
- Daily challenge via bot (`isGroupOwnerPremium` on `/daily-challenge`)
- LLM chat via bot (`isGroupOwnerPremium` on `/chat`)
- Extra announcement webhooks (`group_announcement_webhooks`, max 5)

## Test plan

- [ ] Non-premium user can POST to `/api/discord/webhook` and receive `{ ok: true }` (previously 403 `premium_required`).
- [ ] Non-premium user can own up to 3 groups; the 4th returns `premium_required`.
- [ ] Non-premium group owner can accept up to 10 members; the 11th join attempt returns `premium_required`.
- [ ] Premium group owner can accept up to 30 members; the 31st returns `member_limit`.
- [ ] Auto-vote cron endpoint still returns `premium_required` for non-premium users.
- [ ] Scheduled vote creation still returns `premium_required` for non-premium users.
- [ ] Announcement webhook CRUD endpoints still return `premium_required` for non-premium users.

## Notes

- Force-with-lease push was required because this branch was rebased onto main after #144 squash-merged. Old commit `7b01f29` content is fully preserved in main as `82a8208`; nothing lost.
- The `isUserPremium` import in `discord.routes.ts` is still used by the `isGroupOwnerPremium` helper for the daily-challenge and chat endpoints — intentionally not removed.