### PR TITLE
fix(frontend): improve landing page footer contrast

### DIFF
--- a/packages/frontend/src/pages/LandingPage.tsx
+++ b/packages/frontend/src/pages/LandingPage.tsx
@@ -384,10 +384,10 @@ export function LandingPage() {
       </section>
 
       {/* ═══ FOOTER ═══ */}
-      <footer className="border-t border-white/[0.04] px-4 py-10 mt-auto">
-        <div className="max-w-5xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-muted-foreground/25">
+      <footer className="border-t border-white/[0.08] px-4 py-10 mt-auto">
+        <div className="max-w-5xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-muted-foreground">
           <div className="flex items-center gap-2.5">
-            <WawptnLogo size={20} className="text-muted-foreground/25" />
+            <WawptnLogo size={20} className="text-muted-foreground" />
             <span className="tracking-wide">
               WAWPTN — {t('app.tagline')} — v{__APP_VERSION__} — {new Date(__BUILD_TIME__).toLocaleDateString('fr-FR', { day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit' })}
             </span>


### PR DESCRIPTION
## Summary
- Bump landing page footer text and logo from `text-muted-foreground/25` to full `text-muted-foreground` so version/tagline/privacy text is actually legible
- Slightly strengthen the top border (`white/[0.04]` → `white/[0.08]`) so the footer separates cleanly from the pricing section

## Test plan
- [ ] Visit `/` (landing page) and confirm the footer text and logo are readable on the dark background
- [ ] Confirm other pages (which use the global `AppFooter` component) are unchanged
