### PR TITLE
fix(discord): webhook fallback fires when bot path fails or is disabled

### DIFF
--- a/packages/backend/src/infrastructure/discord/__tests__/notifier.test.ts
+++ b/packages/backend/src/infrastructure/discord/__tests__/notifier.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// vi.hoisted — variables available inside vi.mock factories (which are hoisted)
+// ---------------------------------------------------------------------------
+
+const {
+  mockDb,
+  dbResults,
+  dbCallCounts,
+  postSessionCreatedMock,
+  postSessionClosedMock,
+  isBotClientEnabledMock,
+  buildVoteSummaryMock,
+  flushPendingMock,
+} = vi.hoisted(() => {
+  /**
+   * Chainable mock mimicking a Knex query builder.
+   * Every method returns the same proxy, and `await` resolves to `resolveValue`.
+   */
+  function chain(resolveValue: unknown = undefined): unknown {
+    const proxy: unknown = new Proxy(() => {}, {
+      get(_t, prop: string) {
+        if (prop === 'then') {
+          return (res: (v: unknown) => void, rej: (e: unknown) => void) =>
+            Promise.resolve(resolveValue).then(res, rej)
+        }
+        return (..._a: unknown[]) => proxy
+      },
+      apply() {
+        return proxy
+      },
+    })
+    return proxy
+  }
+
+  const dbResults = new Map<string, unknown[]>()
+  const dbCallCounts = new Map<string, number>()
+
+  function nextResult(table: string): unknown {
+    const idx = dbCallCounts.get(table) ?? 0
+    dbCallCounts.set(table, idx + 1)
+    const arr = dbResults.get(table)
+    if (!arr || arr.length === 0) return undefined
+    return arr[Math.min(idx, arr.length - 1)]
+  }
+
+  const noop = () => {}
+  const mockDb = Object.assign(
+    (table: string) => chain(nextResult(table)),
+    { fn: { now: () => 'NOW()' }, raw: noop },
+  )
+
+  return {
+    mockDb,
+    dbResults,
+    dbCallCounts,
+    postSessionCreatedMock: vi.fn(),
+    postSessionClosedMock: vi.fn(),
+    isBotClientEnabledMock: vi.fn(),
+    buildVoteSummaryMock: vi.fn(),
+    flushPendingMock: vi.fn(),
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@/infrastructure/database/connection.js', () => ({ db: mockDb }))
+
+vi.mock('@/infrastructure/logger/logger.js', () => {
+  const noop = () => {}
+  const child = () => ({ info: noop, warn: noop, error: noop, debug: noop, child })
+  return { logger: { info: noop, warn: noop, error: noop, debug: noop, child } }
+})
+
+vi.mock('@/config/env.js', () => ({
+  env: { CORS_ORIGIN: 'https://wawptn.test' },
+}))
+
+vi.mock('@/infrastructure/discord/bot-client.js', () => ({
+  postSessionCreated: postSessionCreatedMock,
+  postSessionClosed: postSessionClosedMock,
+  isBotClientEnabled: isBotClientEnabledMock,
+}))
+
+vi.mock('@/infrastructure/discord/vote-summary.js', () => ({
+  buildVoteSummary: buildVoteSummaryMock,
+}))
+
+vi.mock('@/infrastructure/discord/live-vote-updater.js', () => ({
+  flushPending: flushPendingMock,
+}))
+
+// ---------------------------------------------------------------------------
+// Import module under test (after mocks)
+// ---------------------------------------------------------------------------
+
+import { notifySessionCreated } from '../notifier.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setDbResult(table: string, ...values: unknown[]) {
+  dbResults.set(table, values)
+}
+
+const fetchMock = vi.fn()
+// notifier posts webhooks via global fetch
+globalThis.fetch = fetchMock as unknown as typeof fetch
+
+const games = [
+  { steamAppId: 730, gameName: 'Counter-Strike 2', headerImageUrl: 'https://img/730.jpg' },
+  { steamAppId: 440, gameName: 'Team Fortress 2', headerImageUrl: 'https://img/440.jpg' },
+]
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('notifySessionCreated', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    dbResults.clear()
+    dbCallCounts.clear()
+    fetchMock.mockReset()
+    fetchMock.mockResolvedValue({ ok: true, status: 204 })
+    buildVoteSummaryMock.mockResolvedValue({ tallies: [], totalVoters: 0 })
+  })
+
+  it('posts via bot when channel is linked and bot is enabled', async () => {
+    setDbResult('groups', {
+      id: 'g1',
+      name: 'Test Group',
+      discord_channel_id: 'chan-123',
+      discord_webhook_url: null,
+    })
+    setDbResult('voting_sessions', { display_name: 'Alice' })
+
+    isBotClientEnabledMock.mockReturnValue(true)
+    postSessionCreatedMock.mockResolvedValue({ messageId: 'msg-abc' })
+
+    await notifySessionCreated('g1', 'sess-1', games)
+
+    expect(postSessionCreatedMock).toHaveBeenCalledTimes(1)
+    expect(postSessionCreatedMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'sess-1',
+        groupId: 'g1',
+        groupName: 'Test Group',
+        channelId: 'chan-123',
+        creatorName: 'Alice',
+      }),
+    )
+    // Webhook fallback MUST NOT fire when the bot successfully handled it.
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('falls back to webhook when bot is disabled even if channel is linked', async () => {
+    // Regression guard for the gap where a group with both a linked channel
+    // AND a configured webhook received NO notification when the bot HTTP
+    // URL was missing from the backend env.
+    setDbResult('groups', {
+      id: 'g1',
+      name: 'Test Group',
+      discord_channel_id: 'chan-123',
+      discord_webhook_url: 'https://discord.com/api/webhooks/xxx/yyy',
+    })
+    setDbResult('voting_sessions', { display_name: 'Bob' })
+
+    isBotClientEnabledMock.mockReturnValue(false)
+
+    await notifySessionCreated('g1', 'sess-1', games)
+
+    expect(postSessionCreatedMock).not.toHaveBeenCalled()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(url).toBe('https://discord.com/api/webhooks/xxx/yyy')
+    const body = JSON.parse((init as { body: string }).body)
+    expect(body.embeds[0].title).toContain('Nouvelle session de vote')
+    expect(body.embeds[0].description).toContain('Counter-Strike 2')
+    expect(body.embeds[0].url).toBe('https://wawptn.test/groups/g1/vote')
+  })
+
+  it('falls back to webhook when bot post fails (returns null)', async () => {
+    setDbResult('groups', {
+      id: 'g1',
+      name: 'Test Group',
+      discord_channel_id: 'chan-123',
+      discord_webhook_url: 'https://discord.com/api/webhooks/xxx/yyy',
+    })
+    setDbResult('voting_sessions', { display_name: 'Carol' })
+
+    isBotClientEnabledMock.mockReturnValue(true)
+    // Simulate bot HTTP failure — postSessionCreated swallows and returns null.
+    postSessionCreatedMock.mockResolvedValue(null)
+
+    await notifySessionCreated('g1', 'sess-1', games)
+
+    expect(postSessionCreatedMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses only webhook when group has no linked channel', async () => {
+    setDbResult('groups', {
+      id: 'g1',
+      name: 'Test Group',
+      discord_channel_id: null,
+      discord_webhook_url: 'https://discord.com/api/webhooks/xxx/yyy',
+    })
+    setDbResult('voting_sessions', { display_name: 'Dave' })
+
+    isBotClientEnabledMock.mockReturnValue(true)
+
+    await notifySessionCreated('g1', 'sess-1', games)
+
+    expect(postSessionCreatedMock).not.toHaveBeenCalled()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('is a silent no-op when neither channel nor webhook are configured', async () => {
+    setDbResult('groups', {
+      id: 'g1',
+      name: 'Test Group',
+      discord_channel_id: null,
+      discord_webhook_url: null,
+    })
+    setDbResult('voting_sessions', { display_name: 'Eve' })
+
+    isBotClientEnabledMock.mockReturnValue(true)
+
+    await notifySessionCreated('g1', 'sess-1', games)
+
+    expect(postSessionCreatedMock).not.toHaveBeenCalled()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('returns silently when the group does not exist', async () => {
+    setDbResult('groups', undefined)
+
+    isBotClientEnabledMock.mockReturnValue(true)
+
+    await notifySessionCreated('missing-group', 'sess-1', games)
+
+    expect(postSessionCreatedMock).not.toHaveBeenCalled()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/backend/src/infrastructure/discord/notifier.ts
+++ b/packages/backend/src/infrastructure/discord/notifier.ts
@@ -1,5 +1,6 @@
 import { db } from '../database/connection.js'
 import { logger } from '../logger/logger.js'
+import { env } from '../../config/env.js'
 import type { VoteResult } from '@wawptn/types'
 import { postSessionClosed, postSessionCreated, isBotClientEnabled } from './bot-client.js'
 import { buildVoteSummary } from './vote-summary.js'
@@ -73,9 +74,16 @@ export async function notifySessionCreated(
 
   const creatorName = creator?.display_name || 'Un membre'
 
+  // Track whether the bot-backed path successfully posted. If it did, we
+  // skip the webhook fallback to avoid a duplicate announcement in the
+  // same guild. If it DIDN'T (bot disabled, channel unlinked, or HTTP call
+  // failed), the webhook takes over so that starting a vote on the web
+  // still surfaces in Discord whenever ANY integration is configured.
+  let botHandled = false
+
   // ── Primary: bot-backed interactive message ─────────────────────────
   // Requires a linked channel AND the bot HTTP URL configured. When
-  // either is missing we silently fall back to webhook-only mode.
+  // either is missing we silently fall back to webhook-only mode below.
   if (group.discord_channel_id && isBotClientEnabled()) {
     const summary = await buildVoteSummary(sessionId)
     const response = await postSessionCreated({
@@ -105,27 +113,38 @@ export async function notifySessionCreated(
         { sessionId, groupId, messageId: response.messageId, channelId: group.discord_channel_id },
         'Discord session message posted',
       )
+      botHandled = true
     }
   }
 
   // ── Fallback: legacy primary webhook ────────────────────────────────
-  // Only used when there is NO linked bot channel. Kept so groups that
-  // configured a webhook URL pre-bot continue to receive notifications.
-  if (!group.discord_channel_id && group.discord_webhook_url) {
+  // Fires when the bot-backed path didn't (or couldn't) handle the event
+  // — either because no channel is linked, the bot is disabled, or the
+  // HTTP call failed — and a webhook URL is configured for the group.
+  // This is the "simple path" for groups that only set up a Discord
+  // webhook without running the bot.
+  if (!botHandled && group.discord_webhook_url) {
     const gameList = games
       .slice(0, 25)
       .map((g, i) => `**${i + 1}.** ${g.gameName}`)
       .join('\n')
 
+    const voteUrl = `${env.CORS_ORIGIN}/groups/${groupId}/vote`
+
     await postWebhook(group.discord_webhook_url, {
       embeds: [{
         title: '🎮 Nouvelle session de vote !',
-        description: `**${creatorName}** a lancé un vote dans **${group.name}**.\n\n${gameList}\n\nVotez sur le site !`,
+        description: `**${creatorName}** a lancé un vote dans **${group.name}**.\n\n${gameList}\n\n[Votez sur le site](${voteUrl})`,
         color: 0x5865F2,
+        url: voteUrl,
         timestamp: new Date().toISOString(),
         thumbnail: games[0]?.headerImageUrl ? { url: games[0].headerImageUrl } : undefined,
       }],
     })
+    logger.info(
+      { sessionId, groupId },
+      'Discord session webhook posted (fallback)',
+    )
   }
 }
 
@@ -136,6 +155,12 @@ export async function notifyVoteClosed(
 ): Promise<void> {
   const group = await db('groups').where({ id: groupId }).first()
   if (!group) return
+
+  // Track whether the bot-backed interactive message was successfully
+  // transitioned into its closed state. If it was, we skip the primary
+  // webhook broadcast to avoid a duplicate winner announcement in the
+  // same channel.
+  let botClosed = false
 
   // ── Primary: edit the bot's interactive message into closed state ───
   if (isBotClientEnabled()) {
@@ -154,6 +179,7 @@ export async function notifyVoteClosed(
         result,
         summary,
       })
+      botClosed = true
     }
   }
 
@@ -166,10 +192,12 @@ export async function notifyVoteClosed(
     .where({ group_id: groupId })
     .select('webhook_url')
 
-  // When the group has no linked channel we also want the legacy
-  // primary webhook (if set) to receive the result — otherwise it is
-  // skipped because the bot already posted a closed state above.
-  const primaryFallback = !group.discord_channel_id && group.discord_webhook_url
+  // Primary webhook fallback: fires whenever the bot didn't post a closed
+  // state (bot disabled, session was never posted by the bot, or the close
+  // HTTP call failed) and a webhook URL is configured. Mirrors the
+  // notifySessionCreated fallback so groups that rely on webhook-only get
+  // both the open announcement AND the winner reveal.
+  const primaryFallback = !botClosed && group.discord_webhook_url
     ? [group.discord_webhook_url]
     : []
 


### PR DESCRIPTION
When starting a vote on the web for a group with a linked Discord
channel, no Discord message was posted if the bot HTTP URL wasn't
configured (or the bot call failed), even when the group had a
webhook URL set. The webhook fallback was gated on the channel NOT
being linked, so the two transports were mutually exclusive.

Track whether the bot path actually handled the event (success of
postSessionCreated / postSessionClosed). When it didn't, fall through
to the webhook so every reachable integration gets a shot. Apply the
same pattern to notifyVoteClosed for symmetry, and add a clickable
link to the vote page in the session-created webhook embed.

https://claude.ai/code/session_0141DwSkUmQVtRVQjM8FzjC5