### PR TITLE
feat(vote): enforce one open session per group at the DB layer

### DIFF
--- a/packages/backend/migrations/20260415_b_unique_open_session_per_group.ts
+++ b/packages/backend/migrations/20260415_b_unique_open_session_per_group.ts
@@ -1,0 +1,53 @@
+import type { Knex } from 'knex'
+
+/**
+ * Enforce "at most one open voting session per group" at the database layer.
+ *
+ * The domain layer (createVotingSession) already does a transactional
+ * `SELECT ... FOR UPDATE` + insert, but under READ COMMITTED isolation
+ * Postgres does not acquire predicate locks on queries that return zero
+ * rows — two concurrent "start vote" requests for the same group can both
+ * pass the pre-check and both insert, yielding two `status='open'` rows
+ * for the same group.
+ *
+ * A partial unique index over `(group_id) WHERE status = 'open'` closes
+ * that window: the second concurrent INSERT fails with 23505 and the
+ * domain layer translates it to the same 409 conflict the early-exit
+ * path already returns.
+ *
+ * The index is created IF NOT EXISTS so the migration is safely
+ * idempotent even if a prior rollout ran it manually.
+ */
+export async function up(knex: Knex): Promise<void> {
+  // Before creating the unique index, deduplicate any groups that have
+  // more than one open session (legacy data, or rows that slipped
+  // through the pre-index race window). Keep the most recent row open
+  // and close the rest — we close them rather than delete so any votes
+  // already cast stay in the audit history.
+  await knex.raw(`
+    UPDATE voting_sessions
+    SET status = 'closed', closed_at = NOW()
+    WHERE id IN (
+      SELECT id FROM (
+        SELECT id,
+               ROW_NUMBER() OVER (
+                 PARTITION BY group_id
+                 ORDER BY created_at DESC, id DESC
+               ) AS rn
+        FROM voting_sessions
+        WHERE status = 'open'
+      ) ranked
+      WHERE ranked.rn > 1
+    )
+  `)
+
+  await knex.raw(`
+    CREATE UNIQUE INDEX IF NOT EXISTS uniq_voting_sessions_one_open_per_group
+    ON voting_sessions (group_id)
+    WHERE status = 'open'
+  `)
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw('DROP INDEX IF EXISTS uniq_voting_sessions_one_open_per_group')
+}

--- a/packages/backend/src/domain/__tests__/create-session.test.ts
+++ b/packages/backend/src/domain/__tests__/create-session.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// vi.hoisted — variables available inside vi.mock factories (which are hoisted)
+// ---------------------------------------------------------------------------
+
+const {
+  mockDb,
+  trxResults,
+  dbResults,
+  trxCallCounts,
+  dbCallCounts,
+  computeCommonGamesMock,
+  recordSessionEventMock,
+} = vi.hoisted(() => {
+  /**
+   * Chainable mock mimicking a Knex query builder.
+   * Every method returns the same proxy, and `await` resolves to `resolveValue`.
+   * When `resolveValue` is itself a thenable (e.g. `Promise.reject(...)`) the
+   * rejection propagates through, which is how we simulate a 23505 on insert.
+   */
+  function chain(resolveValue: unknown = undefined): unknown {
+    const proxy: unknown = new Proxy(() => {}, {
+      get(_t, prop: string) {
+        if (prop === 'then') {
+          return (res: (v: unknown) => void, rej: (e: unknown) => void) =>
+            Promise.resolve(resolveValue).then(res, rej)
+        }
+        return (..._a: unknown[]) => proxy
+      },
+      apply() {
+        return proxy
+      },
+    })
+    return proxy
+  }
+
+  const trxResults = new Map<string, unknown[]>()
+  const dbResults = new Map<string, unknown[]>()
+  const trxCallCounts = new Map<string, number>()
+  const dbCallCounts = new Map<string, number>()
+
+  function nextResult(
+    map: Map<string, unknown[]>,
+    counts: Map<string, number>,
+    table: string,
+  ): unknown {
+    const idx = counts.get(table) ?? 0
+    counts.set(table, idx + 1)
+    const arr = map.get(table)
+    if (!arr || arr.length === 0) return undefined
+    return arr[Math.min(idx, arr.length - 1)]
+  }
+
+  const noop = () => {}
+
+  const mockDb = Object.assign(
+    (table: string) => chain(nextResult(dbResults, dbCallCounts, table)),
+    {
+      transaction: async (cb: (trx: unknown) => Promise<unknown>) => {
+        const trx = Object.assign(
+          (table: string) => chain(nextResult(trxResults, trxCallCounts, table)),
+          {
+            fn: { now: () => 'NOW()' },
+            raw: noop,
+          },
+        )
+        return cb(trx)
+      },
+      raw: noop,
+    },
+  )
+
+  return {
+    mockDb,
+    trxResults,
+    dbResults,
+    trxCallCounts,
+    dbCallCounts,
+    computeCommonGamesMock: vi.fn(),
+    recordSessionEventMock: vi.fn(),
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@/infrastructure/database/connection.js', () => ({ db: mockDb }))
+
+vi.mock('@/infrastructure/logger/logger.js', () => {
+  const noop = () => {}
+  const child = () => ({ info: noop, warn: noop, error: noop, debug: noop, child })
+  return { logger: { info: noop, warn: noop, error: noop, debug: noop, child } }
+})
+
+vi.mock('@/infrastructure/database/common-games.js', () => ({
+  computeCommonGames: computeCommonGamesMock,
+}))
+
+vi.mock('@/domain/session-audit-trail.js', () => ({
+  recordSessionEvent: recordSessionEventMock,
+}))
+
+// Domain events are fire-and-forget; swallow listeners for the test.
+vi.mock('@/domain/events/event-bus.js', () => ({
+  domainEvents: { emit: () => {}, on: () => {}, removeAllListeners: () => {} },
+}))
+
+// ---------------------------------------------------------------------------
+// Import module under test (after mocks)
+// ---------------------------------------------------------------------------
+
+import { createVotingSession } from '../create-session.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setTrxResult(table: string, ...values: unknown[]) {
+  trxResults.set(table, values)
+}
+function setDbResult(table: string, ...values: unknown[]) {
+  dbResults.set(table, values)
+}
+
+const sampleGames = [
+  { steamAppId: 730, gameName: 'Counter-Strike 2', headerImageUrl: 'https://img/730.jpg' },
+  { steamAppId: 440, gameName: 'Team Fortress 2', headerImageUrl: 'https://img/440.jpg' },
+]
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createVotingSession — "one open session per group" enforcement', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    trxResults.clear()
+    dbResults.clear()
+    trxCallCounts.clear()
+    dbCallCounts.clear()
+    computeCommonGamesMock.mockResolvedValue(sampleGames)
+    recordSessionEventMock.mockResolvedValue(undefined)
+  })
+
+  function stageHappyPrechecks() {
+    // group_members.pluck → valid members list
+    setDbResult('group_members', ['u1', 'u2'])
+    // groups.first → group row (no threshold override)
+    setDbResult('groups', { common_game_threshold: null })
+    // votes.select → no previous vote counts
+    setDbResult('votes', [])
+  }
+
+  it('throws a 409 when the pre-check finds an existing open session', async () => {
+    stageHappyPrechecks()
+    // voting_sessions.first (pre-check inside trx) returns an existing row.
+    setTrxResult('voting_sessions', { id: 'existing-session-id' })
+
+    await expect(
+      createVotingSession({ groupId: 'g1', createdBy: 'u1', participantIds: ['u1', 'u2'] }),
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      errorCode: 'conflict',
+      message: 'A voting session is already open',
+    })
+
+    // We bail out of the transaction before hitting the insert path.
+    expect(recordSessionEventMock).not.toHaveBeenCalled()
+  })
+
+  it('translates Postgres 23505 unique_violation on the insert into the same 409 conflict', async () => {
+    // This simulates the race window: pre-check finds no open session,
+    // but between the SELECT and the INSERT a concurrent transaction
+    // committed an open session for the same group, so the partial
+    // unique index rejects our INSERT.
+    stageHappyPrechecks()
+
+    const uniqueViolation = Object.assign(
+      new Error(
+        'insert into "voting_sessions" - duplicate key value violates unique constraint "uniq_voting_sessions_one_open_per_group"',
+      ),
+      { code: '23505' },
+    )
+
+    // The first trx('voting_sessions') call is the FOR UPDATE pre-check
+    // (resolves to undefined — no existing session). The second call is
+    // the insert — rejects with 23505.
+    setTrxResult('voting_sessions', undefined, Promise.reject(uniqueViolation))
+    // Swallow the unhandled rejection warning emitted when Vitest sees
+    // the rejected promise we staged above before the proxy consumes it.
+    ;(trxResults.get('voting_sessions')![1] as Promise<unknown>).catch(() => {})
+
+    await expect(
+      createVotingSession({ groupId: 'g1', createdBy: 'u1', participantIds: ['u1', 'u2'] }),
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      errorCode: 'conflict',
+      message: 'A voting session is already open',
+    })
+  })
+
+  it('re-throws non-unique-violation DB errors unchanged', async () => {
+    // Defensive: a 23502 NOT NULL violation (or any other error) should
+    // propagate as-is so we don't mask real bugs as spurious 409s.
+    stageHappyPrechecks()
+
+    const otherError = Object.assign(
+      new Error('insert into "voting_sessions" - null value in column "created_by"'),
+      { code: '23502' },
+    )
+    setTrxResult('voting_sessions', undefined, Promise.reject(otherError))
+    ;(trxResults.get('voting_sessions')![1] as Promise<unknown>).catch(() => {})
+
+    await expect(
+      createVotingSession({ groupId: 'g1', createdBy: 'u1', participantIds: ['u1', 'u2'] }),
+    ).rejects.toMatchObject({
+      code: '23502',
+    })
+  })
+})

--- a/packages/backend/src/domain/create-session.ts
+++ b/packages/backend/src/domain/create-session.ts
@@ -33,6 +33,26 @@ export interface CreateSessionResult {
   games: SessionGame[]
 }
 
+/** Shape the "already open" 409 conflict uniformly in one place so both the
+ *  in-transaction pre-check and the post-insert unique-violation handler
+ *  throw the exact same error object. */
+function conflictError(): Error & { statusCode: number; errorCode: string } {
+  const err = new Error('A voting session is already open') as Error & {
+    statusCode: number
+    errorCode: string
+  }
+  err.statusCode = 409
+  err.errorCode = 'conflict'
+  return err
+}
+
+/** Postgres SQLSTATE 23505 = unique_violation. node-postgres exposes this on
+ *  `err.code`; Knex wraps it but keeps the original property. We only care
+ *  about the string match so we coerce to string defensively. */
+function isUniqueViolation(err: unknown): boolean {
+  return typeof err === 'object' && err !== null && (err as { code?: unknown }).code === '23505'
+}
+
 /**
  * Create a voting session for a group.
  * Computes common games, sorts by popularity, inserts session + participants + games,
@@ -110,8 +130,20 @@ export async function createVotingSession(params: CreateSessionParams): Promise<
     return a.gameName.localeCompare(b.gameName)
   })
 
-  // Atomic check-and-create: use a transaction with FOR UPDATE to prevent
-  // concurrent requests from both passing the "no open session" check
+  // Atomic check-and-create. Two layers of protection:
+  //
+  //  1. In-transaction `SELECT ... FOR UPDATE` + pre-check. Catches the
+  //     common case early so we can return a clean 409 without wasting
+  //     an INSERT and surfacing a Postgres error. NOTE: under READ
+  //     COMMITTED, FOR UPDATE on a query returning zero rows does NOT
+  //     acquire predicate locks, so it alone cannot prevent two
+  //     concurrent "start vote" requests from both passing this check.
+  //
+  //  2. Partial unique index `uniq_voting_sessions_one_open_per_group`
+  //     on `(group_id) WHERE status = 'open'`. The database rejects the
+  //     second concurrent insert with Postgres error 23505, which we
+  //     translate into the same 409 conflict below. This is the real
+  //     race-proof guarantee.
   const session = await db.transaction(async (trx) => {
     const existingSession = await trx('voting_sessions')
       .where({ group_id: groupId, status: 'open' })
@@ -119,18 +151,27 @@ export async function createVotingSession(params: CreateSessionParams): Promise<
       .first()
 
     if (existingSession) {
-      const err = new Error('A voting session is already open') as Error & { statusCode: number; errorCode: string }
-      err.statusCode = 409
-      err.errorCode = 'conflict'
-      throw err
+      throw conflictError()
     }
 
-    const [sess] = await trx('voting_sessions').insert({
-      group_id: groupId,
-      status: 'open',
-      created_by: createdBy,
-      ...(scheduledAt ? { scheduled_at: scheduledAt } : {}),
-    }).returning('*')
+    let sess
+    try {
+      [sess] = await trx('voting_sessions').insert({
+        group_id: groupId,
+        status: 'open',
+        created_by: createdBy,
+        ...(scheduledAt ? { scheduled_at: scheduledAt } : {}),
+      }).returning('*')
+    } catch (err) {
+      // Postgres 23505 = unique_violation. Raised when a concurrent
+      // transaction won the race and committed its own open session
+      // first. Translate to the same 409 the pre-check produces so
+      // callers only ever see one shape.
+      if (isUniqueViolation(err) && /uniq_voting_sessions_one_open_per_group/.test(String(err))) {
+        throw conflictError()
+      }
+      throw err
+    }
 
     await trx('voting_session_participants').insert(
       validMembers.map(uid => ({

--- a/packages/backend/src/presentation/routes/discord.routes.ts
+++ b/packages/backend/src/presentation/routes/discord.routes.ts
@@ -385,9 +385,18 @@ router.post('/vote/start', async (req: Request, res: Response) => {
   } catch (error) {
     const err = error as Error & { statusCode?: number; errorCode?: string }
     const status = err.statusCode || 500
+    // The Discord bot surfaces `message` verbatim to end users; the app
+    // UI is in French so translate the well-known domain errors here.
+    // Anything unrecognised falls through to the original message.
+    const message =
+      err.errorCode === 'conflict'
+        ? 'Un vote est déjà en cours dans ce groupe. Terminez-le avant d\'en démarrer un autre.'
+        : err.errorCode === 'no_common_games'
+          ? 'Aucun jeu en commun trouvé pour ce groupe. Assurez-vous que les bibliothèques Steam sont synchronisées et publiques.'
+          : err.message
     res.status(status).json({
       error: err.errorCode || 'internal',
-      message: err.message,
+      message,
     })
   }
 })

--- a/packages/frontend/src/i18n/locales/en.json
+++ b/packages/frontend/src/i18n/locales/en.json
@@ -111,6 +111,7 @@
     "syncSuccess": "Sync started!",
     "syncError": "Sync error",
     "startVoteError": "Unable to start vote",
+    "voteAlreadyOpen": "A vote is already in progress for this group. Joining the existing vote.",
     "generateInviteError": "Unable to generate invite",
     "history": "Game night history",
     "voteStarted": "A vote has just been started!",

--- a/packages/frontend/src/i18n/locales/fr.json
+++ b/packages/frontend/src/i18n/locales/fr.json
@@ -114,6 +114,7 @@
     "syncSuccess": "Synchronisation lancée !",
     "syncError": "Erreur de synchronisation",
     "startVoteError": "Impossible de lancer le vote",
+    "voteAlreadyOpen": "Un vote est déjà en cours dans ce groupe. Vous rejoignez le vote existant.",
     "generateInviteError": "Impossible de générer l'invitation",
     "history": "Historique des soirées",
     "voteStarted": "Un vote vient d'être lancé !",

--- a/packages/frontend/src/pages/GroupPage.tsx
+++ b/packages/frontend/src/pages/GroupPage.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next'
 import type { CommonGame } from '@wawptn/types'
 import { useGroupStore } from '@/stores/group.store'
 import { useAuthStore } from '@/stores/auth.store'
-import { api } from '@/lib/api'
+import { api, ApiError } from '@/lib/api'
 import { track } from '@/lib/analytics'
 import { getSocket } from '@/lib/socket'
 import { Button } from '@/components/ui/button'
@@ -198,7 +198,12 @@ export function GroupPage() {
       })
       navigate(`/groups/${id}/vote`)
     } catch (err) {
-      if (err instanceof Error && err.message.includes('already open')) {
+      // 409 conflict = another vote is already open for this group. The
+      // backend enforces "one open session per group" via a partial
+      // unique index; redirect the user to the existing vote so they
+      // can join it instead of landing on an error toast.
+      if (err instanceof ApiError && err.status === 409) {
+        toast.info(t('group.voteAlreadyOpen'))
         navigate(`/groups/${id}/vote`)
       } else {
         toast.error(err instanceof Error ? err.message : t('group.startVoteError'))


### PR DESCRIPTION
## Summary

The "one open voting session per group" rule was already enforced at the application layer, but had three gaps this PR closes:

### 1. Race window at the DB layer
Under Postgres READ COMMITTED, `SELECT ... FOR UPDATE` on a query returning zero rows doesn't acquire predicate locks — two concurrent "start vote" requests could both pass the pre-check and both insert. Added a partial unique index `voting_sessions(group_id) WHERE status='open'` and translate the resulting `23505` unique_violation into the same 409 conflict the pre-check returns. Extracted `conflictError()` / `isUniqueViolation()` helpers so both paths throw the identical shape. Migration closes any existing duplicates (keep most recent open, close the rest — votes preserved).

### 2. English message leaking into the French Discord bot reply
`POST /api/discord/vote/start` now maps `errorCode === 'conflict'` to `"Un vote est déjà en cours dans ce groupe. Terminez-le avant d'en démarrer un autre."` (and `no_common_games` too) before responding. The bot surfaces `message` verbatim to users.

### 3. Frontend matched the error by substring
`GroupPage.handleStartVote` now uses `err instanceof ApiError && err.status === 409` instead of `err.message.includes('already open')`, and surfaces a toast (`group.voteAlreadyOpen`) explaining why the user is redirected to the existing vote. Added i18n strings to `fr.json` and `en.json`.

## Test plan
- [x] New `create-session.test.ts` — 3 cases: pre-check conflict, race-window 23505 translation, unrelated DB error re-throw
- [x] 40/40 backend tests pass (3 new)
- [x] `tsc --noEmit` clean on backend + frontend
- [x] `npm run lint` clean (4 pre-existing frontend warnings)
- [ ] Smoke test after deploy: try to start a second vote in a group that already has one open — should get a toast and land on the existing vote page

https://claude.ai/code/session_0141DwSkUmQVtRVQjM8FzjC5