### PR TITLE
feat(discord): move daily challenges out of the premium tier

### DIFF
--- a/packages/backend/src/presentation/routes/discord.routes.ts
+++ b/packages/backend/src/presentation/routes/discord.routes.ts
@@ -480,12 +480,11 @@ router.post('/daily-challenge/create', async (req: Request, res: Response) => {
       return
     }
 
-    // Check premium (Discord bot integration requires group owner premium)
-    const ownerPremium = await isGroupOwnerPremium(group.id)
-    if (!ownerPremium) {
-      res.status(403).json({ error: 'premium_required', message: 'Discord bot integration requires a premium subscription' })
-      return
-    }
+    // Daily challenges are part of the free "groupe vivant" baseline —
+    // the goal is to keep linked channels active without asking users
+    // to upgrade first. Premium still covers features with real cost
+    // or broadcast scope (LLM chat, announcement multi-webhooks,
+    // auto-vote cron, scheduled votes).
 
     // Compute today's date in Europe/Paris timezone
     const todayRow = await db.raw(`SELECT (now() AT TIME ZONE 'Europe/Paris')::date AS today`)


### PR DESCRIPTION
## Summary

Daily challenges are part of the free "groupe vivant" baseline: their purpose is to keep linked Discord channels active without asking users to upgrade first. Gating creation behind premium defeats the engagement loop the feature was built to drive.

Remove the group-owner premium check on `POST /discord/daily-challenge/create`. `/daily-challenge/claim` and `PATCH /daily-challenge/:id/message` were already free, so this aligns the whole sub-feature on a single tier.

## What stays premium
Premium still covers features with real cost or broadcast scope:
- LLM chat via Discord
- Announcement multi-webhooks (`group_announcement_webhooks`)
- Auto-vote cron
- Scheduled votes (`scheduledAt`)
- `>2` groups per free user / `>8` members per free group / `>20` members per premium group

## Test plan
- [x] 40/40 backend tests pass
- [x] `tsc --noEmit` clean
- [x] `npm run lint` clean (4 pre-existing warnings)
- [ ] Smoke test after deploy: `/wawptn-daily-challenge` in a linked channel whose owner is free — should create the challenge instead of returning 403

Related: wifsimster/wawptn#143

https://claude.ai/code/session_0141DwSkUmQVtRVQjM8FzjC5