### PR TITLE
feat(discord): move bidirectional voting out of the premium tier

### DIFF
--- a/packages/backend/src/presentation/routes/discord.routes.ts
+++ b/packages/backend/src/presentation/routes/discord.routes.ts
@@ -362,12 +362,11 @@ router.post('/vote/start', async (req: Request, res: Response) => {
     return
   }
 
-  // Discord bot actions require group owner premium
-  const ownerPremium = await isGroupOwnerPremium(groupId)
-  if (!ownerPremium) {
-    res.status(403).json({ error: 'premium_required', message: 'Discord bot integration requires a premium subscription' })
-    return
-  }
+  // Bidirectional voting (start a vote from Discord, see it on the web,
+  // vote from either side) is part of the free tier — it's the core
+  // promise of the product per the C4 design decision (2026-04-14).
+  // Other Discord bot features (daily challenges, LLM chat) keep their
+  // own premium gates lower in this file.
 
   // Get all group members as participants
   const memberIds = await db('group_members')
@@ -1148,7 +1147,17 @@ userRouter.delete('/link', requireAuth, async (req: Request, res: Response) => {
   res.json({ ok: true, wasLinked: deleted > 0 })
 })
 
-// Set webhook URL for a group (group owner only)
+// Set webhook URL for a group (group owner only).
+//
+// Binding a Discord destination to a group is part of the free tier
+// (C4 design decision — 2026-04-14). Both binding paths must be free
+// for the promise to hold: `/setup` for users who deploy the bot in
+// their guild, and this `/webhook` endpoint for users who only want
+// one-way announcements without running a bot. Keeping only one of
+// them free would leave webhook-only adopters behind the paywall.
+//
+// Announcement webhooks (multi-channel broadcast) stay premium — see
+// `/announcements` below.
 userRouter.post('/webhook', requireAuth, async (req: Request, res: Response) => {
   const userId = req.userId!
   const { groupId, webhookUrl } = req.body as { groupId: string; webhookUrl: string }
@@ -1164,13 +1173,6 @@ userRouter.post('/webhook', requireAuth, async (req: Request, res: Response) => 
 
   if (!membership) {
     res.status(403).json({ error: 'forbidden', message: 'Only group owners can set the webhook URL' })
-    return
-  }
-
-  // Discord webhook requires premium
-  const premium = await isUserPremium(userId)
-  if (!premium) {
-    res.status(403).json({ error: 'premium_required', message: 'Discord webhook requires a premium subscription' })
     return
   }
 


### PR DESCRIPTION
## Summary

Bidirectional voting is the core product promise: start a vote anywhere (web or Discord), see it everywhere, vote from either side. For "Salon = Groupe" (C4 design decision, 2026-04-14) to hold, this loop has to be free. Two endpoints were still gated and blocking that:

- **`POST /discord/vote/start`** — required group-owner premium, so `/wawptn-vote` couldn't start a session in a free group even though the web `POST /api/groups/:id/vote` creates sessions for free. Inconsistent gate across surfaces.
- **`POST /discord/webhook`** — required user premium to bind a webhook URL to a group. The parallel `POST /discord/setup` (bot binding) was already moved to free in C4, so this left webhook-only adopters (no bot deployed) behind the paywall for the same action.

This PR removes both premium checks and leaves a comment on each route documenting the C4 rationale.

## Scope (what stays premium)
Everything else from the audit on wifsimster/wawptn#143:
- Auto-vote cron (`auto_vote_schedule`)
- Vote scheduling (`scheduledAt`)
- `group_announcement_webhooks` (multi-channel broadcast)
- Discord daily challenges
- Discord LLM chat (real LLM cost)
- `>2` groups per free user / `>8` members per free group

## Test plan
- [x] Backend tests: 40/40 pass
- [x] `tsc --noEmit` clean
- [x] `npm run lint` clean (4 pre-existing warnings)
- [ ] Smoke test after deploy: start `/wawptn-vote` as a free user in a group whose owner is also free — should succeed and post the interactive message in the linked channel
- [ ] Set a webhook URL via `POST /api/discord/webhook` as a free user — should return 200 instead of 403

Related: wifsimster/wawptn#143

https://claude.ai/code/session_0141DwSkUmQVtRVQjM8FzjC5