### PR TITLE
fix(i18n): simplify start vote button label to "Lancer un vote"

### DIFF
--- a/packages/frontend/e2e/modals.mobile.spec.ts
+++ b/packages/frontend/e2e/modals.mobile.spec.ts
@@ -120,7 +120,7 @@ test.describe('Modals on mobile', () => {
       await page.goto('/groups/group-1')
       await page.waitForTimeout(500)
       // Wait for group page to load
-      await expect(page.getByText('Lancer un vote pour ce soir')).toBeVisible({ timeout: 10000 })
+      await expect(page.getByText('Lancer un vote')).toBeVisible({ timeout: 10000 })
 
       // Tap the avatar bar to open mobile sidebar
       await page.getByRole('button', { name: 'Voir les membres' }).click()
@@ -144,7 +144,7 @@ test.describe('Modals on mobile', () => {
     test('shows vote history in sidebar', async ({ page }) => {
       await page.goto('/groups/group-1')
       await page.waitForTimeout(500)
-      await expect(page.getByText('Lancer un vote pour ce soir')).toBeVisible({ timeout: 10000 })
+      await expect(page.getByText('Lancer un vote')).toBeVisible({ timeout: 10000 })
 
       await page.getByRole('button', { name: 'Voir les membres' }).click()
 
@@ -173,7 +173,7 @@ test.describe('Modals on mobile', () => {
 
       await page.goto('/groups/group-2')
       await page.waitForTimeout(500)
-      await expect(page.getByText('Lancer un vote pour ce soir')).toBeVisible({ timeout: 10000 })
+      await expect(page.getByText('Lancer un vote')).toBeVisible({ timeout: 10000 })
 
       await page.getByRole('button', { name: 'Voir les membres' }).click()
       const sidebar = page.getByRole('dialog')
@@ -198,7 +198,7 @@ test.describe('Modals on mobile', () => {
     test('opens from sidebar and confirms deletion', async ({ page }) => {
       await page.goto('/groups/group-1')
       await page.waitForTimeout(500)
-      await expect(page.getByText('Lancer un vote pour ce soir')).toBeVisible({ timeout: 10000 })
+      await expect(page.getByText('Lancer un vote')).toBeVisible({ timeout: 10000 })
 
       await page.getByRole('button', { name: 'Voir les membres' }).click()
       const sidebar = page.getByRole('dialog')
@@ -222,7 +222,7 @@ test.describe('Modals on mobile', () => {
     test('shows kick dialog for non-self members (owner view)', async ({ page }) => {
       await page.goto('/groups/group-1')
       await page.waitForTimeout(500)
-      await expect(page.getByText('Lancer un vote pour ce soir')).toBeVisible({ timeout: 10000 })
+      await expect(page.getByText('Lancer un vote')).toBeVisible({ timeout: 10000 })
 
       await page.getByRole('button', { name: 'Voir les membres' }).click()
       const sidebar = page.getByRole('dialog')
@@ -245,11 +245,11 @@ test.describe('Modals on mobile', () => {
     test.beforeEach(async ({ page }) => {
       await page.goto('/groups/group-1')
       await page.waitForTimeout(500)
-      await expect(page.getByText('Lancer un vote pour ce soir')).toBeVisible({ timeout: 10000 })
+      await expect(page.getByText('Lancer un vote')).toBeVisible({ timeout: 10000 })
     })
 
     test('opens with all members selected by default', async ({ page }) => {
-      await page.getByText('Lancer un vote pour ce soir').click()
+      await page.getByText('Lancer un vote').click()
 
       const dialog = page.getByRole('dialog')
       await expect(dialog).toBeVisible()
@@ -258,7 +258,7 @@ test.describe('Modals on mobile', () => {
     })
 
     test('toggles individual member selection via checkbox', async ({ page }) => {
-      await page.getByText('Lancer un vote pour ce soir').click()
+      await page.getByText('Lancer un vote').click()
       const dialog = page.getByRole('dialog')
       await expect(dialog.getByText('Qui joue ce soir ?')).toBeVisible()
       await page.waitForTimeout(400) // Wait for drawer animation to settle
@@ -273,7 +273,7 @@ test.describe('Modals on mobile', () => {
     })
 
     test('select all / deselect all toggle', async ({ page }) => {
-      await page.getByText('Lancer un vote pour ce soir').click()
+      await page.getByText('Lancer un vote').click()
       const dialog = page.getByRole('dialog')
       await expect(dialog.getByText('Qui joue ce soir ?')).toBeVisible()
       await page.waitForTimeout(400)
@@ -288,7 +288,7 @@ test.describe('Modals on mobile', () => {
     })
 
     test('proceeds to confirmation step and starts vote', async ({ page }) => {
-      await page.getByText('Lancer un vote pour ce soir').click()
+      await page.getByText('Lancer un vote').click()
       const dialog = page.getByRole('dialog')
       await expect(dialog.getByText('Qui joue ce soir ?')).toBeVisible()
       await page.waitForTimeout(400)
@@ -306,7 +306,7 @@ test.describe('Modals on mobile', () => {
     })
 
     test('schedule vote option shows date picker', async ({ page }) => {
-      await page.getByText('Lancer un vote pour ce soir').click()
+      await page.getByText('Lancer un vote').click()
       const dialog = page.getByRole('dialog')
       await expect(dialog.getByText('Qui joue ce soir ?')).toBeVisible()
       await page.waitForTimeout(400)
@@ -324,7 +324,7 @@ test.describe('Modals on mobile', () => {
     })
 
     test('back button returns to member selection', async ({ page }) => {
-      await page.getByText('Lancer un vote pour ce soir').click()
+      await page.getByText('Lancer un vote').click()
       const dialog = page.getByRole('dialog')
       await expect(dialog.getByText('Qui joue ce soir ?')).toBeVisible()
       await page.waitForTimeout(400)
@@ -339,7 +339,7 @@ test.describe('Modals on mobile', () => {
     })
 
     test('disables Suivant when fewer than 2 members selected', async ({ page }) => {
-      await page.getByText('Lancer un vote pour ce soir').click()
+      await page.getByText('Lancer un vote').click()
       const dialog = page.getByRole('dialog')
       await expect(dialog.getByText('Qui joue ce soir ?')).toBeVisible()
       await page.waitForTimeout(400)

--- a/packages/frontend/e2e/voting.mobile.spec.ts
+++ b/packages/frontend/e2e/voting.mobile.spec.ts
@@ -411,10 +411,10 @@ test.describe('Voting system on mobile', () => {
     test('complete flow: start vote -> select games -> submit -> close -> result', async ({ page }) => {
       // Step 1: Start from group page
       await page.goto('/groups/group-1')
-      await expect(page.getByText('Lancer un vote pour ce soir')).toBeVisible({ timeout: 15000 })
+      await expect(page.getByText('Lancer un vote')).toBeVisible({ timeout: 15000 })
 
       // Step 2: Open vote setup
-      await page.getByText('Lancer un vote pour ce soir').click()
+      await page.getByText('Lancer un vote').click()
       const dialog = page.getByRole('dialog')
       await expect(dialog.getByText('Qui joue ce soir ?')).toBeVisible()
       await page.waitForTimeout(400) // Wait for drawer animation

--- a/packages/frontend/src/i18n/locales/en.json
+++ b/packages/frontend/src/i18n/locales/en.json
@@ -65,7 +65,7 @@
   "group": {
     "back": "Back",
     "lastSession": "Last session",
-    "startVote": "Start a vote for tonight",
+    "startVote": "Start a vote",
     "commonGamesCount": "{{count}} games in common",
     "members": "Members ({{count}})",
     "syncLibraries": "Sync libraries",
@@ -378,7 +378,7 @@
     "notPlayedLong": "Not played in a while",
     "popularForgotten": "Popular but forgotten",
     "startVote": "Start a vote",
-    "startVoteHint": "Start a vote for tonight"
+    "startVoteHint": "Start a vote"
   },
   "landing": {
     "headline": "What are we playing tonight?",

--- a/packages/frontend/src/i18n/locales/fr.json
+++ b/packages/frontend/src/i18n/locales/fr.json
@@ -68,7 +68,7 @@
   "group": {
     "back": "Retour",
     "lastSession": "Dernière soirée",
-    "startVote": "Lancer un vote pour ce soir",
+    "startVote": "Lancer un vote",
     "commonGamesCount": "{{count}} jeux en commun",
     "members": "Membres ({{count}})",
     "syncLibraries": "Synchroniser les bibliothèques",
@@ -387,7 +387,7 @@
     "notPlayedLong": "Pas joué depuis longtemps",
     "popularForgotten": "Populaire mais oublié",
     "startVote": "Lancer un vote",
-    "startVoteHint": "Lancer un vote pour ce soir"
+    "startVoteHint": "Lancer un vote"
   },
   "landing": {
     "headline": "On joue à quoi ce soir ?",


### PR DESCRIPTION
Remove the "pour ce soir" suffix from the French startVote and
startVoteHint labels, and update the related e2e test selectors.

https://claude.ai/code/session_01RNWz1RgxVB6BxfSgNAiTXo