### PR TITLE
docs(discord): mark announcement webhooks explicitly premium (C4)

### DIFF
--- a/packages/backend/src/presentation/routes/discord.routes.ts
+++ b/packages/backend/src/presentation/routes/discord.routes.ts
@@ -1192,8 +1192,17 @@ userRouter.post('/webhook', requireAuth, async (req: Request, res: Response) => 
 // Lets a group owner broadcast vote results to additional channels beyond
 // the primary discord_webhook_url — typically #general or #announcements in
 // the same guild for cross-channel visibility. The primary webhook stays
-// where it is; these are additive. All three endpoints are owner-only and
-// premium-gated, matching the existing /webhook route above.
+// where it is; these are additive.
+//
+// These endpoints stay PREMIUM explicitly, by arbitration (2026-04-15, #143).
+// When the C4 "Salon = Groupe" decision made the primary binding free
+// (`/setup` and `/webhook` above), the premium line was redrawn to cover
+// only features with (a) real runtime cost, or (b) broadcast scope beyond
+// the single bound channel. Announcement webhooks are case (b): one POST
+// here fans out to up to ANNOUNCEMENT_WEBHOOK_LIMIT channels, so they are
+// explicitly premium and not part of the base binding promise.
+//
+// Related explicitly-premium endpoints in this file: `/chat` (LLM cost).
 
 const ANNOUNCEMENT_WEBHOOK_LIMIT = 5
 


### PR DESCRIPTION
## Summary

- Fix stale comment above `/discord/announcements/*` that referenced `/webhook` as a "premium-gated precedent". Since `/webhook` moved to the free tier under C4 (#143), that reference was misleading — a reviewer could reasonably conclude announcement webhooks should also move free.
- Explicitly document the 2026-04-15 arbitration (#143) that keeps announcement webhooks premium on a **different** rationale: broadcast scope beyond the single bound channel, not "matching `/webhook`".
- Cross-reference `/chat` as the other explicitly-premium endpoint in the file (coût LLM runtime).

Comment-only change, no runtime behaviour. Closes out the code-side cleanup of #143.

## Test plan

- [x] Comment text reviewed for accuracy against current code
- [x] No runtime path touched — `assertOwnerAndPremium` unchanged at `discord.routes.ts:1209-1227`
- [x] File still parses (only block comment edited)

https://github.com/Wifsimster/wawptn/issues/143