### PR TITLE
feat(persona): scope persona du jour per-group instead of app-wide

### DIFF
--- a/packages/backend/migrations/20260415_add_group_persona_settings.ts
+++ b/packages/backend/migrations/20260415_add_group_persona_settings.ts
@@ -1,0 +1,44 @@
+import type { Knex } from 'knex'
+
+/**
+ * Per-group daily persona settings.
+ *
+ * Before this migration the "persona du jour" was a global singleton: one
+ * persona was hashed from the Paris date and shown to every group, every
+ * channel, everywhere. This table moves persona selection to a per-group
+ * concern — each group can now have its own rotation, its own disabled
+ * list, and its own override. The global `bot.*` rows in `app_settings`
+ * remain as a fallback layer so existing groups keep working with zero
+ * backfill (missing rows = use global defaults).
+ *
+ * The table is 1:1 with `groups` (group_id is primary key) and rows are
+ * created lazily on first write. The shared `personas` pool stays global.
+ */
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('group_persona_settings', (table) => {
+    table
+      .uuid('group_id')
+      .primary()
+      .references('id')
+      .inTable('groups')
+      .onDelete('CASCADE')
+    // When null, the group inherits bot.persona_rotation_enabled.
+    table.boolean('rotation_enabled').nullable()
+    // Persona ids excluded from the group's rotation. Merged with the
+    // global bot.disabled_personas list at read time.
+    table
+      .specificType('disabled_personas', 'text[]')
+      .notNullable()
+      .defaultTo('{}')
+    // Hard override: when set and not expired, the group always uses this
+    // persona regardless of the daily hash. Null = no override.
+    table.string('persona_override', 50).nullable()
+    table.timestamp('override_expires_at', { useTz: true }).nullable()
+    table.timestamp('created_at', { useTz: true }).defaultTo(knex.fn.now())
+    table.timestamp('updated_at', { useTz: true }).defaultTo(knex.fn.now())
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists('group_persona_settings')
+}

--- a/packages/backend/src/domain/persona-selection.ts
+++ b/packages/backend/src/domain/persona-selection.ts
@@ -1,0 +1,316 @@
+import { db } from '../infrastructure/database/connection.js'
+
+/**
+ * Daily persona selection — per group.
+ *
+ * Each group has its own deterministic "persona du jour" derived from
+ * `djb2("${YYYY-MM-DD}:${groupId}")`. The selection layers over three
+ * fallback levels in priority order:
+ *
+ *   1. Group override (`group_persona_settings.persona_override`)
+ *   2. Global override (`app_settings.bot.persona_override`)
+ *   3. Deterministic daily hash of the group's filtered persona pool
+ *
+ * When the group has no row in `group_persona_settings`, it silently
+ * inherits the global `bot.*` defaults — existing groups keep working
+ * with zero backfill. The shared `personas` table stays global.
+ *
+ * The cache is keyed on `(parisDate, groupId)` and lives as long as the
+ * Paris day does: when the date string changes, all stale entries are
+ * garbage-collected on the next read. That gives us sub-millisecond hits
+ * on the steady state and a clean cutover at midnight without any cron.
+ */
+
+export interface DailyPersona {
+  id: string
+  name: string
+  embedColor: number
+  introMessage: string
+}
+
+interface PersonaRow {
+  id: string
+  name: string
+  embed_color: number
+  intro_message: string
+  is_active: boolean
+  created_at: Date
+}
+
+/**
+ * djb2 string hash — deterministic, same as packages/discord/src/personas.ts
+ * and packages/backend legacy route. Keep all three call sites in lockstep
+ * so the backend, Discord bot, and future consumers always pick the same
+ * persona for the same (date, groupId).
+ */
+export function hashCode(str: string): number {
+  let hash = 5381
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) + hash + str.charCodeAt(i)) | 0
+  }
+  return Math.abs(hash)
+}
+
+/**
+ * Canonical selection key shared by the backend and the Discord bot.
+ * Pass `null` as the groupId for the global/app-wide fallback (used by
+ * the legacy `/api/persona/current` endpoint).
+ */
+export function selectionKey(dateStr: string, groupId: string | null): string {
+  return groupId ? `${dateStr}:${groupId}` : dateStr
+}
+
+/** Returns the current Paris-local date as YYYY-MM-DD. */
+export function parisDate(now: Date = new Date()): string {
+  return now.toLocaleDateString('en-CA', { timeZone: 'Europe/Paris' })
+}
+
+// ─── Cache ────────────────────────────────────────────────────────────────
+
+interface CacheEntry {
+  date: string
+  persona: DailyPersona
+}
+
+const personaCache = new Map<string, CacheEntry>()
+
+function pruneStale(today: string): void {
+  // Lazy prune: when today's date differs from a cached entry's date, drop
+  // the entry. Keeps memory bounded in O(groups) and avoids a cron job.
+  for (const [key, entry] of personaCache) {
+    if (entry.date !== today) personaCache.delete(key)
+  }
+}
+
+/**
+ * Drop cached entries for a specific group. Call after a PATCH to
+ * `/groups/:id/persona-settings` so the next read reflects the new
+ * override / disabled list immediately.
+ */
+export function invalidateGroupPersonaCache(groupId: string | null): void {
+  const suffix = groupId ? `:${groupId}` : ''
+  for (const key of personaCache.keys()) {
+    if (groupId === null ? !key.includes(':') : key.endsWith(suffix)) {
+      personaCache.delete(key)
+    }
+  }
+}
+
+// ─── App-settings helpers ────────────────────────────────────────────────
+
+interface GlobalDefaults {
+  rotationEnabled: boolean
+  disabledIds: string[]
+  overrideId: string | null
+}
+
+async function loadGlobalDefaults(): Promise<GlobalDefaults> {
+  const rows = await db('app_settings')
+    .whereIn('key', [
+      'bot.persona_rotation_enabled',
+      'bot.disabled_personas',
+      'bot.persona_override',
+    ])
+    .select('key', 'value')
+
+  let rotationEnabled = true
+  let disabledIds: string[] = []
+  let overrideId: string | null = null
+
+  for (const row of rows as Array<{ key: string; value: unknown }>) {
+    if (row.key === 'bot.persona_rotation_enabled') {
+      rotationEnabled = row.value === true
+    } else if (row.key === 'bot.disabled_personas') {
+      disabledIds = Array.isArray(row.value) ? (row.value as string[]) : []
+    } else if (row.key === 'bot.persona_override') {
+      overrideId = typeof row.value === 'string' && row.value ? row.value : null
+    }
+  }
+
+  return { rotationEnabled, disabledIds, overrideId }
+}
+
+interface GroupSettingsRow {
+  rotation_enabled: boolean | null
+  disabled_personas: string[] | null
+  persona_override: string | null
+  override_expires_at: Date | null
+}
+
+async function loadGroupSettings(groupId: string): Promise<GroupSettingsRow | null> {
+  const row = await db('group_persona_settings')
+    .where({ group_id: groupId })
+    .first<GroupSettingsRow>()
+  return row ?? null
+}
+
+// ─── Core selection ──────────────────────────────────────────────────────
+
+function pickFromPool(pool: PersonaRow[], key: string): PersonaRow {
+  const index = hashCode(key) % pool.length
+  return pool[index]!
+}
+
+function toDailyPersona(row: PersonaRow): DailyPersona {
+  return {
+    id: row.id,
+    name: row.name,
+    embedColor: row.embed_color,
+    introMessage: row.intro_message,
+  }
+}
+
+/**
+ * Resolves the persona of the day for a specific group. Pass `null` for
+ * the global fallback persona (used by the deprecated top-level endpoint).
+ */
+export async function selectPersonaForGroup(
+  groupId: string | null,
+  now: Date = new Date(),
+): Promise<DailyPersona | null> {
+  const dateStr = parisDate(now)
+  const cacheKey = selectionKey(dateStr, groupId)
+
+  const cached = personaCache.get(cacheKey)
+  if (cached && cached.date === dateStr) {
+    return cached.persona
+  }
+  pruneStale(dateStr)
+
+  const [personas, globals, groupSettings] = await Promise.all([
+    db('personas')
+      .where({ is_active: true })
+      .orderBy('created_at', 'asc')
+      .select<PersonaRow[]>('id', 'name', 'embed_color', 'intro_message', 'is_active', 'created_at'),
+    loadGlobalDefaults(),
+    groupId ? loadGroupSettings(groupId) : Promise.resolve(null),
+  ])
+
+  if (personas.length === 0) return null
+
+  // Resolve effective settings (group overrides global, nullish inherits).
+  const rotationEnabled =
+    groupSettings?.rotation_enabled ?? globals.rotationEnabled
+  const disabledIds = new Set<string>([
+    ...globals.disabledIds,
+    ...(groupSettings?.disabled_personas ?? []),
+  ])
+  const overrideExpired =
+    groupSettings?.override_expires_at != null &&
+    groupSettings.override_expires_at.getTime() < now.getTime()
+  const groupOverride =
+    groupSettings?.persona_override && !overrideExpired
+      ? groupSettings.persona_override
+      : null
+  const effectiveOverride = groupOverride ?? globals.overrideId
+
+  let selected: PersonaRow | undefined
+
+  // 1. Override (group > global)
+  if (effectiveOverride) {
+    selected = personas.find((p) => p.id === effectiveOverride)
+  }
+
+  // 2. Rotation disabled → default persona (first active)
+  if (!selected && !rotationEnabled) {
+    selected = personas[0]
+  }
+
+  // 3. Deterministic daily hash on the filtered pool
+  if (!selected) {
+    const available = personas.filter((p) => !disabledIds.has(p.id))
+    const pool = available.length > 0 ? available : personas
+    selected = pickFromPool(pool, cacheKey)
+  }
+
+  if (!selected) return null
+
+  const persona = toDailyPersona(selected)
+  personaCache.set(cacheKey, { date: dateStr, persona })
+  return persona
+}
+
+/**
+ * Batch helper used by `GET /api/groups` to enrich the list response with
+ * `todayPersona` in a single pass without triggering N+1 DB reads. All
+ * groups share the same `personas`/`app_settings` fetch, and only the
+ * per-group `group_persona_settings` rows are fetched in bulk.
+ */
+export async function selectPersonasForGroups(
+  groupIds: string[],
+  now: Date = new Date(),
+): Promise<Map<string, DailyPersona>> {
+  const result = new Map<string, DailyPersona>()
+  if (groupIds.length === 0) return result
+
+  const dateStr = parisDate(now)
+  const uncached: string[] = []
+  for (const gid of groupIds) {
+    const hit = personaCache.get(selectionKey(dateStr, gid))
+    if (hit && hit.date === dateStr) {
+      result.set(gid, hit.persona)
+    } else {
+      uncached.push(gid)
+    }
+  }
+  if (uncached.length === 0) return result
+  pruneStale(dateStr)
+
+  const [personas, globals, groupRows] = await Promise.all([
+    db('personas')
+      .where({ is_active: true })
+      .orderBy('created_at', 'asc')
+      .select<PersonaRow[]>('id', 'name', 'embed_color', 'intro_message', 'is_active', 'created_at'),
+    loadGlobalDefaults(),
+    db('group_persona_settings')
+      .whereIn('group_id', uncached)
+      .select<Array<GroupSettingsRow & { group_id: string }>>(
+        'group_id',
+        'rotation_enabled',
+        'disabled_personas',
+        'persona_override',
+        'override_expires_at',
+      ),
+  ])
+  if (personas.length === 0) return result
+
+  const settingsByGroup = new Map<string, GroupSettingsRow>()
+  for (const row of groupRows) {
+    settingsByGroup.set(row.group_id, row)
+  }
+
+  for (const gid of uncached) {
+    const gs = settingsByGroup.get(gid) ?? null
+    const rotationEnabled = gs?.rotation_enabled ?? globals.rotationEnabled
+    const disabledIds = new Set<string>([
+      ...globals.disabledIds,
+      ...(gs?.disabled_personas ?? []),
+    ])
+    const overrideExpired =
+      gs?.override_expires_at != null &&
+      gs.override_expires_at.getTime() < now.getTime()
+    const groupOverride =
+      gs?.persona_override && !overrideExpired ? gs.persona_override : null
+    const effectiveOverride = groupOverride ?? globals.overrideId
+
+    let selected: PersonaRow | undefined
+    if (effectiveOverride) {
+      selected = personas.find((p) => p.id === effectiveOverride)
+    }
+    if (!selected && !rotationEnabled) {
+      selected = personas[0]
+    }
+    if (!selected) {
+      const available = personas.filter((p) => !disabledIds.has(p.id))
+      const pool = available.length > 0 ? available : personas
+      selected = pickFromPool(pool, selectionKey(dateStr, gid))
+    }
+    if (!selected) continue
+
+    const persona = toDailyPersona(selected)
+    personaCache.set(selectionKey(dateStr, gid), { date: dateStr, persona })
+    result.set(gid, persona)
+  }
+
+  return result
+}

--- a/packages/backend/src/presentation/routes/discord.routes.ts
+++ b/packages/backend/src/presentation/routes/discord.routes.ts
@@ -815,17 +815,50 @@ router.get('/bot-settings', async (_req: Request, res: Response) => {
   res.json(settings)
 })
 
-// Get all Discord channels linked to a group (for scheduled messages)
+// Get all Discord channels linked to a group (for scheduled messages).
+// Each entry now carries `groupId` + per-group persona settings so the bot
+// can compute the correct "persona du jour" per channel: one persona pick
+// per group, not one globally shared persona for every linked server.
 router.get('/linked-channels', async (_req: Request, res: Response) => {
   const channels = await db('groups')
-    .whereNotNull('discord_channel_id')
+    .leftJoin('group_persona_settings', 'group_persona_settings.group_id', 'groups.id')
+    .whereNotNull('groups.discord_channel_id')
     .select(
-      'discord_channel_id as channelId',
-      'discord_guild_id as guildId',
-      'name as groupName',
+      'groups.id as groupId',
+      'groups.discord_channel_id as channelId',
+      'groups.discord_guild_id as guildId',
+      'groups.name as groupName',
+      'group_persona_settings.rotation_enabled as rotationEnabled',
+      'group_persona_settings.disabled_personas as disabledPersonas',
+      'group_persona_settings.persona_override as personaOverride',
+      'group_persona_settings.override_expires_at as overrideExpiresAt',
     )
 
-  res.json(channels)
+  res.json(
+    channels.map((c: {
+      groupId: string
+      channelId: string
+      guildId: string | null
+      groupName: string
+      rotationEnabled: boolean | null
+      disabledPersonas: string[] | null
+      personaOverride: string | null
+      overrideExpiresAt: Date | string | null
+    }) => ({
+      groupId: c.groupId,
+      channelId: c.channelId,
+      guildId: c.guildId,
+      groupName: c.groupName,
+      personaSettings: {
+        rotationEnabled: c.rotationEnabled,
+        disabledPersonas: c.disabledPersonas ?? [],
+        personaOverride: c.personaOverride,
+        overrideExpiresAt: c.overrideExpiresAt
+          ? new Date(c.overrideExpiresAt).toISOString()
+          : null,
+      },
+    })),
+  )
 })
 
 // ─── Per-guild bot config overrides (Tom #2) ──────────────────────────────

--- a/packages/backend/src/presentation/routes/group.routes.ts
+++ b/packages/backend/src/presentation/routes/group.routes.ts
@@ -10,6 +10,12 @@ import { logger } from '../../infrastructure/logger/logger.js'
 import { isUserPremium, FREE_TIER_LIMITS, PREMIUM_TIER_LIMITS } from '../middleware/tier.middleware.js'
 import { requireGroupMembership } from '../middleware/group-membership.middleware.js'
 import { isBannedFromGroup } from '../../domain/discord-auth-intent.js'
+import {
+  selectPersonaForGroup,
+  selectPersonasForGroups,
+  invalidateGroupPersonaCache,
+  parisDate,
+} from '../../domain/persona-selection.js'
 
 const router = Router()
 
@@ -72,6 +78,10 @@ router.get('/', async (req: Request, res: Response) => {
     })
   )
 
+  // Enrich with each group's "persona du jour" — computed in a single
+  // batch so the list page doesn't need an N+1 cascade of follow-up calls.
+  const personaMap = await selectPersonasForGroups(groupIds)
+
   res.json(groups.map(g => ({
     id: g.id,
     name: g.name,
@@ -86,6 +96,7 @@ router.get('/', async (req: Request, res: Response) => {
           closedAt: lastSessionMap.get(g.id)!.closed_at,
         }
       : null,
+    todayPersona: personaMap.get(g.id) || null,
   })))
 })
 
@@ -113,6 +124,8 @@ router.get('/:id', requireGroupMembership(), async (req: Request, res: Response)
       'group_members.notifications_enabled as notificationsEnabled'
     )
 
+  const todayPersona = await selectPersonaForGroup(groupId)
+
   res.json({
     id: group.id,
     name: group.name,
@@ -122,6 +135,131 @@ router.get('/:id', requireGroupMembership(), async (req: Request, res: Response)
     autoVoteDurationMinutes: group.auto_vote_duration_minutes || 120,
     createdAt: group.created_at,
     members,
+    todayPersona,
+  })
+})
+
+// GET /api/groups/:id/persona/current — group's current "persona du jour".
+// Public to any group member. Drives the per-group PersonaBadge on the
+// groups list and the hero on the group detail page.
+router.get('/:id/persona/current', requireGroupMembership(), async (req: Request, res: Response) => {
+  try {
+    const groupId = String(req.params['id'])
+    const persona = await selectPersonaForGroup(groupId)
+
+    if (!persona) {
+      res.status(404).json({ error: 'not_found', message: 'No active personas' })
+      return
+    }
+
+    res.json({ persona, date: parisDate() })
+  } catch (error) {
+    logger.error({ error: String(error), groupId: req.params['id'] }, 'group persona: failed to get current')
+    res.status(500).json({ error: 'internal', message: 'Failed to get group persona' })
+  }
+})
+
+// GET /api/groups/:id/persona-settings — returns the effective per-group
+// overrides (rows are lazy-created so missing rows return defaults).
+router.get('/:id/persona-settings', requireGroupMembership(), async (req: Request, res: Response) => {
+  const groupId = String(req.params['id'])
+  const row = await db('group_persona_settings').where({ group_id: groupId }).first()
+  res.json({
+    groupId,
+    rotationEnabled: row?.rotation_enabled ?? null,
+    disabledPersonas: (row?.disabled_personas as string[] | null) ?? [],
+    personaOverride: row?.persona_override ?? null,
+    overrideExpiresAt: row?.override_expires_at ? new Date(row.override_expires_at).toISOString() : null,
+  })
+})
+
+// PATCH /api/groups/:id/persona-settings — owner-only. Creates the row
+// lazily on first write and invalidates the per-group cache so the next
+// read picks up the change immediately. Emits `persona:changed` on the
+// group room so connected clients refresh their badge in real time.
+router.patch('/:id/persona-settings', requireGroupMembership({ role: 'owner' }), async (req: Request, res: Response) => {
+  const userId = req.userId!
+  const groupId = String(req.params['id'])
+  const { rotationEnabled, disabledPersonas, personaOverride, overrideExpiresAt } = req.body as {
+    rotationEnabled?: boolean | null
+    disabledPersonas?: string[]
+    personaOverride?: string | null
+    overrideExpiresAt?: string | null
+  }
+
+  // Validate disabled list shape
+  if (disabledPersonas !== undefined && !Array.isArray(disabledPersonas)) {
+    res.status(400).json({ error: 'validation', message: 'disabledPersonas must be an array of persona ids' })
+    return
+  }
+  if (
+    disabledPersonas !== undefined &&
+    disabledPersonas.some((id) => typeof id !== 'string' || id.length === 0 || id.length > 50)
+  ) {
+    res.status(400).json({ error: 'validation', message: 'disabledPersonas entries must be non-empty persona ids' })
+    return
+  }
+
+  // Validate override references a real persona id
+  if (personaOverride !== undefined && personaOverride !== null) {
+    if (typeof personaOverride !== 'string' || personaOverride.length === 0 || personaOverride.length > 50) {
+      res.status(400).json({ error: 'validation', message: 'personaOverride must be a persona id or null' })
+      return
+    }
+    const exists = await db('personas').where({ id: personaOverride, is_active: true }).first()
+    if (!exists) {
+      res.status(400).json({ error: 'validation', message: 'personaOverride must reference an active persona' })
+      return
+    }
+  }
+
+  let expiresAt: Date | null | undefined
+  if (overrideExpiresAt !== undefined) {
+    if (overrideExpiresAt === null) {
+      expiresAt = null
+    } else {
+      const parsed = new Date(overrideExpiresAt)
+      if (Number.isNaN(parsed.getTime())) {
+        res.status(400).json({ error: 'validation', message: 'overrideExpiresAt must be an ISO 8601 date or null' })
+        return
+      }
+      expiresAt = parsed
+    }
+  }
+
+  const patch: Record<string, unknown> = { updated_at: db.fn.now() }
+  if (rotationEnabled !== undefined) patch['rotation_enabled'] = rotationEnabled
+  if (disabledPersonas !== undefined) patch['disabled_personas'] = disabledPersonas
+  if (personaOverride !== undefined) patch['persona_override'] = personaOverride
+  if (expiresAt !== undefined) patch['override_expires_at'] = expiresAt
+
+  // Upsert: insert if missing, update otherwise
+  await db('group_persona_settings')
+    .insert({ group_id: groupId, ...patch })
+    .onConflict('group_id')
+    .merge(patch)
+
+  invalidateGroupPersonaCache(groupId)
+
+  // Notify connected members so their badge refreshes instantly
+  const persona = await selectPersonaForGroup(groupId)
+  if (persona) {
+    getIO().to(`group:${groupId}`).emit('persona:changed', {
+      groupId,
+      persona,
+      date: parisDate(),
+      reason: 'settings',
+    })
+  }
+
+  logger.info({ userId, groupId, patch }, 'group persona settings updated')
+  res.json({
+    groupId,
+    rotationEnabled: rotationEnabled ?? null,
+    disabledPersonas: disabledPersonas ?? [],
+    personaOverride: personaOverride ?? null,
+    overrideExpiresAt: expiresAt ? expiresAt.toISOString() : null,
+    todayPersona: persona,
   })
 })
 

--- a/packages/backend/src/presentation/routes/persona.routes.ts
+++ b/packages/backend/src/presentation/routes/persona.routes.ts
@@ -1,103 +1,36 @@
 import { Router, type Request, type Response } from 'express'
-import { db } from '../../infrastructure/database/connection.js'
 import { logger } from '../../infrastructure/logger/logger.js'
+import { selectPersonaForGroup } from '../../domain/persona-selection.js'
 
 const router = Router()
 
-// In-memory cache (persona changes at most once per day)
-let cachedPersona: { id: string; name: string; embedColor: number; introMessage: string } | null = null
-let cacheExpiry = 0
-
 /**
- * djb2 string hash — deterministic, same as packages/discord/src/personas.ts.
- * Keep in sync with the Discord bot's hashCode function.
+ * GET /api/persona/current — public, returns the global fallback persona
+ * for the app (used on the login/landing page and anywhere no group
+ * context exists).
+ *
+ * **Deprecated.** Per-group personas are the new canonical source — each
+ * group now has its own daily persona reachable at
+ * `GET /api/groups/:groupId/persona/current`. This endpoint is kept for
+ * backward compatibility with the landing page and signals its status via
+ * a `Deprecation` + `Sunset` header (RFC 8594).
  */
-function hashCode(str: string): number {
-  let hash = 5381
-  for (let i = 0; i < str.length; i++) {
-    hash = ((hash << 5) + hash + str.charCodeAt(i)) | 0
-  }
-  return Math.abs(hash)
-}
-
-// GET /api/persona/current — public, returns today's active persona
 router.get('/current', async (_req: Request, res: Response) => {
   try {
-    const now = Date.now()
-    if (cachedPersona && now < cacheExpiry) {
-      res.json(cachedPersona)
-      return
-    }
+    const persona = await selectPersonaForGroup(null)
 
-    // Check for admin persona override
-    const overrideSetting = await db('app_settings')
-      .where({ key: 'bot.persona_override' })
-      .select('value')
-      .first()
-    const overrideId: string | null = typeof overrideSetting?.value === 'string' && overrideSetting.value
-      ? overrideSetting.value
-      : null
-
-    // Check if rotation is enabled
-    const rotationSetting = await db('app_settings')
-      .where({ key: 'bot.persona_rotation_enabled' })
-      .select('value')
-      .first()
-    const rotationEnabled = rotationSetting?.value === true
-
-    // Get disabled personas list
-    const disabledSetting = await db('app_settings')
-      .where({ key: 'bot.disabled_personas' })
-      .select('value')
-      .first()
-    const disabledIds: string[] = Array.isArray(disabledSetting?.value) ? disabledSetting.value : []
-
-    // Fetch active personas
-    const personas = await db('personas')
-      .where({ is_active: true })
-      .orderBy('created_at', 'asc')
-      .select('id', 'name', 'embed_color', 'intro_message')
-
-    if (personas.length === 0) {
+    if (!persona) {
       res.status(404).json({ error: 'not_found', message: 'No active personas' })
       return
     }
 
-    let selected
-
-    // Admin override takes priority
-    if (overrideId) {
-      const overridePersona = personas.find((p: { id: string }) => p.id === overrideId)
-      if (overridePersona) {
-        selected = overridePersona
-      }
-    }
-
-    if (!selected && !rotationEnabled) {
-      // No rotation: use first active persona (default)
-      selected = personas[0]
-    } else if (!selected) {
-      // Filter out disabled personas
-      const available = disabledIds.length > 0
-        ? personas.filter((p: { id: string }) => !disabledIds.includes(p.id))
-        : personas
-      const pool = available.length > 0 ? available : personas
-
-      // Deterministic selection based on date (Europe/Paris timezone)
-      const dateStr = new Date().toLocaleDateString('en-CA', { timeZone: 'Europe/Paris' })
-      const index = hashCode(dateStr) % pool.length
-      selected = pool[index]
-    }
-
-    cachedPersona = {
-      id: selected.id,
-      name: selected.name,
-      embedColor: selected.embed_color,
-      introMessage: selected.intro_message,
-    }
-    cacheExpiry = now + 5 * 60 * 1000 // 5 minutes
-
-    res.json(cachedPersona)
+    res.setHeader('Deprecation', 'true')
+    res.setHeader('Sunset', 'Wed, 31 Dec 2026 23:59:59 GMT')
+    res.setHeader(
+      'Link',
+      '</api/groups/{groupId}/persona/current>; rel="successor-version"',
+    )
+    res.json(persona)
   } catch (error) {
     logger.error({ error: String(error) }, 'persona: failed to get current')
     res.status(500).json({ error: 'internal', message: 'Failed to get current persona' })

--- a/packages/discord/src/lib/api.ts
+++ b/packages/discord/src/lib/api.ts
@@ -32,13 +32,29 @@ export async function backendApi<T>(path: string, options: ApiOptions = {}): Pro
   return res.json() as Promise<T>
 }
 
+/**
+ * Per-group persona overrides shipped alongside each linked channel. When
+ * a field is null/empty, the group inherits the global bot.* defaults.
+ */
+export interface GroupPersonaOverrides {
+  rotationEnabled: boolean | null
+  disabledPersonas: string[]
+  personaOverride: string | null
+  overrideExpiresAt: string | null
+}
+
 export interface LinkedChannel {
+  /** Backend group UUID — the selection key for the per-group persona
+   * hash. Always present on fresh rows; older rows that predate the
+   * per-group persona refactor may be missing if the group was deleted. */
+  groupId: string
   channelId: string
   /** Discord guild (server) ID — used by the per-guild scheduler to
    * route each channel through its own cron. Nullable for legacy rows
    * inserted before the backend started storing the guild id. */
   guildId: string | null
   groupName: string
+  personaSettings: GroupPersonaOverrides
 }
 
 export async function getLinkedChannels(): Promise<LinkedChannel[]> {

--- a/packages/discord/src/personas.ts
+++ b/packages/discord/src/personas.ts
@@ -417,6 +417,9 @@ function hashCode(str: string): number {
  * Uses Europe/Paris timezone so the persona changes at midnight local time.
  * Uses API-loaded personas if available, falls back to hardcoded.
  * Filters out disabled personas if provided.
+ *
+ * Global / app-wide fallback — prefer `getTodayPersonaForGroup` when a
+ * group context is available so each group gets its own persona.
  */
 export function getTodayPersona(disabledIds: string[] = []): Persona {
   const pool = getPersonaPool()
@@ -426,6 +429,43 @@ export function getTodayPersona(disabledIds: string[] = []): Persona {
   const finalPool = available.length > 0 ? available : pool // fallback if all disabled
   const dateStr = new Date().toLocaleDateString('en-CA', { timeZone: 'Europe/Paris' }) // YYYY-MM-DD
   const index = hashCode(dateStr) % finalPool.length
+  return finalPool[index]!
+}
+
+/**
+ * Returns today's persona for a specific group. The selection key is
+ * `${YYYY-MM-DD}:${groupId}` so each group draws its own deterministic
+ * persona from the shared pool — exactly matching the backend hash in
+ * `packages/backend/src/domain/persona-selection.ts`.
+ *
+ * Override priority: explicit `override` arg > rotation disabled (default
+ * persona) > filtered hash pick. If `rotationEnabled === false` the group
+ * always sees the default persona (index 0).
+ */
+export function getTodayPersonaForGroup(
+  groupId: string,
+  opts: {
+    disabledIds?: string[]
+    rotationEnabled?: boolean | null
+    override?: string | null
+  } = {},
+): Persona {
+  const pool = getPersonaPool()
+  if (opts.override) {
+    const forced = pool.find(p => p.id === opts.override)
+    if (forced) return forced
+  }
+  if (opts.rotationEnabled === false) {
+    return pool[0]!
+  }
+  const disabled = opts.disabledIds ?? []
+  const available = disabled.length > 0
+    ? pool.filter(p => !disabled.includes(p.id))
+    : pool
+  const finalPool = available.length > 0 ? available : pool
+  const dateStr = new Date().toLocaleDateString('en-CA', { timeZone: 'Europe/Paris' })
+  const key = `${dateStr}:${groupId}`
+  const index = hashCode(key) % finalPool.length
   return finalPool[index]!
 }
 

--- a/packages/discord/src/scheduler.ts
+++ b/packages/discord/src/scheduler.ts
@@ -7,7 +7,14 @@ import {
   type BotSettings,
   type LinkedChannel,
 } from './lib/api.js'
-import { getTodayPersona, getDefaultPersona, getPersonaById, loadPersonasFromApi, startPersonaCacheRefresh } from './personas.js'
+import {
+  getTodayPersona,
+  getTodayPersonaForGroup,
+  getDefaultPersona,
+  getPersonaById,
+  loadPersonasFromApi,
+  startPersonaCacheRefresh,
+} from './personas.js'
 
 // ─── State ────────────────────────────────────────────────────────────────────
 
@@ -43,6 +50,40 @@ function getPersona() {
   return getTodayPersona(disabled)
 }
 
+/**
+ * Per-group variant: layers the group's own overrides on top of the
+ * global bot settings. Each group draws its own deterministic persona
+ * from the shared pool via `djb2("${date}:${groupId}")`. Mirrors the
+ * backend's `selectPersonaForGroup` exactly so both ends always pick
+ * the same persona for the same group on the same day.
+ */
+function getPersonaForChannel(channel: LinkedChannel) {
+  const globalOverride = currentSettings?.persona_override || null
+  const groupOverride = channel.personaSettings.personaOverride || null
+  const effectiveOverride = groupOverride ?? globalOverride
+  if (effectiveOverride) {
+    const forced = getPersonaById(effectiveOverride)
+    if (forced) return forced
+  }
+
+  const rotationEnabled =
+    channel.personaSettings.rotationEnabled ??
+    currentSettings?.persona_rotation_enabled ??
+    true
+  if (!rotationEnabled) {
+    return getDefaultPersona()
+  }
+
+  const disabled = new Set<string>([
+    ...(currentSettings?.disabled_personas ?? []),
+    ...(channel.personaSettings.disabledPersonas ?? []),
+  ])
+  return getTodayPersonaForGroup(channel.groupId, {
+    disabledIds: Array.from(disabled),
+    rotationEnabled: true,
+  })
+}
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function pickRandom(pool: string[]): string {
@@ -51,6 +92,17 @@ function pickRandom(pool: string[]): string {
 
 function buildReminderEmbed(message: string): EmbedBuilder {
   const persona = getPersona()
+  return new EmbedBuilder()
+    .setDescription(message)
+    .setColor(persona.embedColor)
+    .setFooter({ text: `WAWPTN — ${persona.name}` })
+}
+
+function buildReminderEmbedForChannel(
+  channel: LinkedChannel,
+  message: string,
+): EmbedBuilder {
+  const persona = getPersonaForChannel(channel)
   return new EmbedBuilder()
     .setDescription(message)
     .setColor(persona.embedColor)
@@ -66,21 +118,28 @@ async function sendPersonaAnnouncement(client: Client): Promise<void> {
       return
     }
 
-    const persona = getPersona()
-    const embed = new EmbedBuilder()
-      .setDescription(persona.introMessage)
-      .setColor(persona.embedColor)
-      .setFooter({ text: `WAWPTN — Persona du jour : ${persona.name}` })
-
-    for (const { channelId, groupName } of channels) {
+    // Each linked channel announces *its own group's* persona. With 50
+    // groups this means 50 distinct intro messages at midnight — the bot
+    // no longer broadcasts a single global persona to every server.
+    for (const channel of channels) {
       try {
-        const channel = await client.channels.fetch(channelId)
-        if (channel?.isTextBased()) {
-          await (channel as TextChannel).send({ embeds: [embed] })
-          console.log(`[scheduler] Sent persona announcement to channel ${channelId} (${groupName})`)
+        const persona = getPersonaForChannel(channel)
+        const embed = new EmbedBuilder()
+          .setDescription(persona.introMessage)
+          .setColor(persona.embedColor)
+          .setFooter({ text: `WAWPTN — Persona du jour : ${persona.name}` })
+        const dchannel = await client.channels.fetch(channel.channelId)
+        if (dchannel?.isTextBased()) {
+          await (dchannel as TextChannel).send({ embeds: [embed] })
+          console.log(
+            `[scheduler] Sent persona announcement to channel ${channel.channelId} (${channel.groupName}) — persona: ${persona.name}`,
+          )
         }
       } catch (err) {
-        console.error(`[scheduler] Failed to send persona announcement to channel ${channelId} (${groupName}):`, err)
+        console.error(
+          `[scheduler] Failed to send persona announcement to channel ${channel.channelId} (${channel.groupName}):`,
+          err,
+        )
       }
     }
   } catch (err) {
@@ -88,32 +147,59 @@ async function sendPersonaAnnouncement(client: Client): Promise<void> {
   }
 }
 
+type ReminderPool = 'friday' | 'weekday' | 'backOnline'
+
+function selectReminderMessage(channel: LinkedChannel, kind: ReminderPool): string | null {
+  const persona = getPersonaForChannel(channel)
+  const pool =
+    kind === 'friday'
+      ? persona.fridayMessages
+      : kind === 'weekday'
+        ? persona.weekdayMessages
+        : persona.backOnlineMessages
+  if (!Array.isArray(pool) || pool.length === 0) return null
+  return pickRandom(pool)
+}
+
 async function sendToChannels(
   client: Client,
   channels: LinkedChannel[],
-  pool: string[],
+  kind: ReminderPool,
 ): Promise<void> {
   if (channels.length === 0) return
-  const message = pickRandom(pool)
-  const embed = buildReminderEmbed(message)
 
-  for (const { channelId, groupName } of channels) {
+  // Each channel resolves its own persona + message so per-group settings
+  // (disabled list, override) are honoured individually.
+  for (const channel of channels) {
     try {
-      const channel = await client.channels.fetch(channelId)
-      if (channel?.isTextBased()) {
-        await (channel as TextChannel).send({ embeds: [embed] })
-        console.log(`[scheduler] Sent reminder to channel ${channelId} (${groupName})`)
+      const message = selectReminderMessage(channel, kind)
+      if (!message) {
+        console.warn(
+          `[scheduler] No ${kind} message available for channel ${channel.channelId} (${channel.groupName})`,
+        )
+        continue
+      }
+      const embed = buildReminderEmbedForChannel(channel, message)
+      const dchannel = await client.channels.fetch(channel.channelId)
+      if (dchannel?.isTextBased()) {
+        await (dchannel as TextChannel).send({ embeds: [embed] })
+        console.log(
+          `[scheduler] Sent ${kind} reminder to channel ${channel.channelId} (${channel.groupName})`,
+        )
       }
     } catch (err) {
-      console.error(`[scheduler] Failed to send to channel ${channelId} (${groupName}):`, err)
+      console.error(
+        `[scheduler] Failed to send ${kind} reminder to channel ${channel.channelId} (${channel.groupName}):`,
+        err,
+      )
     }
   }
 }
 
-async function sendToLinkedChannels(client: Client, pool: string[]): Promise<void> {
+async function sendToLinkedChannels(client: Client, kind: ReminderPool): Promise<void> {
   try {
     const channels = await getLinkedChannels()
-    await sendToChannels(client, channels, pool)
+    await sendToChannels(client, channels, kind)
   } catch (err) {
     console.error('[scheduler] Failed to fetch linked channels:', err)
   }
@@ -123,8 +209,8 @@ async function sendToLinkedChannels(client: Client, pool: string[]): Promise<voi
 
 export async function notifyBackOnline(client: Client): Promise<void> {
   const persona = getPersona()
-  console.log(`[persona] Today's persona: ${persona.name} (${persona.id})`)
-  await sendToLinkedChannels(client, persona.backOnlineMessages)
+  console.log(`[persona] Today's global persona: ${persona.name} (${persona.id})`)
+  await sendToLinkedChannels(client, 'backOnline')
 }
 
 // ─── Manual test trigger ──────────────────────────────────────────────────────
@@ -143,7 +229,12 @@ export async function triggerReminder(
   channelId: string,
   kind: 'friday' | 'weekday',
 ): Promise<{ personaName: string; message: string }> {
-  const persona = getPersona()
+  // Look up the linked channel so we can use per-group persona selection
+  // — the preview must match what the real scheduled reminder will send.
+  const linked = await getLinkedChannels()
+  const channelInfo = linked.find((c) => c.channelId === channelId)
+
+  const persona = channelInfo ? getPersonaForChannel(channelInfo) : getPersona()
   const pool = kind === 'friday' ? persona.fridayMessages : persona.weekdayMessages
 
   if (!Array.isArray(pool) || pool.length === 0) {
@@ -153,7 +244,9 @@ export async function triggerReminder(
   }
 
   const message = pickRandom(pool)
-  const embed = buildReminderEmbed(message)
+  const embed = channelInfo
+    ? buildReminderEmbedForChannel(channelInfo, message)
+    : buildReminderEmbed(message)
 
   const channel = await client.channels.fetch(channelId)
   if (!channel || !channel.isTextBased()) {
@@ -192,10 +285,11 @@ function scheduleGuildReminders(
     tasks.friday = cron.schedule(
       friday,
       () => {
-        const persona = getPersona()
-        console.log(`[scheduler] Friday reminder triggered for guild ${guildKey ?? '<legacy>'} with persona: ${persona.name}`)
+        console.log(
+          `[scheduler] Friday reminder triggered for guild ${guildKey ?? '<legacy>'} — ${channels.length} channel(s), per-group personas`,
+        )
         const jitterMs = Math.floor(Math.random() * 15 * 60 * 1000)
-        setTimeout(() => sendToChannels(client, channels, persona.fridayMessages), jitterMs)
+        setTimeout(() => sendToChannels(client, channels, 'friday'), jitterMs)
       },
       { timezone },
     )
@@ -208,10 +302,11 @@ function scheduleGuildReminders(
     tasks.weekday = cron.schedule(
       weekday,
       () => {
-        const persona = getPersona()
-        console.log(`[scheduler] Weekday reminder triggered for guild ${guildKey ?? '<legacy>'} with persona: ${persona.name}`)
+        console.log(
+          `[scheduler] Weekday reminder triggered for guild ${guildKey ?? '<legacy>'} — ${channels.length} channel(s), per-group personas`,
+        )
         const jitterMs = Math.floor(Math.random() * 15 * 60 * 1000)
-        setTimeout(() => sendToChannels(client, channels, persona.weekdayMessages), jitterMs)
+        setTimeout(() => sendToChannels(client, channels, 'weekday'), jitterMs)
       },
       { timezone },
     )

--- a/packages/frontend/src/components/persona-badge.tsx
+++ b/packages/frontend/src/components/persona-badge.tsx
@@ -5,6 +5,7 @@ import { Sparkles } from 'lucide-react'
 import { api } from '@/lib/api'
 
 interface PersonaData {
+  id?: string
   name: string
   embedColor: number
   introMessage: string
@@ -14,35 +15,94 @@ function colorIntToHex(color: number): string {
   return `#${color.toString(16).padStart(6, '0')}`
 }
 
+interface PersonaBadgeProps {
+  /**
+   * Group identifier for the per-group "persona du jour". When omitted,
+   * the badge falls back to the deprecated global persona endpoint —
+   * used only on screens without a group context (e.g. landing page).
+   */
+  groupId?: string
+  /**
+   * Pre-fetched persona. When provided the component skips its own
+   * network call — lets the groups list pass the enriched `todayPersona`
+   * field down without any extra round-trip.
+   */
+  persona?: PersonaData | null
+  /**
+   * `hero` renders the dominant full-width card with the intro message,
+   * `compact` renders an inline one-line chip suitable for GroupCard.
+   */
+  variant?: 'hero' | 'compact'
+  className?: string
+}
+
 /**
- * Daily persona greeting card.
+ * Daily persona greeting card — now scoped per-group.
  *
- * Displays the rotating Discord-bot persona of the day with its name and
- * full intro message visible (no hover tooltip). Intended to live at the
- * top of the groups list — a welcoming "your friend just said hi" moment
- * on daily return to the app.
+ * Displays the group's rotating bot persona with its name and (in hero
+ * variant) full intro message. Each group has its own deterministic
+ * daily pick from the shared persona pool, so two users looking at two
+ * different groups on the same day will usually see different personas.
  */
-export function PersonaBadge() {
+export function PersonaBadge({ groupId, persona: initialPersona, variant = 'hero', className }: PersonaBadgeProps) {
   const { t } = useTranslation()
-  const [persona, setPersona] = useState<PersonaData | null>(null)
+  const [fetched, setFetched] = useState<PersonaData | null>(null)
 
   useEffect(() => {
-    api.getCurrentPersona()
-      .then(setPersona)
-      .catch(() => {})
-  }, [])
+    // Parent already supplied the persona (list enrichment) — skip fetch.
+    if (initialPersona) return
+    let cancelled = false
+    const run = async () => {
+      try {
+        if (groupId) {
+          const result = await api.getGroupPersona(groupId)
+          if (!cancelled) setFetched(result.persona)
+        } else {
+          const result = await api.getCurrentPersona()
+          if (!cancelled) setFetched(result)
+        }
+      } catch {
+        /* swallow — persona is a nice-to-have, not critical */
+      }
+    }
+    void run()
+    return () => {
+      cancelled = true
+    }
+  }, [groupId, initialPersona])
 
+  // Prop wins over locally fetched state so the list-enriched path (and
+  // real-time `persona:changed` socket updates) always reflects the latest.
+  const persona = initialPersona ?? fetched
   if (!persona) return null
 
   const color = colorIntToHex(persona.embedColor)
+
+  if (variant === 'compact') {
+    return (
+      <span
+        className={`inline-flex items-center gap-1.5 rounded-full border border-white/[0.08] px-2 py-0.5 text-[11px] font-medium ${className ?? ''}`}
+        style={{
+          backgroundColor: `${color}14`,
+          color,
+          borderColor: `${color}33`,
+        }}
+        aria-label={t('persona.todayGroup')}
+        title={persona.introMessage}
+      >
+        <Sparkles className="w-3 h-3" />
+        <span className="truncate max-w-[140px]">{persona.name}</span>
+      </span>
+    )
+  }
 
   return (
     <motion.section
       initial={{ opacity: 0, y: 12 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
-      aria-label={t('persona.today')}
-      className="relative overflow-hidden rounded-lg border border-white/[0.06] bg-card/40 p-4 mb-6"
+      aria-label={t('persona.todayGroup')}
+      className={`relative overflow-hidden rounded-lg border border-white/[0.06] bg-card/40 p-4 mb-6 ${className ?? ''}`}
       style={{
         backgroundImage: `linear-gradient(135deg, ${color}14 0%, transparent 60%)`,
         borderLeft: `3px solid ${color}`,
@@ -59,7 +119,7 @@ export function PersonaBadge() {
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 mb-1">
             <span className="text-[11px] uppercase tracking-wider font-medium text-muted-foreground">
-              {t('persona.today')}
+              {groupId ? t('persona.todayGroup') : t('persona.today')}
             </span>
             <span className="text-muted-foreground/30">·</span>
             <span className="text-sm font-semibold truncate" style={{ color }}>

--- a/packages/frontend/src/i18n/locales/en.json
+++ b/packages/frontend/src/i18n/locales/en.json
@@ -419,6 +419,10 @@
     "unlocked": "Unlocked ✓",
     "unlockedToast": "{{icon}} Challenge unlocked: {{title}}"
   },
+  "persona": {
+    "today": "Today's persona",
+    "todayGroup": "Tonight's group persona"
+  },
   "socket": {
     "lostConnection": "Connection lost",
     "tryingToReconnect": "Trying to reconnect...",

--- a/packages/frontend/src/i18n/locales/fr.json
+++ b/packages/frontend/src/i18n/locales/fr.json
@@ -454,7 +454,8 @@
     "unlockedToast": "{{icon}} Défi débloqué : {{title}}"
   },
   "persona": {
-    "today": "Persona du jour"
+    "today": "Persona du jour",
+    "todayGroup": "Le persona du groupe ce soir"
   },
   "socket": {
     "lostConnection": "Connexion perdue",

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -73,11 +73,12 @@ export const api = {
   },
 
   // Groups
-  getGroups: () => request<{ id: string; name: string; role: string; createdAt: string; memberCount: number; commonGameCount: number; lastSession: { gameName: string; gameAppId: number; closedAt: string } | null }[]>('/groups'),
+  getGroups: () => request<{ id: string; name: string; role: string; createdAt: string; memberCount: number; commonGameCount: number; lastSession: { gameName: string; gameAppId: number; closedAt: string } | null; todayPersona: { id: string; name: string; embedColor: number; introMessage: string } | null }[]>('/groups'),
   getGroup: (id: string) => request<{
     id: string; name: string; createdBy: string; commonGameThreshold: number | null; createdAt: string;
     autoVoteSchedule: string | null; autoVoteDurationMinutes: number;
-    members: { id: string; steamId: string; displayName: string; avatarUrl: string; libraryVisible: boolean; role: string; joinedAt: string; notificationsEnabled: boolean }[]
+    members: { id: string; steamId: string; displayName: string; avatarUrl: string; libraryVisible: boolean; role: string; joinedAt: string; notificationsEnabled: boolean }[];
+    todayPersona: { id: string; name: string; embedColor: number; introMessage: string } | null;
   }>(`/groups/${id}`),
   createGroup: (name: string) => request<{ id: string; name: string; inviteToken: string; inviteExpiresAt: string }>('/groups', {
     method: 'POST',
@@ -206,8 +207,25 @@ export const api = {
       body: JSON.stringify(patch),
     }),
 
-  // Persona
+  // Persona — the app-wide endpoint is the global fallback (login page).
+  // Prefer `getGroupPersona(groupId)` for the per-group "persona du jour".
   getCurrentPersona: () => request<{ id: string; name: string; embedColor: number; introMessage: string }>('/persona/current'),
+  getGroupPersona: (groupId: string) =>
+    request<{ persona: { id: string; name: string; embedColor: number; introMessage: string }; date: string }>(`/groups/${groupId}/persona/current`),
+  getGroupPersonaSettings: (groupId: string) =>
+    request<import('@wawptn/types').GroupPersonaSettings>(`/groups/${groupId}/persona-settings`),
+  updateGroupPersonaSettings: (
+    groupId: string,
+    patch: import('@wawptn/types').GroupPersonaSettingsUpdate,
+  ) =>
+    request<
+      import('@wawptn/types').GroupPersonaSettings & {
+        todayPersona: { id: string; name: string; embedColor: number; introMessage: string } | null
+      }
+    >(`/groups/${groupId}/persona-settings`, {
+      method: 'PATCH',
+      body: JSON.stringify(patch),
+    }),
 
   // Admin
   getAdminBotSettings: () => request<Record<string, unknown>>('/admin/bot-settings'),

--- a/packages/frontend/src/pages/GroupPage.tsx
+++ b/packages/frontend/src/pages/GroupPage.tsx
@@ -26,6 +26,7 @@ import { GameGrid, type GameFilters } from '@/components/game-grid'
 import { RandomPickModal } from '@/components/random-pick-modal'
 import { VoteSetupDialog } from '@/components/vote-setup-dialog'
 import { TonightPickHero } from '@/components/tonight-pick-hero'
+import { PersonaBadge } from '@/components/persona-badge'
 
 export function GroupPage() {
   const { t } = useTranslation()
@@ -51,6 +52,7 @@ export function GroupPage() {
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false)
   const [randomPickOpen, setRandomPickOpen] = useState(false)
   const [onlineUserIds, setOnlineUserIds] = useState<string[]>([])
+  const [todayPersona, setTodayPersona] = useState<{ id: string; name: string; embedColor: number; introMessage: string } | null>(null)
   const lastSeenMapRef = useRef<Map<string, number>>(new Map())
 
   const loadCommonGames = useCallback(async (groupId: string, filter?: string) => {
@@ -98,6 +100,9 @@ export function GroupPage() {
     const socket = getSocket()
     socket.emit('group:join', id)
 
+    socket.on('persona:changed', (data) => {
+      if (data.groupId === id) setTodayPersona(data.persona)
+    })
     socket.on('group:presence', (data) => setOnlineUserIds(data.onlineUserIds))
     socket.on('member:online', (data) => setOnlineUserIds((prev) => prev.includes(data.userId) ? prev : [...prev, data.userId]))
     socket.on('member:offline', (data) => {
@@ -147,6 +152,7 @@ export function GroupPage() {
 
     return () => {
       socket.emit('group:leave', id)
+      socket.off('persona:changed')
       socket.off('group:presence')
       socket.off('member:online')
       socket.off('member:offline')
@@ -287,6 +293,14 @@ export function GroupPage() {
     }
   }
 
+  // Keep the hero persona in sync with the group detail response. The
+  // socket listener above applies live midnight/override flips on top.
+  useEffect(() => {
+    if (currentGroup?.todayPersona) {
+      setTodayPersona(currentGroup.todayPersona)
+    }
+  }, [currentGroup?.todayPersona])
+
   const onlineMembers = useMemo(() => new Set(onlineUserIds), [onlineUserIds])
   const lastSeenMap = lastSeenMapRef.current
   const currentUserRole = currentGroup?.members.find(m => m.id === user?.id)?.role || 'member'
@@ -395,6 +409,18 @@ export function GroupPage() {
 
           {/* Main content: hero + games grid */}
           <div className="space-y-3 sm:space-y-4 min-w-0">
+            {/* Per-group "persona du jour" — hero variant. Pre-fetched via
+                the enriched group detail response, refreshed live via the
+                `persona:changed` socket event (midnight flip or owner
+                override). */}
+            {todayPersona && (
+              <PersonaBadge
+                groupId={id}
+                persona={todayPersona}
+                variant="hero"
+              />
+            )}
+
             {/* Hero: "Tonight's Pick" — dominant CTA at the top of the page.
                 Replaces the old 2-button grid (Start vote / Random pick) and
                 surfaces a client-scored recommendation so a first-time user

--- a/packages/frontend/src/pages/GroupsPage.tsx
+++ b/packages/frontend/src/pages/GroupsPage.tsx
@@ -249,8 +249,8 @@ export function GroupsPage() {
           </div>
         </div>
 
-        {/* Today's bot persona — greeting card */}
-        <PersonaBadge />
+        {/* Per-group persona du jour lives on each GroupCard below —
+            no longer a single global badge at the top of the page. */}
 
         {/* Search Groups */}
         {groups.length > 3 && (
@@ -493,6 +493,13 @@ export function GroupsPage() {
                           {group.name}
                           {group.role === 'owner' && (
                             <Crown className="w-4 h-4 text-reward shrink-0" />
+                          )}
+                          {group.todayPersona && (
+                            <PersonaBadge
+                              variant="compact"
+                              persona={group.todayPersona}
+                              className="ml-1"
+                            />
                           )}
                         </h3>
                         <div className="flex items-center gap-2 text-sm text-muted-foreground mt-0.5">

--- a/packages/frontend/src/stores/group.store.ts
+++ b/packages/frontend/src/stores/group.store.ts
@@ -1,12 +1,15 @@
 import { create } from 'zustand'
 import { api } from '@/lib/api'
 
+interface DailyPersona { id: string; name: string; embedColor: number; introMessage: string }
+
 interface GroupState {
-  groups: { id: string; name: string; role: string; createdAt: string; memberCount: number; commonGameCount: number; lastSession: { gameName: string; gameAppId: number; closedAt: string } | null }[]
+  groups: { id: string; name: string; role: string; createdAt: string; memberCount: number; commonGameCount: number; lastSession: { gameName: string; gameAppId: number; closedAt: string } | null; todayPersona: DailyPersona | null }[]
   currentGroup: {
     id: string; name: string; createdBy: string; commonGameThreshold: number | null; createdAt: string;
     autoVoteSchedule: string | null; autoVoteDurationMinutes: number;
-    members: { id: string; steamId: string; displayName: string; avatarUrl: string; libraryVisible: boolean; role: string; joinedAt: string; notificationsEnabled: boolean }[]
+    members: { id: string; steamId: string; displayName: string; avatarUrl: string; libraryVisible: boolean; role: string; joinedAt: string; notificationsEnabled: boolean }[];
+    todayPersona: DailyPersona | null
   } | null
   loading: boolean
   fetchGroups: () => Promise<void>

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -44,6 +44,47 @@ export interface GroupWithMembers extends Group {
 }
 
 // ============================================
+// Persona (daily bot persona — per group)
+// ============================================
+
+/**
+ * Lean per-group "persona du jour" projection. The full persona pool lives
+ * in the global `personas` table and is shared across all groups — each
+ * group gets its own deterministic daily pick from that shared pool via
+ * `djb2("${YYYY-MM-DD}:${groupId}")`.
+ */
+export interface GroupDailyPersona {
+  id: string
+  name: string
+  embedColor: number
+  introMessage: string
+}
+
+/**
+ * Per-group persona settings. All fields are optional overrides — when a
+ * value is null/empty, the group falls back to the global `bot.*` defaults
+ * stored in `app_settings`. Stored 1:1 with groups in `group_persona_settings`.
+ */
+export interface GroupPersonaSettings {
+  groupId: string
+  rotationEnabled: boolean
+  disabledPersonas: string[]
+  personaOverride: string | null
+  overrideExpiresAt: string | null
+}
+
+/**
+ * Payload accepted by `PATCH /api/groups/:id/persona-settings`. Undefined
+ * fields are left untouched; null clears an override.
+ */
+export interface GroupPersonaSettingsUpdate {
+  rotationEnabled?: boolean
+  disabledPersonas?: string[]
+  personaOverride?: string | null
+  overrideExpiresAt?: string | null
+}
+
+// ============================================
 // Games
 // ============================================
 
@@ -363,6 +404,7 @@ export interface ServerToClientEvents {
   'member:offline': (data: { groupId: string; userId: string }) => void
   'notification:new': (data: Notification) => void
   'challenge:unlocked': (data: { userId: string; challengeId: string; title: string; icon: string; tier: number }) => void
+  'persona:changed': (data: { groupId: string; persona: GroupDailyPersona; date: string; reason: 'rotation' | 'override' | 'settings' }) => void
 }
 
 export interface ClientToServerEvents {


### PR DESCRIPTION
Each group now draws its own deterministic "persona du jour" from the
shared persona pool via djb2("${YYYY-MM-DD}:${groupId}"), so two groups
looking at the app on the same day usually see different personas.

- Schema: new group_persona_settings table (1:1 with groups), lazy-
  created on first write, rotation_enabled / disabled_personas /
  persona_override / override_expires_at. Global bot.* app_settings
  remain as a fallback layer via COALESCE so existing groups keep
  working with zero backfill.
- Backend: new domain/persona-selection.ts with selectPersonaForGroup +
  batch selectPersonasForGroups, midnight-safe per-(date, groupId)
  cache, and invalidateGroupPersonaCache. New nested endpoints
  GET /api/groups/:id/persona/current, GET/PATCH .../persona-settings
  (owner-only). Legacy /api/persona/current stays as global fallback
  with Deprecation / Sunset headers. GET /api/groups and /api/groups/:id
  now embed a lean todayPersona field so the list page has zero N+1.
- Socket.io: new persona:changed event emitted on group:${id} rooms
  after a settings PATCH so connected members refresh instantly.
- Discord: /api/discord/linked-channels now carries groupId + per-group
  persona overrides; scheduler iterates per-channel and each reminder/
  midnight announcement uses its own group's persona (no more single
  global broadcast). New getTodayPersonaForGroup in personas.ts with
  the same djb2 key as the backend.
- Frontend: PersonaBadge gains groupId / persona / variant props
  (hero | compact). Global badge removed from GroupsPage; compact badge
  now inlined on each GroupCard using the enriched list payload. Hero
  badge added to GroupPage, reactive to persona:changed socket events.
  French copy: « Le persona du groupe ce soir ».

https://claude.ai/code/session_01Ss7EWLVnSHMiWs5CpFpBxC