### PR TITLE
fix(frontend): surface in-progress vote on group detail page

### DIFF
--- a/packages/frontend/src/components/tonight-pick-hero.tsx
+++ b/packages/frontend/src/components/tonight-pick-hero.tsx
@@ -28,6 +28,15 @@ interface TonightPickHeroProps {
   members: Member[]
   onStartVote: () => void
   onRandomPick: () => void
+  /**
+   * If a voting session is already open for this group, the hero renders a
+   * "join existing vote" variant instead of the normal "start a vote" CTA.
+   * The backend enforces one open session per group, so surfacing this at
+   * the group detail page prevents users from walking through the setup
+   * dialog only to land on a 409 toast on the vote page.
+   */
+  activeVoteSession?: { id: string; scheduledAt: string | null } | null
+  onJoinActiveVote?: () => void
 }
 
 type PickReason = 'neverPlayed' | 'topRated' | 'mostOwned' | 'comeback'
@@ -115,6 +124,8 @@ export function TonightPickHero({
   members,
   onStartVote,
   onRandomPick,
+  activeVoteSession,
+  onJoinActiveVote,
 }: TonightPickHeroProps) {
   const { t } = useTranslation()
   const pick = useMemo(() => scoreGames(games, voteHistory), [games, voteHistory])
@@ -123,6 +134,79 @@ export function TonightPickHero({
     return (
       <div className="relative overflow-hidden rounded-xl border border-border/60 bg-card/40">
         <Skeleton className="w-full h-[220px] sm:h-[260px]" />
+      </div>
+    )
+  }
+
+  // A vote is already open for this group → show a dedicated "join" hero
+  // instead of the normal pick, since creating another vote would just
+  // bounce off the backend's one-open-session-per-group guard. We key
+  // the "scheduled" vs "in progress" copy off the presence of a
+  // `scheduledAt` timestamp rather than comparing against `Date.now()` to
+  // keep the render pure — the VotePage itself handles countdown vs live
+  // display once the user clicks through.
+  if (activeVoteSession && onJoinActiveVote) {
+    const isScheduled = !!activeVoteSession.scheduledAt
+    const avatars = members.slice(0, 5)
+    return (
+      <div className="relative overflow-hidden rounded-xl border border-primary/40 bg-card/40 ring-1 ring-primary/20">
+        {/* Soft animated glow to draw attention away from the regular hero. */}
+        <div
+          aria-hidden="true"
+          className="absolute inset-0 bg-gradient-to-r from-primary/20 via-primary/5 to-transparent pointer-events-none"
+        />
+        <div className="relative p-4 sm:p-6 flex flex-col sm:flex-row gap-4 sm:gap-5 items-start sm:items-center">
+          <div className="shrink-0 w-12 h-12 rounded-full bg-primary/15 flex items-center justify-center">
+            <Vote className="w-6 h-6 text-primary" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 mb-1.5">
+              <span className="relative flex h-2 w-2">
+                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-primary/60" />
+                <span className="relative inline-flex rounded-full h-2 w-2 bg-primary" />
+              </span>
+              <span className="text-[11px] uppercase tracking-wider text-primary font-bold">
+                {t('tonightPick.voteInProgressEyebrow')}
+              </span>
+            </div>
+            <h2 className="text-xl sm:text-2xl font-heading font-bold leading-tight">
+              {isScheduled
+                ? t('tonightPick.voteScheduledTitle')
+                : t('tonightPick.voteInProgressTitle')}
+            </h2>
+            <p className="text-sm text-muted-foreground mt-1">
+              {isScheduled
+                ? t('tonightPick.voteScheduledDescription')
+                : t('tonightPick.voteInProgressDescription')}
+            </p>
+          </div>
+          <div className="flex flex-col items-stretch sm:items-end gap-2 w-full sm:w-auto">
+            <Button
+              onClick={onJoinActiveVote}
+              className="h-11 px-5 gap-2 font-heading font-bold text-base shrink-0 card-hover-glow w-full sm:w-auto"
+            >
+              <Vote className="w-4 h-4" />
+              {t('group.joinActiveVote')}
+            </Button>
+            {members.length > 0 && (
+              <div className="flex -space-x-2 self-center sm:self-end">
+                {avatars.map((member) => (
+                  <Avatar key={member.id} className="w-6 h-6 ring-2 ring-background">
+                    <AvatarImage src={member.avatarUrl} alt={member.displayName} />
+                    <AvatarFallback className="text-[10px]">
+                      {member.displayName.charAt(0).toUpperCase()}
+                    </AvatarFallback>
+                  </Avatar>
+                ))}
+                {members.length > 5 && (
+                  <div className="w-6 h-6 rounded-full bg-muted ring-2 ring-background flex items-center justify-center text-[9px] text-muted-foreground font-medium">
+                    +{members.length - 5}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
       </div>
     )
   }

--- a/packages/frontend/src/i18n/locales/en.json
+++ b/packages/frontend/src/i18n/locales/en.json
@@ -112,6 +112,7 @@
     "syncError": "Sync error",
     "startVoteError": "Unable to start vote",
     "voteAlreadyOpen": "A vote is already in progress for this group. Joining the existing vote.",
+    "joinActiveVote": "Join the active vote",
     "generateInviteError": "Unable to generate invite",
     "history": "Game night history",
     "historyUpgradeCta": "Go premium to see the full history",
@@ -213,7 +214,12 @@
     "reasonNever": "Never played together",
     "reasonTopRated": "Top rated",
     "reasonMostOwned": "Most owned",
-    "reasonComeback": "Comeback kings"
+    "reasonComeback": "Comeback kings",
+    "voteInProgressEyebrow": "Vote in progress",
+    "voteInProgressTitle": "A vote is in progress",
+    "voteInProgressDescription": "Join your friends to cast your pick and reveal tonight's game.",
+    "voteScheduledTitle": "A vote is scheduled",
+    "voteScheduledDescription": "A vote has already been scheduled in this group. Open it to see the details."
   },
   "voteSetup": {
     "title": "Who's playing tonight?",

--- a/packages/frontend/src/i18n/locales/fr.json
+++ b/packages/frontend/src/i18n/locales/fr.json
@@ -115,6 +115,7 @@
     "syncError": "Erreur de synchronisation",
     "startVoteError": "Impossible de lancer le vote",
     "voteAlreadyOpen": "Un vote est déjà en cours dans ce groupe. Vous rejoignez le vote existant.",
+    "joinActiveVote": "Rejoindre le vote en cours",
     "generateInviteError": "Impossible de générer l'invitation",
     "history": "Historique des soirées",
     "historyUpgradeCta": "Passez premium pour voir l'historique complet",
@@ -222,7 +223,12 @@
     "reasonNever": "Jamais joué ensemble",
     "reasonTopRated": "Le mieux noté",
     "reasonMostOwned": "Le plus possédé",
-    "reasonComeback": "Retour gagnant"
+    "reasonComeback": "Retour gagnant",
+    "voteInProgressEyebrow": "Vote en cours",
+    "voteInProgressTitle": "Un vote est en cours",
+    "voteInProgressDescription": "Rejoins tes amis pour donner ta voix et découvrir le jeu de ce soir.",
+    "voteScheduledTitle": "Un vote est planifié",
+    "voteScheduledDescription": "Un vote a déjà été programmé dans ce groupe. Ouvre-le pour voir les détails."
   },
   "voteSetup": {
     "title": "Qui joue ce soir ?",

--- a/packages/frontend/src/pages/GroupPage.tsx
+++ b/packages/frontend/src/pages/GroupPage.tsx
@@ -54,6 +54,12 @@ export function GroupPage() {
   const [randomPickOpen, setRandomPickOpen] = useState(false)
   const [onlineUserIds, setOnlineUserIds] = useState<string[]>([])
   const [todayPersona, setTodayPersona] = useState<{ id: string; name: string; embedColor: number; introMessage: string } | null>(null)
+  // Mirrors the backend's "one open session per group" guard so the group
+  // detail page can surface a "join existing vote" CTA instead of walking
+  // users through the setup dialog only to bounce off a 409 on the vote
+  // page. Populated on mount via GET /groups/:id/vote and kept fresh via
+  // the `session:created` and `vote:closed` socket events.
+  const [activeVoteSession, setActiveVoteSession] = useState<{ id: string; scheduledAt: string | null } | null>(null)
   const lastSeenMapRef = useRef<Map<string, number>>(new Map())
 
   const loadCommonGames = useCallback(async (groupId: string, filter?: string) => {
@@ -82,6 +88,20 @@ export function GroupPage() {
     }
   }
 
+  const loadActiveVoteSession = async (groupId: string) => {
+    try {
+      const data = await api.getVoteSession(groupId)
+      if (data.session) {
+        setActiveVoteSession({ id: data.session.id, scheduledAt: data.session.scheduledAt })
+      } else {
+        setActiveVoteSession(null)
+      }
+    } catch {
+      // Non-critical: if we can't tell, fall back to the normal start-vote
+      // flow and let the backend's 409 handler catch any race.
+    }
+  }
+
   const activeFilter = gameFilters.multiplayerOnly ? 'multiplayer' : gameFilters.coopOnly ? 'coop' : undefined
 
   // Ref mirror of activeFilter so socket listeners always see the latest
@@ -102,6 +122,7 @@ export function GroupPage() {
     if (!id) return
     fetchGroup(id)
     loadVoteHistory(id)
+    loadActiveVoteSession(id)
 
     const socket = getSocket()
     socket.emit('group:join', id)
@@ -135,6 +156,17 @@ export function GroupPage() {
     })
     socket.on('library:synced', () => loadCommonGames(id, activeFilterRef.current))
     socket.on('session:created', (data) => {
+      // Track the new session locally so the hero flips to the "join vote"
+      // variant and any in-flight setup dialog is short-circuited. Also
+      // covers the user who started the vote — their local state was
+      // already updated in handleStartVote, but keeping this listener
+      // authoritative avoids subtle drift if two tabs are open.
+      setActiveVoteSession({ id: data.sessionId, scheduledAt: data.scheduledAt ?? null })
+      // If the user had the setup dialog open (e.g. a teammate beat them
+      // to the punch), close it — otherwise they'd walk through the form
+      // just to hit the 409 conflict handler on submit.
+      setVoteSetupOpen(false)
+
       // Don't notify the user who started the vote
       if (data.createdBy === user?.id) return
 
@@ -155,6 +187,13 @@ export function GroupPage() {
         toast(t('group.voteStartedOthers'))
       }
     })
+    socket.on('vote:closed', () => {
+      // Vote finished — clear the in-progress flag so the hero flips back
+      // to the normal "start a vote" CTA and the next vote can be created
+      // without bouncing off the 409 guard.
+      setActiveVoteSession(null)
+      loadVoteHistory(id)
+    })
 
     return () => {
       socket.emit('group:leave', id)
@@ -169,6 +208,7 @@ export function GroupPage() {
       socket.off('group:renamed')
       socket.off('library:synced')
       socket.off('session:created')
+      socket.off('vote:closed')
     }
   }, [id, fetchGroup, navigate, loadCommonGames, t, user?.id])
 
@@ -196,7 +236,10 @@ export function GroupPage() {
     if (!id) return
     try {
       const hasActiveFilters = filters && (filters.multiplayer || filters.coop || filters.free)
-      await api.createVoteSession(id, participantIds, activeFilter, scheduledAt, hasActiveFilters ? filters : undefined)
+      const result = await api.createVoteSession(id, participantIds, activeFilter, scheduledAt, hasActiveFilters ? filters : undefined)
+      // Record the new session locally so the hero flips immediately even
+      // if the socket event loses the race with the navigation.
+      setActiveVoteSession({ id: result.session.id, scheduledAt: result.session.scheduledAt })
       track('vote.started', {
         participantCount: participantIds.length,
         scheduled: !!scheduledAt,
@@ -206,16 +249,35 @@ export function GroupPage() {
     } catch (err) {
       // 409 conflict = another vote is already open for this group. The
       // backend enforces "one open session per group" via a partial
-      // unique index; redirect the user to the existing vote so they
-      // can join it instead of landing on an error toast.
+      // unique index. We normally prevent reaching this path by
+      // short-circuiting the CTA when `activeVoteSession` is populated,
+      // but a race (two clients clicking "start vote" at once) can still
+      // land here. Refresh the local state so future clicks route to the
+      // join variant, then redirect the user to the existing vote.
       if (err instanceof ApiError && err.status === 409) {
         toast.info(t('group.voteAlreadyOpen'))
+        loadActiveVoteSession(id)
         navigate(`/groups/${id}/vote`)
       } else {
         toast.error(err instanceof Error ? err.message : t('group.startVoteError'))
       }
     }
   }
+
+  // Unified CTA entry point for the "start vote" buttons scattered across
+  // the hero, the mobile bottom bar, and the sidebar. When a vote is
+  // already open we skip the setup dialog entirely and drop the user on
+  // the existing vote page. This is the fix for the UX bug where users
+  // would walk through the dialog only to be told a vote is already in
+  // progress on the next page.
+  const openVoteFlow = useCallback(() => {
+    if (!id) return
+    if (activeVoteSession) {
+      navigate(`/groups/${id}/vote`)
+    } else {
+      setVoteSetupOpen(true)
+    }
+  }, [id, activeVoteSession, navigate])
 
   const handleGenerateInvite = async () => {
     if (!id) return
@@ -415,7 +477,7 @@ export function GroupPage() {
               onDeleteHistory={handleDeleteHistory}
               onToggleNotifications={handleToggleNotifications}
               onUpdateAutoVote={handleUpdateAutoVote}
-              onStartVote={() => setVoteSetupOpen(true)}
+              onStartVote={openVoteFlow}
             />
           </div>
 
@@ -442,20 +504,30 @@ export function GroupPage() {
               loading={loadingGames}
               voteHistory={voteHistory}
               members={currentGroup.members}
-              onStartVote={() => setVoteSetupOpen(true)}
+              onStartVote={openVoteFlow}
               onRandomPick={() => setRandomPickOpen(true)}
+              activeVoteSession={activeVoteSession}
+              onJoinActiveVote={() => navigate(`/groups/${id}/vote`)}
             />
 
             {/* Mobile: fixed bottom action bar — kept as the persistent
                 primary CTA on small screens so the vote is always one tap
-                away even when the user has scrolled the grid. */}
+                away even when the user has scrolled the grid. Flips to
+                "join vote" when a session is already open so the user
+                isn't walked through the setup dialog for nothing. */}
             <div className="fixed bottom-0 left-0 right-0 z-40 sm:hidden bg-background/95 backdrop-blur-sm border-t border-border px-3 pt-2 pb-[max(1rem,env(safe-area-inset-bottom))]">
               <Button
-                onClick={() => setVoteSetupOpen(true)}
+                onClick={openVoteFlow}
                 className="w-full h-12 gap-2 active:scale-[0.98] transition-transform"
               >
-                <span className="font-heading font-bold">{t('group.startVote')}</span>
-                <span className="opacity-80 text-sm">· {t('group.commonGamesCount', { count: commonGames.length })}</span>
+                {activeVoteSession ? (
+                  <span className="font-heading font-bold">{t('group.joinActiveVote')}</span>
+                ) : (
+                  <>
+                    <span className="font-heading font-bold">{t('group.startVote')}</span>
+                    <span className="opacity-80 text-sm">· {t('group.commonGamesCount', { count: commonGames.length })}</span>
+                  </>
+                )}
               </Button>
             </div>
             {/* Spacer for fixed bottom bar on mobile */}
@@ -558,7 +630,7 @@ export function GroupPage() {
               onDeleteHistory={handleDeleteHistory}
               onToggleNotifications={handleToggleNotifications}
               onUpdateAutoVote={handleUpdateAutoVote}
-              onStartVote={() => setVoteSetupOpen(true)}
+              onStartVote={openVoteFlow}
               compact
             />
           </ResponsiveDialogContent>


### PR DESCRIPTION
## Summary

- Detect any open voting session on group detail load (and react to `session:created` / `vote:closed` socket events) so the hero flips to a dedicated "join active vote" variant instead of walking users through the setup dialog only to bounce off the backend's 409 "one open session per group" guard.
- Mobile bottom-bar CTA and sidebar entry points also short-circuit to the existing vote page when a session is already open.
- New "vote in progress" variant of `TonightPickHero` with a pulsing indicator and "Rejoindre le vote en cours" button; separate copy for scheduled sessions.

## Why

Users clicking "Lancer un vote" could walk through the full setup dialog and only see the "Un vote est déjà en cours…" toast on the next page. The group detail page now knows about the active session up-front and routes the user straight into the existing vote.

## Test plan

- [ ] Open a group with no active vote → hero shows "Tonight's Pick" and "Lancer un vote" opens the setup dialog.
- [ ] Start a vote, then revisit the group detail page → hero shows "Vote en cours" and the CTA navigates directly to `/groups/:id/vote`.
- [ ] With a group detail page open, have another member start a vote → hero flips live via `session:created`, open setup dialog auto-closes.
- [ ] Close the vote → hero flips back to "Tonight's Pick" via `vote:closed`.
- [ ] Scheduled vote → hero shows the scheduled copy variant.
- [ ] Mobile bottom bar label flips between "Lancer un vote" and "Rejoindre le vote en cours".

https://claude.ai/code/session_01Avy6BsUhfNWCvCfeoyZMgD