### PR TITLE
ops: self-hosted deploy workflow for homelab (replaces Watchtower)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,44 @@
+name: Deploy — homelab
+
+# Runs on the self-hosted runner alongside the target docker host. Fires
+# after the upstream image-publishing workflow succeeds on main, pulls
+# `:latest`, reconciles the compose stack, and prunes dangling images.
+# Replaces Watchtower — deploys are now observable in the Actions log.
+
+on:
+  workflow_run:
+    workflows: ["Docker Publish"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-homelab-${{ github.repository }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Pull & reconcile
+    runs-on: [self-hosted]
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || github.event.workflow_run.conclusion == 'success'
+    defaults:
+      run:
+        working-directory: /opt/docker/wawptn
+    steps:
+      - name: Pull latest image(s)
+        run: docker compose pull
+
+      - name: Reconcile stack
+        run: docker compose up -d
+
+      - name: Show status
+        run: docker compose ps
+
+      - name: Prune dangling images
+        working-directory: /
+        run: docker image prune -f


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/deploy.yml` running on the existing `docker-server` self-hosted runner on the homelab.
- Fires on `workflow_run` after the upstream image-publishing workflow succeeds on `main`, plus manual `workflow_dispatch`.
- Pulls `:latest`, reconciles with `docker compose up -d`, dumps status, prunes dangling images.
- Replaces Watchtower: deploys are observable in the Actions log and fail loudly on a bad pull/up, rather than silently retrying on the next polling tick.

## Test plan

- [ ] Merge → next push to `main` triggering the upstream workflow chains into `Deploy — homelab`
- [ ] Job turns green; `docker compose ps` output shows the expected containers
- [ ] Watchtower label removal on the homelab compose tracked separately (no repo change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)