### PR TITLE
feat(a11y): improve WCAG 2.1 AA compliance across frontend

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -71,7 +71,13 @@ function App() {
 
   if (loading) {
     return (
-      <div className="min-h-screen flex flex-col items-center justify-center gap-4">
+      <div
+        className="min-h-screen flex flex-col items-center justify-center gap-4"
+        role="status"
+        aria-busy="true"
+        aria-live="polite"
+        aria-label="Chargement de l'application"
+      >
         <Skeleton className="h-12 w-12 rounded-full" />
         <Skeleton className="h-4 w-32" />
       </div>

--- a/packages/frontend/src/components/app-header.tsx
+++ b/packages/frontend/src/components/app-header.tsx
@@ -56,11 +56,12 @@ export function AppHeader({ children, className, maxWidth = 'narrow' }: AppHeade
           </div>
         )}
         <button
+          type="button"
           onClick={() => navigate('/')}
           className="flex items-center gap-2 hover:opacity-80 transition-opacity shrink-0"
           aria-label={t('app.name') + ' — ' + t('app.tagline')}
         >
-          <WawptnLogo size={28} className="text-primary" />
+          <WawptnLogo size={28} className="text-primary" aria-hidden="true" />
           <span className={cn('font-heading font-bold text-lg tracking-[-0.03em]', children ? 'hidden sm:inline' : 'inline')}>WAWPTN</span>
         </button>
         <div className={cn('flex-1', children && 'hidden sm:block')} />
@@ -72,6 +73,7 @@ export function AppHeader({ children, className, maxWidth = 'narrow' }: AppHeade
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <button
+              type="button"
               className="flex items-center justify-center rounded-full hover:ring-2 hover:ring-primary/20 transition-all p-1.5 -m-1 min-h-[44px] min-w-[44px]"
               aria-label={t('profile.title')}
             >

--- a/packages/frontend/src/components/celebration-particles.tsx
+++ b/packages/frontend/src/components/celebration-particles.tsx
@@ -41,7 +41,7 @@ export function CelebrationParticles({ count = 18 }: CelebrationParticlesProps =
   const [particles] = useState<Particle[]>(() => createParticles(count))
 
   return (
-    <div className="pointer-events-none absolute inset-0 overflow-hidden">
+    <div className="pointer-events-none absolute inset-0 overflow-hidden motion-reduce:hidden" aria-hidden="true">
       {particles.map(p => (
         <motion.div
           key={p.id}

--- a/packages/frontend/src/components/cron-autocomplete.tsx
+++ b/packages/frontend/src/components/cron-autocomplete.tsx
@@ -115,6 +115,9 @@ export function CronAutocomplete({ id, value, onChange, placeholder, autoFocus }
     return match ? t(match.labelKey) : null
   }, [value, t])
 
+  const listboxId = id ? `${id}-listbox` : undefined
+  const activeOptionId = id && activeIndex >= 0 ? `${id}-option-${activeIndex}` : undefined
+
   return (
     <div ref={containerRef} className="relative">
       <div className="relative">
@@ -124,7 +127,8 @@ export function CronAutocomplete({ id, value, onChange, placeholder, autoFocus }
           role="combobox"
           aria-expanded={open}
           aria-autocomplete="list"
-          aria-controls={id ? `${id}-listbox` : undefined}
+          aria-controls={listboxId}
+          aria-activedescendant={open ? activeOptionId : undefined}
           value={value}
           onChange={(e) => {
             onChange(e.target.value)
@@ -166,7 +170,7 @@ export function CronAutocomplete({ id, value, onChange, placeholder, autoFocus }
           ) : (
             <ul
               ref={listRef}
-              id={id ? `${id}-listbox` : undefined}
+              id={listboxId}
               role="listbox"
               className="max-h-60 overflow-y-auto py-1"
             >
@@ -176,6 +180,7 @@ export function CronAutocomplete({ id, value, onChange, placeholder, autoFocus }
                 return (
                   <li
                     key={preset.expression}
+                    id={id ? `${id}-option-${index}` : undefined}
                     data-index={index}
                     role="option"
                     aria-selected={isSelected}

--- a/packages/frontend/src/components/error-boundary.tsx
+++ b/packages/frontend/src/components/error-boundary.tsx
@@ -28,13 +28,13 @@ class ErrorBoundaryInner extends Component<Props, State> {
 
     if (this.state.hasError) {
       return (
-        <div className="min-h-screen flex flex-col items-center justify-center px-4">
+        <main id="main-content" role="alert" className="min-h-screen flex flex-col items-center justify-center px-4">
           <h1 className="text-2xl font-bold mb-2">{t('error.title', "Oups, quelque chose s'est mal passe")}</h1>
           <p className="text-muted-foreground mb-6">{t('error.description', 'Une erreur inattendue est survenue.')}</p>
-          <Button onClick={() => { this.setState({ hasError: false }); window.location.href = '/' }}>
+          <Button type="button" onClick={() => { this.setState({ hasError: false }); window.location.href = '/' }}>
             {t('error.backHome', "Retour a l'accueil")}
           </Button>
-        </div>
+        </main>
       )
     }
 

--- a/packages/frontend/src/components/group-stats.tsx
+++ b/packages/frontend/src/components/group-stats.tsx
@@ -170,14 +170,16 @@ export function GroupStats({ groupId, compact = false }: GroupStatsProps) {
           type="button"
           className="w-full flex items-center justify-between"
           onClick={() => setExpanded(!expanded)}
+          aria-expanded={expanded}
+          aria-controls="group-stats-panel-compact"
         >
           <h2 className="font-semibold flex items-center gap-2 text-sm">
-            <BarChart3 className="w-4 h-4" />
+            <BarChart3 className="w-4 h-4" aria-hidden="true" />
             {t('stats.title')}
           </h2>
-          {expanded ? <ChevronUp className="w-4 h-4 text-muted-foreground" /> : <ChevronDown className="w-4 h-4 text-muted-foreground" />}
+          {expanded ? <ChevronUp className="w-4 h-4 text-muted-foreground" aria-hidden="true" /> : <ChevronDown className="w-4 h-4 text-muted-foreground" aria-hidden="true" />}
         </button>
-        {expanded && content}
+        {expanded && <div id="group-stats-panel-compact">{content}</div>}
       </div>
     )
   }
@@ -189,16 +191,18 @@ export function GroupStats({ groupId, compact = false }: GroupStatsProps) {
           type="button"
           className="w-full flex items-center justify-between"
           onClick={() => setExpanded(!expanded)}
+          aria-expanded={expanded}
+          aria-controls="group-stats-panel"
         >
           <h2 className="font-semibold flex items-center gap-2 text-sm">
-            <BarChart3 className="w-4 h-4" />
+            <BarChart3 className="w-4 h-4" aria-hidden="true" />
             {t('stats.title')}
           </h2>
-          {expanded ? <ChevronUp className="w-4 h-4 text-muted-foreground" /> : <ChevronDown className="w-4 h-4 text-muted-foreground" />}
+          {expanded ? <ChevronUp className="w-4 h-4 text-muted-foreground" aria-hidden="true" /> : <ChevronDown className="w-4 h-4 text-muted-foreground" aria-hidden="true" />}
         </button>
       </CardHeader>
       {expanded && (
-        <CardContent>
+        <CardContent id="group-stats-panel">
           {content}
         </CardContent>
       )}

--- a/packages/frontend/src/components/notification-bell.tsx
+++ b/packages/frontend/src/components/notification-bell.tsx
@@ -75,19 +75,30 @@ export function NotificationBell() {
     }
   }
 
+  const bellLabel = unreadCount > 0
+    ? t('notifications.titleWithCount', {
+        defaultValue: '{{title}} ({{count}} non lues)',
+        title: t('notifications.title'),
+        count: unreadCount,
+      })
+    : t('notifications.title')
+
   return (
     <div className="relative">
       <button
+        type="button"
         onClick={handleOpen}
+        aria-haspopup="menu"
+        aria-expanded={open}
         className="relative flex items-center justify-center rounded-full hover:bg-white/[0.06] transition-colors p-2 -m-1 min-h-[44px] min-w-[44px]"
-        aria-label={t('notifications.title')}
+        aria-label={bellLabel}
       >
         <motion.div
           key={bellAnimationKey}
           animate={{ rotate: [0, 12, -12, 8, -8, 0] }}
           transition={{ duration: 0.4 }}
         >
-          <Bell className="w-5 h-5" />
+          <Bell className="w-5 h-5" aria-hidden="true" />
         </motion.div>
         <AnimatePresence>
           {unreadCount > 0 && (
@@ -95,6 +106,7 @@ export function NotificationBell() {
               initial={{ scale: 0 }}
               animate={{ scale: [0, 1.2, 1] }}
               exit={{ scale: 0 }}
+              aria-hidden="true"
               className="absolute top-1.5 right-1.5 w-2.5 h-2.5 bg-destructive rounded-full"
             />
           )}
@@ -105,13 +117,15 @@ export function NotificationBell() {
         {open && (
           <>
             {/* Backdrop */}
-            <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} />
+            <div className="fixed inset-0 z-40" aria-hidden="true" onClick={() => setOpen(false)} />
 
             <motion.div
               initial={{ opacity: 0, y: -8 }}
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -8 }}
               transition={{ duration: 0.15 }}
+              role="dialog"
+              aria-label={t('notifications.title')}
               className="absolute right-0 top-full mt-1 z-50 w-80 max-w-[calc(100vw-2rem)] max-h-[calc(100vh-5rem)] rounded-md border border-border bg-popover shadow-md overflow-hidden flex flex-col"
             >
               {/* Header */}
@@ -119,10 +133,11 @@ export function NotificationBell() {
                 <span className="text-sm font-medium">{t('notifications.title')}</span>
                 {unreadCount > 0 && (
                   <button
+                    type="button"
                     onClick={() => markAllAsRead()}
                     className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
                   >
-                    <CheckCheck className="w-3.5 h-3.5" />
+                    <CheckCheck className="w-3.5 h-3.5" aria-hidden="true" />
                     {t('notifications.markAllRead')}
                   </button>
                 )}
@@ -134,10 +149,11 @@ export function NotificationBell() {
                   they click "Enable" and grant or deny. */}
               {permission === 'default' && (
                 <button
+                  type="button"
                   onClick={handleEnableNotifications}
                   className="flex items-center gap-2 px-3 py-2 border-b border-border text-xs text-muted-foreground hover:text-foreground hover:bg-accent/30 transition-colors"
                 >
-                  <BellRing className="w-3.5 h-3.5 text-primary" />
+                  <BellRing className="w-3.5 h-3.5 text-primary" aria-hidden="true" />
                   {t('pwa.enableNotifications')}
                 </button>
               )}

--- a/packages/frontend/src/components/share-button.tsx
+++ b/packages/frontend/src/components/share-button.tsx
@@ -200,7 +200,7 @@ function ShareMenuItem({
       className={cn(
         'relative flex w-full cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-2 text-sm outline-none',
         'transition-colors hover:bg-accent hover:text-accent-foreground',
-        'focus-visible:bg-accent focus-visible:text-accent-foreground'
+        'focus-visible:bg-accent focus-visible:text-accent-foreground focus-visible:ring-[2px] focus-visible:ring-ring/60'
       )}
     >
       <span className="flex h-4 w-4 items-center justify-center text-muted-foreground">

--- a/packages/frontend/src/components/ui/dropdown-menu.tsx
+++ b/packages/frontend/src/components/ui/dropdown-menu.tsx
@@ -22,7 +22,7 @@ function DropdownMenuSubTrigger({
     <DropdownMenuPrimitive.SubTrigger
       data-slot="dropdown-menu-sub-trigger"
       className={cn(
-        'flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+        'flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus-visible:ring-[2px] focus-visible:ring-ring/60 data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
         inset && 'pl-8',
         className
       )}
@@ -82,7 +82,7 @@ function DropdownMenuItem({
     <DropdownMenuPrimitive.Item
       data-slot="dropdown-menu-item"
       className={cn(
-        'relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+        'relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground focus-visible:ring-[2px] focus-visible:ring-ring/60 data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
         inset && 'pl-8',
         className
       )}

--- a/packages/frontend/src/components/vote-setup-dialog.tsx
+++ b/packages/frontend/src/components/vote-setup-dialog.tsx
@@ -210,7 +210,7 @@ export function VoteSetupDialog({ open, onOpenChange, members, groupId, onlineMe
                 tabIndex={0}
                 onClick={toggleAll}
                 onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleAll() } }}
-                className="flex items-center gap-3 py-3 px-2 -mx-2 rounded-md cursor-pointer hover:bg-accent/50 active:bg-accent/10 transition-colors"
+                className="flex items-center gap-3 py-3 px-2 -mx-2 rounded-md cursor-pointer hover:bg-accent/50 active:bg-accent/10 transition-colors focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/40"
               >
                 <Checkbox
                   id="select-all"
@@ -376,7 +376,7 @@ export function VoteSetupDialog({ open, onOpenChange, members, groupId, onlineMe
                     value={scheduledDate}
                     min={minDateTime}
                     onChange={(e) => setScheduledDate(e.target.value)}
-                    className="w-full rounded-lg border border-border bg-background px-3 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+                    className="w-full rounded-lg border border-border bg-background px-3 py-3 text-sm focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/40 focus-visible:border-primary/30"
                   />
                   <p className="text-xs text-muted-foreground">
                     {t('voteSetup.scheduleHint')}

--- a/packages/frontend/src/hooks/useDocumentTitle.ts
+++ b/packages/frontend/src/hooks/useDocumentTitle.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react'
+
+const BASE_TITLE = 'WAWPTN'
+
+/**
+ * Set `document.title` while the component is mounted, restoring the
+ * previous value on unmount. Improves screen-reader context on route
+ * changes (WCAG 2.4.2 Page Titled).
+ */
+export function useDocumentTitle(title: string | null | undefined) {
+  useEffect(() => {
+    if (!title) return
+    const previous = document.title
+    document.title = `${title} — ${BASE_TITLE}`
+    return () => {
+      document.title = previous
+    }
+  }, [title])
+}

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -613,3 +613,19 @@
   overscroll-behavior: contain;
   touch-action: pan-y;
 }
+
+/* ── Global reduced-motion override ──
+   WCAG 2.3.3: honour users who prefer reduced motion by neutralising
+   non-essential animations and transitions across the entire app
+   (Framer Motion, Tailwind transitions, custom keyframes). Keep
+   opacity transitions short so async UI still fades in gracefully. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/packages/frontend/src/pages/AdminPage.tsx
+++ b/packages/frontend/src/pages/AdminPage.tsx
@@ -31,6 +31,7 @@ import {
 import { useAuthStore } from '@/stores/auth.store'
 import { api } from '@/lib/api'
 import { cn } from '@/lib/utils'
+import { useDocumentTitle } from '@/hooks/useDocumentTitle'
 
 /* ─── Types ─────────────────────────────────────────── */
 
@@ -206,6 +207,7 @@ const tabContent: Variants = {
 /* ─── Main component ────────────────────────────────── */
 
 export function AdminPage() {
+  useDocumentTitle('Administration')
   const navigate = useNavigate()
   const { user } = useAuthStore()
   const [activeTab, setActiveTab] = useState<AdminTab>('overview')

--- a/packages/frontend/src/pages/ComparePage.tsx
+++ b/packages/frontend/src/pages/ComparePage.tsx
@@ -10,6 +10,7 @@ import { StatDiffChip } from '@/components/stat-diff-chip'
 import { PlaytimeBar } from '@/components/playtime-bar'
 import { useAuthStore } from '@/stores/auth.store'
 import { useProfileStore } from '@/stores/profile.store'
+import { useDocumentTitle } from '@/hooks/useDocumentTitle'
 
 function toHours(minutes: number | null): number {
   if (!minutes || minutes <= 0) return 0
@@ -28,6 +29,7 @@ function compareKey(a: string, b: string): string {
  * "compare with me" button only needs to pass `b`.
  */
 export function ComparePage() {
+  useDocumentTitle('Comparaison')
   const [params] = useSearchParams()
   const navigate = useNavigate()
   const { user: me } = useAuthStore()
@@ -70,7 +72,7 @@ export function ComparePage() {
         </AppHeader>
         <main id="main-content" className="max-w-2xl mx-auto w-full p-4 flex-1 flex items-center justify-center text-center">
           <div>
-            <h2 className="text-lg font-semibold">Comparaison impossible</h2>
+            <h1 className="text-lg font-semibold">Comparaison impossible</h1>
             <p className="text-sm text-muted-foreground mt-2">
               Il faut deux utilisateurs différents pour lancer une comparaison.
             </p>
@@ -89,7 +91,14 @@ export function ComparePage() {
             <ArrowLeft className="h-5 w-5" />
           </Button>
         </AppHeader>
-        <main id="main-content" className="max-w-3xl mx-auto w-full p-4 space-y-4">
+        <main
+          id="main-content"
+          className="max-w-3xl mx-auto w-full p-4 space-y-4"
+          role="status"
+          aria-busy="true"
+          aria-live="polite"
+          aria-label="Chargement de la comparaison"
+        >
           <Skeleton className="h-32 rounded-2xl" />
           <Skeleton className="h-6 w-32" />
           {[1, 2, 3].map((i) => <Skeleton key={i} className="h-16 rounded-xl" />)}
@@ -109,7 +118,7 @@ export function ComparePage() {
         </AppHeader>
         <main id="main-content" className="max-w-2xl mx-auto w-full p-4 flex-1 flex items-center justify-center text-center">
           <div>
-            <h2 className="text-lg font-semibold">Comparaison indisponible</h2>
+            <h1 className="text-lg font-semibold">Comparaison indisponible</h1>
             <p className="text-sm text-muted-foreground mt-2">
               Vous devez partager un groupe avec ces deux utilisateurs pour les comparer.
             </p>
@@ -137,6 +146,7 @@ export function ComparePage() {
       </AppHeader>
 
       <main id="main-content" className="max-w-3xl mx-auto w-full p-4 space-y-6 pb-12">
+        <h1 className="sr-only">Comparaison de {nameA} et {nameB}</h1>
         {/* ── VS header ── */}
         <div className="rounded-2xl border border-border/50 bg-card/50 backdrop-blur-sm p-6">
           <div className="flex items-center justify-center gap-4 sm:gap-8">

--- a/packages/frontend/src/pages/DiscordLinkPage.tsx
+++ b/packages/frontend/src/pages/DiscordLinkPage.tsx
@@ -6,9 +6,11 @@ import { useTranslation } from 'react-i18next'
 import { useAuthStore } from '@/stores/auth.store'
 import { api } from '@/lib/api'
 import { Button } from '@/components/ui/button'
+import { useDocumentTitle } from '@/hooks/useDocumentTitle'
 
 export function DiscordLinkPage() {
   const { t } = useTranslation()
+  useDocumentTitle(t('discordLink.title'))
   const [searchParams] = useSearchParams()
   const navigate = useNavigate()
   const { user } = useAuthStore()
@@ -39,60 +41,66 @@ export function DiscordLinkPage() {
   // No code in URL
   if (!code) {
     return (
-      <div className="min-h-screen flex flex-col items-center justify-center px-4">
-        <X className="w-12 h-12 text-destructive mb-4" />
+      <main id="main-content" className="min-h-screen flex flex-col items-center justify-center px-4">
+        <X className="w-12 h-12 text-destructive mb-4" aria-hidden="true" />
         <h1 className="text-2xl font-bold mb-2">{t('discordLink.invalidCode')}</h1>
         <p className="text-muted-foreground mb-6">{t('discordLink.noCode')}</p>
         <Button onClick={() => navigate('/')}>{t('discordLink.goHome')}</Button>
-      </div>
+      </main>
     )
   }
 
   // Not logged in — prompt to log in
   if (!user) {
     return (
-      <div className="min-h-screen flex flex-col items-center justify-center px-4">
-        <Gamepad2 className="w-12 h-12 text-primary mb-4" />
+      <main id="main-content" className="min-h-screen flex flex-col items-center justify-center px-4">
+        <Gamepad2 className="w-12 h-12 text-primary mb-4" aria-hidden="true" />
         <h1 className="text-2xl font-bold mb-2">{t('discordLink.title')}</h1>
         <p className="text-muted-foreground mb-6">{t('discordLink.loginPrompt')}</p>
         <Button variant="steam" size="lg" asChild>
           <a href={`/api/auth/steam/login?returnTo=${encodeURIComponent(`/discord/link?code=${code}`)}`}>{t('login.signIn')}</a>
         </Button>
-      </div>
+      </main>
     )
   }
 
   // Linking in progress
   if (linking) {
     return (
-      <div className="min-h-screen flex flex-col items-center justify-center">
-        <Loader2 className="w-8 h-8 animate-spin text-primary mb-4" />
+      <main
+        id="main-content"
+        className="min-h-screen flex flex-col items-center justify-center"
+        role="status"
+        aria-busy="true"
+        aria-live="polite"
+      >
+        <Loader2 className="w-8 h-8 animate-spin text-primary mb-4" aria-hidden="true" />
         <p className="text-muted-foreground">{t('discordLink.linking')}</p>
-      </div>
+      </main>
     )
   }
 
   // Success
   if (discordUsername) {
     return (
-      <div className="min-h-screen flex flex-col items-center justify-center px-4">
-        <Check className="w-12 h-12 text-success mb-4" />
+      <main id="main-content" className="min-h-screen flex flex-col items-center justify-center px-4">
+        <Check className="w-12 h-12 text-success mb-4" aria-hidden="true" />
         <h1 className="text-2xl font-bold mb-2">{t('discordLink.linked')}</h1>
         <p className="text-muted-foreground mb-6">
           {t('discordLink.linkedDescription', { username: discordUsername })}
         </p>
         <Button onClick={() => navigate('/')}>{t('discordLink.goHome')}</Button>
-      </div>
+      </main>
     )
   }
 
   // Error
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center px-4">
-      <X className="w-12 h-12 text-destructive mb-4" />
+    <main id="main-content" className="min-h-screen flex flex-col items-center justify-center px-4" role="alert">
+      <X className="w-12 h-12 text-destructive mb-4" aria-hidden="true" />
       <h1 className="text-2xl font-bold mb-2">{t('discordLink.failed')}</h1>
       <p className="text-muted-foreground mb-6">{error}</p>
       <Button onClick={() => navigate('/')}>{t('discordLink.goHome')}</Button>
-    </div>
+    </main>
   )
 }

--- a/packages/frontend/src/pages/GroupPage.tsx
+++ b/packages/frontend/src/pages/GroupPage.tsx
@@ -27,12 +27,14 @@ import { RandomPickModal } from '@/components/random-pick-modal'
 import { VoteSetupDialog } from '@/components/vote-setup-dialog'
 import { TonightPickHero } from '@/components/tonight-pick-hero'
 import { PersonaBadge } from '@/components/persona-badge'
+import { useDocumentTitle } from '@/hooks/useDocumentTitle'
 
 export function GroupPage() {
   const { t } = useTranslation()
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
   const { currentGroup, fetchGroup, leaveGroup, deleteGroup, renameGroup } = useGroupStore()
+  useDocumentTitle(currentGroup?.name ?? t('groups.title'))
   const { user } = useAuthStore()
   const [commonGames, setCommonGames] = useState<CommonGame[]>([])
   const [syncing, setSyncing] = useState(false)
@@ -316,7 +318,14 @@ export function GroupPage() {
         <AppHeader maxWidth="wide">
           <Skeleton className="h-5 w-5 rounded" />
         </AppHeader>
-        <main id="main-content" className="max-w-6xl mx-auto p-4">
+        <main
+          id="main-content"
+          className="max-w-6xl mx-auto p-4"
+          role="status"
+          aria-busy="true"
+          aria-live="polite"
+          aria-label={t('common.loading', 'Chargement…')}
+        >
           <div className="lg:grid lg:grid-cols-[280px_1fr] lg:gap-6">
             <Skeleton className="hidden lg:block h-[300px] rounded-lg" />
             <Skeleton className="h-[400px] w-full rounded-lg" />

--- a/packages/frontend/src/pages/GroupsPage.tsx
+++ b/packages/frontend/src/pages/GroupsPage.tsx
@@ -23,6 +23,7 @@ import { AppHeader } from '@/components/app-header'
 import { AppFooter } from '@/components/app-footer'
 import { InviteLink } from '@/components/invite-link'
 import { PersonaBadge } from '@/components/persona-badge'
+import { useDocumentTitle } from '@/hooks/useDocumentTitle'
 
 const fadeUp: Variants = {
   hidden: { opacity: 0, y: 16 },
@@ -40,6 +41,7 @@ const stagger: Variants = {
 
 export function GroupsPage() {
   const { t } = useTranslation()
+  useDocumentTitle(t('groups.title'))
   const { groups, loading, fetchGroups, createGroup, joinGroup } = useGroupStore()
   const navigate = useNavigate()
   const [refreshing, setRefreshing] = useState(false)
@@ -236,7 +238,7 @@ export function GroupsPage() {
           </div>
         )}
         <div className="flex flex-wrap items-center justify-between gap-2 mb-6">
-          <h2 className="text-2xl font-heading font-bold tracking-[-0.03em]">{t('groups.title')}</h2>
+          <h1 className="text-2xl font-heading font-bold tracking-[-0.03em]">{t('groups.title')}</h1>
           <div className="flex gap-2">
             <Button variant="secondary" size="sm" onClick={() => setShowJoin(true)}>
               <LogIn className="w-4 h-4" />
@@ -383,7 +385,13 @@ export function GroupsPage() {
 
         {/* Groups List */}
         {loading ? (
-          <div className="space-y-3">
+          <div
+            className="space-y-3"
+            role="status"
+            aria-busy="true"
+            aria-live="polite"
+            aria-label={t('common.loading', 'Chargement…')}
+          >
             {[0, 1, 2].map((i) => (
               <Skeleton
                 key={i}

--- a/packages/frontend/src/pages/JoinPage.tsx
+++ b/packages/frontend/src/pages/JoinPage.tsx
@@ -9,6 +9,7 @@ import { useAuthStore } from '@/stores/auth.store'
 import { api } from '@/lib/api'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
+import { useDocumentTitle } from '@/hooks/useDocumentTitle'
 
 const fadeUp: Variants = {
   hidden: { opacity: 0, y: 16 },
@@ -26,6 +27,7 @@ const stagger: Variants = {
 
 export function JoinPage() {
   const { t } = useTranslation()
+  useDocumentTitle(t('join.title', 'Rejoindre un groupe'))
   const { token } = useParams<{ token: string }>()
   const navigate = useNavigate()
   const { user } = useAuthStore()

--- a/packages/frontend/src/pages/LandingPage.tsx
+++ b/packages/frontend/src/pages/LandingPage.tsx
@@ -12,6 +12,7 @@ import { motion, type Variants } from 'framer-motion'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { WawptnLogo } from '@/components/icons/wawptn-logo'
+import { useDocumentTitle } from '@/hooks/useDocumentTitle'
 
 const fadeUp: Variants = {
   hidden: { opacity: 0, y: 32 },
@@ -51,9 +52,11 @@ const ACCENT_STYLES = {
 
 export function LandingPage() {
   const { t } = useTranslation()
+  useDocumentTitle(t('landing.headlineLine2'))
 
   return (
     <div className="min-h-screen flex flex-col overflow-x-hidden">
+      <main id="main-content">
       {/* ═══ HERO ═══ */}
       <section className="relative min-h-[100dvh] flex flex-col items-center justify-center px-4 py-24">
         {/* Top accent line with neon glow */}
@@ -382,6 +385,8 @@ export function LandingPage() {
           </motion.div>
         </div>
       </section>
+
+      </main>
 
       {/* ═══ FOOTER ═══ */}
       <footer className="border-t border-white/[0.04] px-4 py-10 mt-auto">

--- a/packages/frontend/src/pages/NotFoundPage.tsx
+++ b/packages/frontend/src/pages/NotFoundPage.tsx
@@ -2,17 +2,19 @@ import { useNavigate } from 'react-router-dom'
 import { SearchX } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
+import { useDocumentTitle } from '@/hooks/useDocumentTitle'
 
 export function NotFoundPage() {
   const { t } = useTranslation()
+  useDocumentTitle(t('notFound.title'))
   const navigate = useNavigate()
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center px-4">
-      <SearchX className="w-12 h-12 text-muted-foreground mb-4" />
+    <main id="main-content" className="min-h-screen flex flex-col items-center justify-center px-4">
+      <SearchX className="w-12 h-12 text-muted-foreground mb-4" aria-hidden="true" />
       <h1 className="text-2xl font-bold mb-2">{t('notFound.title')}</h1>
       <p className="text-muted-foreground mb-6">{t('notFound.description')}</p>
       <Button onClick={() => navigate('/')}>{t('notFound.backHome')}</Button>
-    </div>
+    </main>
   )
 }

--- a/packages/frontend/src/pages/ProfilePage.tsx
+++ b/packages/frontend/src/pages/ProfilePage.tsx
@@ -19,6 +19,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { api } from '@/lib/api'
 import { useChallengeStore } from '@/stores/challenge.store'
 import { ChallengeCard } from '@/components/challenge-card'
+import { useDocumentTitle } from '@/hooks/useDocumentTitle'
 
 interface Platform {
   id: string
@@ -176,6 +177,7 @@ const statItem: Variants = {
 
 export function ProfilePage() {
   const { t } = useTranslation()
+  useDocumentTitle(t('profile.title'))
   const navigate = useNavigate()
   const [profile, setProfile] = useState<Profile | null>(null)
   const [loading, setLoading] = useState(true)
@@ -335,7 +337,14 @@ export function ProfilePage() {
             <ArrowLeft className="h-5 w-5" />
           </Button>
         </AppHeader>
-        <main id="main-content" className="max-w-2xl mx-auto p-4 space-y-6">
+        <main
+          id="main-content"
+          className="max-w-2xl mx-auto p-4 space-y-6"
+          role="status"
+          aria-busy="true"
+          aria-live="polite"
+          aria-label={t('common.loading', 'Chargement…')}
+        >
           <Skeleton className="h-80 rounded-2xl" />
           <div className="space-y-3 pt-2">
             <Skeleton className="h-4 w-48" />
@@ -390,12 +399,12 @@ export function ProfilePage() {
             </motion.div>
 
             {/* Display name — holographic gradient */}
-            <motion.h2
+            <motion.h1
               variants={nameReveal}
               className="profile-holo-name text-2xl sm:text-3xl font-heading font-bold tracking-tight mb-1.5"
             >
               {profile.displayName}
-            </motion.h2>
+            </motion.h1>
 
             {/* Member since */}
             <motion.p

--- a/packages/frontend/src/pages/SubscriptionPage.tsx
+++ b/packages/frontend/src/pages/SubscriptionPage.tsx
@@ -10,9 +10,11 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { useSubscriptionStore } from '@/stores/subscription.store'
 import { api } from '@/lib/api'
+import { useDocumentTitle } from '@/hooks/useDocumentTitle'
 
 export function SubscriptionPage() {
   const { t } = useTranslation()
+  useDocumentTitle(t('subscription.title'))
   const navigate = useNavigate()
   const { tier, status, currentPeriodEnd, loading, fetchSubscription } = useSubscriptionStore()
   const [searchParams] = useSearchParams()

--- a/packages/frontend/src/pages/UserProfilePage.tsx
+++ b/packages/frontend/src/pages/UserProfilePage.tsx
@@ -9,6 +9,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { Badge } from '@/components/ui/badge'
 import { useAuthStore } from '@/stores/auth.store'
 import { useProfileStore } from '@/stores/profile.store'
+import { useDocumentTitle } from '@/hooks/useDocumentTitle'
 
 function formatPlaytime(minutes: number | null | undefined): string {
   if (!minutes || minutes <= 0) return '—'
@@ -37,6 +38,7 @@ export function UserProfilePage() {
   const { profiles, loading, errors, fetchProfile, refreshProfile } = useProfileStore()
 
   const profile = userId ? profiles[userId] : undefined
+  useDocumentTitle(profile?.displayName ?? 'Profil')
   const isLoading = userId ? loading[userId] : false
   const error = userId ? errors[userId] : null
 

--- a/packages/frontend/src/pages/VotePage.tsx
+++ b/packages/frontend/src/pages/VotePage.tsx
@@ -27,6 +27,7 @@ import {
 import { ShareButton } from '@/components/share-button'
 import { CelebrationParticles } from '@/components/celebration-particles'
 import { decodeHtmlEntities } from '@/lib/utils'
+import { useDocumentTitle } from '@/hooks/useDocumentTitle'
 
 interface Game {
   steamAppId: number
@@ -54,6 +55,7 @@ interface VoteResult {
 
 export function VotePage() {
   const { t } = useTranslation()
+  useDocumentTitle(t('vote.title'))
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
   const { user } = useAuthStore()
@@ -299,7 +301,7 @@ export function VotePage() {
     }
 
     return (
-      <div className="min-h-screen flex flex-col items-center justify-center p-4">
+      <main id="main-content" className="min-h-screen flex flex-col items-center justify-center p-4">
         <AnimatePresence>
           <motion.div
             initial="hidden"
@@ -413,7 +415,7 @@ export function VotePage() {
             </motion.div>
           </motion.div>
         </AnimatePresence>
-      </div>
+      </main>
     )
   }
 
@@ -423,9 +425,9 @@ export function VotePage() {
     const isScheduledSession = scheduledDate && scheduledDate.getTime() > Date.now()
 
     return (
-      <div className="min-h-screen flex flex-col items-center justify-center px-3 sm:px-4 py-4">
-        <Check className="w-16 h-16 text-success mb-4" />
-        <h2 className="text-2xl font-heading font-bold mb-2">{t('vote.submitted')}</h2>
+      <main id="main-content" className="min-h-screen flex flex-col items-center justify-center px-3 sm:px-4 py-4">
+        <Check className="w-16 h-16 text-success mb-4" aria-hidden="true" />
+        <h1 className="text-2xl font-heading font-bold mb-2">{t('vote.submitted')}</h1>
 
         {isScheduledSession && (
           <div className="mb-6 text-center">
@@ -495,16 +497,16 @@ export function VotePage() {
         >
           {t('vote.backToGroup')}
         </Button>
-      </div>
+      </main>
     )
   }
 
   // Non-participant view
   if (!isParticipant) {
     return (
-      <div className="min-h-screen flex flex-col items-center justify-center p-4">
-        <Vote className="w-16 h-16 text-muted-foreground mb-4" />
-        <h2 className="text-2xl font-heading font-bold mb-2">{t('vote.sessionInProgress')}</h2>
+      <main id="main-content" className="min-h-screen flex flex-col items-center justify-center p-4">
+        <Vote className="w-16 h-16 text-muted-foreground mb-4" aria-hidden="true" />
+        <h1 className="text-2xl font-heading font-bold mb-2">{t('vote.sessionInProgress')}</h1>
         <p className="text-muted-foreground mb-6">
           {t('vote.notParticipant')}
         </p>
@@ -514,7 +516,7 @@ export function VotePage() {
         >
           {t('vote.backToGroup')}
         </Button>
-      </div>
+      </main>
     )
   }
 
@@ -529,21 +531,22 @@ export function VotePage() {
 
       <main id="main-content" className="flex-1 flex flex-col p-4 max-w-2xl mx-auto w-full">
         <div className="text-center mb-4">
-          <h2 className="text-xl font-heading font-bold">{t('vote.selectGamesTitle')}</h2>
+          <h1 className="text-xl font-heading font-bold">{t('vote.selectGamesTitle')}</h1>
           <p className="text-sm text-muted-foreground mt-1">
             {t('vote.selectGamesHint', { count: games.length })}
           </p>
         </div>
 
         {/* Search bar */}
-        <div className="relative mb-4">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+        <div className="relative mb-4" role="search">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" aria-hidden="true" />
           <input
             type="text"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             placeholder={t('group.searchGames')}
-            className="w-full rounded-lg border border-border bg-background pl-10 pr-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+            aria-label={t('group.searchGames')}
+            className="w-full rounded-lg border border-border bg-background pl-10 pr-4 py-2.5 text-sm focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/40 focus-visible:border-primary/30"
           />
         </div>
 


### PR DESCRIPTION
## Summary

Audited the frontend against WCAG 2.1 AA by running four specialised sub-agents in parallel (one per POUR principle) and applied concrete fixes. Build + lint pass with no new warnings.

### Headings & landmarks
- Add `<main id="main-content">` wrappers to `LandingPage`, `DiscordLinkPage`, `NotFoundPage`, and every `VotePage` branch that was missing one.
- Promote pages to a single `<h1>` each: `GroupsPage`, `VotePage` (all states), `ComparePage`, `ProfilePage`. Conditional branches are kept mutually exclusive so there's never more than one h1 in the DOM.

### Page titles
- New `useDocumentTitle` hook wired into every top-level page so screen readers get route-specific titles on navigation (WCAG 2.4.2).

### Live regions & loading states
- Wrap skeleton loaders in `role="status"` / `aria-busy` / `aria-live="polite"` containers (`App.tsx`, `GroupsPage`, `GroupPage`, `ComparePage`, `ProfilePage`).
- Give the error boundary `role="alert"` so failures are announced.

### Interactive widgets
- **notification-bell**: `type="button"` on every button, `aria-haspopup` / `aria-expanded` on the trigger, `role="dialog"` on the popover, unread count exposed via `aria-label` rather than a purely visual dot, decorative icons marked `aria-hidden`.
- **cron-autocomplete**: add `aria-activedescendant` + per-option ids so the combobox pattern is complete.
- **group-stats**: add `aria-expanded` / `aria-controls` to the expand toggles.
- **vote-setup-dialog**: replace `focus:` with `focus-visible:` on the datetime input and the select-all row; add a visible ring.
- **share-button** ShareMenuItem + **dropdown-menu** items: add `focus-visible:ring` so keyboard focus is clearly indicated.
- **app-header**: `type="button"` on logo and user-menu triggers.

### Motion (WCAG 2.3.3)
- Mark `celebration-particles` as `aria-hidden` + `motion-reduce:hidden`.
- Add a global `@media (prefers-reduced-motion: reduce)` rule in `index.css` that neutralises non-essential animations and transitions across the entire app.

## Test plan
- [x] `npm run build:types && npm run build --workspace=@wawptn/frontend` passes
- [x] `npm run lint --workspace=@wawptn/frontend` — no new warnings (4 pre-existing warnings unchanged)
- [x] Pre-commit hooks (lint + build) passed
- [ ] Manual keyboard-only pass: tab through Landing, Groups, Group detail, Vote
- [ ] Screen reader smoke test (VoiceOver / NVDA): route titles announce on navigation, loading states announce, notification badge count is read aloud
- [ ] Toggle OS "Reduce motion" setting and verify particles + landing animations are neutralised

https://claude.ai/code/session_0171pdLzQjS4HHupYhC2rjVE