### PR TITLE
feat(groups): show Discord server + channel on group detail

### DIFF
--- a/packages/backend/migrations/20260418_add_discord_name_snapshots.ts
+++ b/packages/backend/migrations/20260418_add_discord_name_snapshots.ts
@@ -1,0 +1,22 @@
+import type { Knex } from 'knex'
+
+/**
+ * Snapshot the Discord guild and channel names alongside the IDs so the UI
+ * can show "linked to #general on MyServer" without a runtime Discord API
+ * call. Names are written when `/wawptn-setup` runs; existing bound groups
+ * keep null names until the command is run again (the frontend shows a
+ * generic "Discord lié" fallback in the meantime).
+ */
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('groups', (table) => {
+    table.text('discord_guild_name').nullable()
+    table.text('discord_channel_name').nullable()
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('groups', (table) => {
+    table.dropColumn('discord_guild_name')
+    table.dropColumn('discord_channel_name')
+  })
+}

--- a/packages/backend/src/presentation/routes/discord.routes.ts
+++ b/packages/backend/src/presentation/routes/discord.routes.ts
@@ -30,10 +30,12 @@ const router = Router()
 // decision C4 — 2026-04-14). The previous premium gate has been removed;
 // every user can bind a channel to their group.
 router.post('/setup', async (req: Request, res: Response) => {
-  const { groupId, discordChannelId, discordGuildId } = req.body as {
+  const { groupId, discordChannelId, discordGuildId, discordGuildName, discordChannelName } = req.body as {
     groupId: string
     discordChannelId: string
     discordGuildId: string
+    discordGuildName?: string | null
+    discordChannelName?: string | null
   }
 
   if (!groupId || !discordChannelId || !discordGuildId) {
@@ -47,12 +49,21 @@ router.post('/setup', async (req: Request, res: Response) => {
     return
   }
 
+  // Names are snapshotted at setup time so the UI can show a readable
+  // "linked to #channel on Server" chip without a live Discord API call.
+  // The bot sends them from the interaction context; tolerate missing
+  // values by falling back to null (frontend shows a generic label).
+  const guildName = typeof discordGuildName === 'string' && discordGuildName.trim() ? discordGuildName.trim().slice(0, 200) : null
+  const channelName = typeof discordChannelName === 'string' && discordChannelName.trim() ? discordChannelName.trim().slice(0, 200) : null
+
   await db('groups').where({ id: groupId }).update({
     discord_channel_id: discordChannelId,
     discord_guild_id: discordGuildId,
+    discord_guild_name: guildName,
+    discord_channel_name: channelName,
   })
 
-  logger.info({ groupId, discordChannelId, discordGuildId }, 'Discord channel linked to group')
+  logger.info({ groupId, discordChannelId, discordGuildId, discordGuildName: guildName, discordChannelName: channelName }, 'Discord channel linked to group')
 
   res.json({ ok: true, groupName: group.name })
 })

--- a/packages/backend/src/presentation/routes/group.routes.ts
+++ b/packages/backend/src/presentation/routes/group.routes.ts
@@ -99,6 +99,8 @@ router.get('/', async (req: Request, res: Response) => {
     todayPersona: personaMap.get(g.id) || null,
     discordGuildId: g.discord_guild_id ?? null,
     discordChannelId: g.discord_channel_id ?? null,
+    discordGuildName: g.discord_guild_name ?? null,
+    discordChannelName: g.discord_channel_name ?? null,
   })))
 })
 
@@ -137,6 +139,8 @@ router.get('/:id', requireGroupMembership(), async (req: Request, res: Response)
     autoVoteDurationMinutes: group.auto_vote_duration_minutes || 120,
     discordGuildId: group.discord_guild_id ?? null,
     discordChannelId: group.discord_channel_id ?? null,
+    discordGuildName: group.discord_guild_name ?? null,
+    discordChannelName: group.discord_channel_name ?? null,
     createdAt: group.created_at,
     members,
     todayPersona,
@@ -322,6 +326,8 @@ router.post('/', async (req: Request, res: Response) => {
     inviteExpiresAt: expiresAt.toISOString(),
     discordGuildId: group.discord_guild_id ?? null,
     discordChannelId: group.discord_channel_id ?? null,
+    discordGuildName: group.discord_guild_name ?? null,
+    discordChannelName: group.discord_channel_name ?? null,
   })
 })
 
@@ -357,6 +363,8 @@ router.patch('/:id', requireGroupMembership({ role: 'owner' }), async (req: Requ
     name: fresh?.name ?? trimmedName,
     discordGuildId: fresh?.discord_guild_id ?? null,
     discordChannelId: fresh?.discord_channel_id ?? null,
+    discordGuildName: fresh?.discord_guild_name ?? null,
+    discordChannelName: fresh?.discord_channel_name ?? null,
   })
 })
 

--- a/packages/discord/src/commands/setup.ts
+++ b/packages/discord/src/commands/setup.ts
@@ -27,6 +27,10 @@ export async function execute(interaction: ChatInputCommandInteraction): Promise
         groupId: group.groupId,
         discordChannelId: interaction.channelId,
         discordGuildId: guildId,
+        // Snapshot the human-readable names so the web UI can render
+        // "linked to #channel on Server" without a live Discord API call.
+        discordGuildName: interaction.guild?.name ?? null,
+        discordChannelName: interaction.channel && 'name' in interaction.channel ? interaction.channel.name ?? null : null,
       },
     })
 

--- a/packages/frontend/src/i18n/locales/en.json
+++ b/packages/frontend/src/i18n/locales/en.json
@@ -209,7 +209,8 @@
     "discordBannerTitle": "Link a Discord channel to this group",
     "discordBannerHint": "Announcements and votes will be posted automatically in the channel you pick.",
     "discordBannerCta": "Link a channel",
-    "discordBannerDialogTitle": "Link a Discord channel"
+    "discordBannerDialogTitle": "Link a Discord channel",
+    "discordLinkedFallback": "Discord linked"
   },
   "filterPresets": {
     "label": "Vibe",

--- a/packages/frontend/src/i18n/locales/fr.json
+++ b/packages/frontend/src/i18n/locales/fr.json
@@ -218,7 +218,8 @@
     "discordBannerTitle": "Lie un salon Discord à ce groupe",
     "discordBannerHint": "Les annonces et votes seront postés automatiquement dans le salon de ton choix.",
     "discordBannerCta": "Lier un salon",
-    "discordBannerDialogTitle": "Lier un salon Discord"
+    "discordBannerDialogTitle": "Lier un salon Discord",
+    "discordLinkedFallback": "Discord lié"
   },
   "filterPresets": {
     "label": "Ambiance",

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -81,20 +81,21 @@ export const api = {
   },
 
   // Groups
-  getGroups: () => request<{ id: string; name: string; role: string; createdAt: string; memberCount: number; commonGameCount: number; lastSession: { gameName: string; gameAppId: number; closedAt: string } | null; todayPersona: { id: string; name: string; embedColor: number; introMessage: string } | null; discordGuildId: string | null; discordChannelId: string | null }[]>('/groups'),
+  getGroups: () => request<{ id: string; name: string; role: string; createdAt: string; memberCount: number; commonGameCount: number; lastSession: { gameName: string; gameAppId: number; closedAt: string } | null; todayPersona: { id: string; name: string; embedColor: number; introMessage: string } | null; discordGuildId: string | null; discordChannelId: string | null; discordGuildName: string | null; discordChannelName: string | null }[]>('/groups'),
   getGroup: (id: string) => request<{
     id: string; name: string; createdBy: string; commonGameThreshold: number | null; createdAt: string;
     autoVoteSchedule: string | null; autoVoteDurationMinutes: number;
     discordGuildId: string | null; discordChannelId: string | null;
+    discordGuildName: string | null; discordChannelName: string | null;
     members: { id: string; steamId: string; displayName: string; avatarUrl: string; libraryVisible: boolean; role: string; joinedAt: string; notificationsEnabled: boolean }[];
     todayPersona: { id: string; name: string; embedColor: number; introMessage: string } | null;
   }>(`/groups/${id}`),
   createGroup: (input: { name: string }) =>
-    request<{ id: string; name: string; inviteToken: string; inviteExpiresAt: string; discordGuildId: string | null; discordChannelId: string | null }>('/groups', {
+    request<{ id: string; name: string; inviteToken: string; inviteExpiresAt: string; discordGuildId: string | null; discordChannelId: string | null; discordGuildName: string | null; discordChannelName: string | null }>('/groups', {
       method: 'POST',
       body: JSON.stringify(input),
     }),
-  renameGroup: (groupId: string, name: string) => request<{ id: string; name: string; discordGuildId: string | null; discordChannelId: string | null }>(`/groups/${groupId}`, {
+  renameGroup: (groupId: string, name: string) => request<{ id: string; name: string; discordGuildId: string | null; discordChannelId: string | null; discordGuildName: string | null; discordChannelName: string | null }>(`/groups/${groupId}`, {
     method: 'PATCH',
     body: JSON.stringify({ name }),
   }),

--- a/packages/frontend/src/pages/GroupPage.tsx
+++ b/packages/frontend/src/pages/GroupPage.tsx
@@ -521,6 +521,29 @@ export function GroupPage() {
               </motion.div>
             )}
 
+            {/* Persistent "linked to X" chip — visible to all members once
+                a Discord channel is bound, so everyone knows where vote
+                announcements will land. Falls back to a generic label for
+                groups bound before the name-snapshot migration. */}
+            {currentGroup.discordChannelId && (
+              <div className="inline-flex items-center gap-1.5 text-xs text-muted-foreground border border-border/60 bg-muted/20 rounded-full px-2.5 py-1">
+                <Link2 className="w-3 h-3 text-primary shrink-0" />
+                {currentGroup.discordChannelName || currentGroup.discordGuildName ? (
+                  <span className="truncate">
+                    {currentGroup.discordChannelName && (
+                      <span className="font-medium">#{currentGroup.discordChannelName}</span>
+                    )}
+                    {currentGroup.discordChannelName && currentGroup.discordGuildName && (
+                      <span className="text-muted-foreground/60"> · </span>
+                    )}
+                    {currentGroup.discordGuildName && <span>{currentGroup.discordGuildName}</span>}
+                  </span>
+                ) : (
+                  <span>{t('group.discordLinkedFallback')}</span>
+                )}
+              </div>
+            )}
+
             {/* Per-group "persona du jour" — hero variant. Pre-fetched via
                 the enriched group detail response, refreshed live via the
                 `persona:changed` socket event (midnight flip or owner

--- a/packages/frontend/src/stores/group.store.ts
+++ b/packages/frontend/src/stores/group.store.ts
@@ -4,11 +4,12 @@ import { api } from '@/lib/api'
 interface DailyPersona { id: string; name: string; embedColor: number; introMessage: string }
 
 interface GroupState {
-  groups: { id: string; name: string; role: string; createdAt: string; memberCount: number; commonGameCount: number; lastSession: { gameName: string; gameAppId: number; closedAt: string } | null; todayPersona: DailyPersona | null; discordGuildId: string | null; discordChannelId: string | null }[]
+  groups: { id: string; name: string; role: string; createdAt: string; memberCount: number; commonGameCount: number; lastSession: { gameName: string; gameAppId: number; closedAt: string } | null; todayPersona: DailyPersona | null; discordGuildId: string | null; discordChannelId: string | null; discordGuildName: string | null; discordChannelName: string | null }[]
   currentGroup: {
     id: string; name: string; createdBy: string; commonGameThreshold: number | null; createdAt: string;
     autoVoteSchedule: string | null; autoVoteDurationMinutes: number;
     discordGuildId: string | null; discordChannelId: string | null;
+    discordGuildName: string | null; discordChannelName: string | null;
     members: { id: string; steamId: string; displayName: string; avatarUrl: string; libraryVisible: boolean; role: string; joinedAt: string; notificationsEnabled: boolean }[];
     todayPersona: DailyPersona | null
   } | null


### PR DESCRIPTION
## Summary
- Snapshots `discord_guild_name` + `discord_channel_name` on `groups` via a new migration; `/wawptn-setup` now writes these alongside the IDs
- Group detail page renders a persistent `#channel · Server` chip visible to every member once the group is bound
- Legacy bound groups (no name snapshot yet) show a generic `Discord lié` fallback until the command is re-run

## Test plan
- [ ] Run `npm run db:migrate`
- [ ] In Discord, run `/wawptn-setup` in a test channel — check `groups.discord_guild_name` and `discord_channel_name` are populated
- [ ] Web: group detail shows `#channel-name · Server Name` chip at the top of the content area
- [ ] Existing bound group (pre-migration) shows the "Discord lié" fallback
- [ ] Unbound group: owner banner still appears; chip does not

🤖 Generated with [Claude Code](https://claude.com/claude-code)