### PR TITLE
fix(frontend): add missing vote.title i18n key

### DIFF
--- a/packages/frontend/src/i18n/locales/en.json
+++ b/packages/frontend/src/i18n/locales/en.json
@@ -256,6 +256,7 @@
     "backHome": "Back to home"
   },
   "vote": {
+    "title": "Vote",
     "tonightYouPlay": "Tonight you're playing",
     "votedFor": "{{yes}} out of {{total}} voted for it",
     "consensusPercent": "{{percent}}% consensus",

--- a/packages/frontend/src/i18n/locales/fr.json
+++ b/packages/frontend/src/i18n/locales/fr.json
@@ -265,6 +265,7 @@
     "backHome": "Retour à l'accueil"
   },
   "vote": {
+    "title": "Vote",
     "tonightYouPlay": "Ce soir vous jouez à",
     "votedFor": "{{yes}} sur {{total}} ont voté pour",
     "consensusPercent": "{{percent}} % de consensus",


### PR DESCRIPTION
## Summary
- `VotePage` calls `useDocumentTitle(t('vote.title'))`, but the `vote.title` key was missing from both `fr.json` and `en.json`, so i18next returned the raw key and the browser tab rendered as `vote.title — WAWPTN`.
- Added `"title": "Vote"` to the `vote` namespace in both locale files.

## Test plan
- [ ] Visit a group vote page and confirm the browser tab title shows `Vote — WAWPTN` instead of `vote.title — WAWPTN`.
- [ ] Verify both `fr` and `en` locales render the translated title.

https://claude.ai/code/session_01WP3jSeVWGD19nbUKzwp23o