### PR TITLE
fix(startup): fatal exit on migration failure

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -221,7 +221,15 @@ async function main() {
     process.exit(1)
   }
 
-  await runMigrations()
+  // Migrations must succeed before the server starts accepting traffic —
+  // a partial or stale schema means request handlers will hit missing
+  // columns and fail at runtime. Exit loudly so the container restarts
+  // (and an operator gets paged) instead of silently serving a broken API.
+  const migrated = await runMigrations()
+  if (!migrated) {
+    logger.fatal('Database migrations failed')
+    process.exit(1)
+  }
 
   // Socket.io
   createSocketServer(httpServer)


### PR DESCRIPTION
## Summary
- `runMigrations()` already runs at boot, but the caller ignored its return value — a thrown migration would log the error and let the server happily listen on a stale schema
- Now treated as fatal: log + `process.exit(1)`, mirroring the existing `testConnection` failure path, so the container restarts and an operator is paged

## Test plan
- [ ] Deploy and confirm normal startup still applies new migrations
- [ ] (Optional) Break a migration locally to verify the process exits instead of serving traffic

🤖 Generated with [Claude Code](https://claude.com/claude-code)