### PR TITLE
feat(frontend): trigger Koe widget from user menu

### DIFF
--- a/packages/frontend/src/components/KoeSupport.tsx
+++ b/packages/frontend/src/components/KoeSupport.tsx
@@ -7,6 +7,14 @@ import { useAuthStore } from '@/stores/auth.store'
 const PROJECT_KEY = (import.meta.env.VITE_KOE_PROJECT_KEY as string | undefined) ?? 'wawptn'
 const API_URL = (import.meta.env.VITE_KOE_API_URL as string | undefined) ?? 'https://koe.battistella.ovh'
 
+// The Koe library ships a floating launcher button we don't want to show —
+// we trigger the widget from the user menu instead. Keep the launcher
+// reachable via DOM so `openKoeSupport` can click it, but hide it visually.
+export function openKoeSupport() {
+  const launcher = document.querySelector<HTMLButtonElement>('.koe-root > button[aria-expanded]')
+  launcher?.click()
+}
+
 const FR_LOCALE = {
   launcherLabel: 'Support',
   title: 'Aide & retours',
@@ -56,18 +64,21 @@ export function KoeSupport() {
   if (!PROJECT_KEY || !API_URL || !user || identity?.userId !== user.id) return null
 
   return (
-    <KoeWidget
-      projectKey={PROJECT_KEY}
-      apiUrl={API_URL}
-      user={{
-        id: user.id,
-        name: user.displayName,
-        avatarUrl: user.avatarUrl,
-        metadata: { steamId: user.steamId },
-      }}
-      userHash={identity.userHash}
-      position="bottom-right"
-      locale={FR_LOCALE}
-    />
+    <>
+      <style>{`.koe-root > button[aria-expanded]{display:none!important}`}</style>
+      <KoeWidget
+        projectKey={PROJECT_KEY}
+        apiUrl={API_URL}
+        user={{
+          id: user.id,
+          name: user.displayName,
+          avatarUrl: user.avatarUrl,
+          metadata: { steamId: user.steamId },
+        }}
+        userHash={identity.userHash}
+        position="bottom-right"
+        locale={FR_LOCALE}
+      />
+    </>
   )
 }

--- a/packages/frontend/src/components/app-header.tsx
+++ b/packages/frontend/src/components/app-header.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { LogOut, User, Shield, Crown } from 'lucide-react'
+import { LogOut, User, Shield, Crown, LifeBuoy } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { cn } from '@/lib/utils'
 import { useAuthStore } from '@/stores/auth.store'
@@ -25,6 +25,7 @@ import {
 } from '@/components/ui/responsive-dialog'
 import { WawptnLogo } from '@/components/icons/wawptn-logo'
 import { NotificationBell } from '@/components/notification-bell'
+import { openKoeSupport } from '@/components/KoeSupport'
 
 interface AppHeaderProps {
   children?: React.ReactNode
@@ -110,6 +111,12 @@ export function AppHeader({ children, className, maxWidth = 'narrow' }: AppHeade
               <DropdownMenuItem onSelect={() => navigate('/admin')}>
                 <Shield />
                 Administration
+              </DropdownMenuItem>
+            )}
+            {user && (
+              <DropdownMenuItem onSelect={() => openKoeSupport()}>
+                <LifeBuoy />
+                {t('groups.support')}
               </DropdownMenuItem>
             )}
             <DropdownMenuSeparator />

--- a/packages/frontend/src/i18n/locales/en.json
+++ b/packages/frontend/src/i18n/locales/en.json
@@ -30,6 +30,7 @@
     "welcomeStep3Desc": "Everyone votes, you see the common game, you play. Simple.",
     "welcomeCta": "Create my first group",
     "logout": "Log out",
+    "support": "Help & feedback",
     "logoutConfirmTitle": "Log out?",
     "logoutConfirmDescription": "You will be redirected to the login page.",
     "logoutConfirm": "Log out",

--- a/packages/frontend/src/i18n/locales/fr.json
+++ b/packages/frontend/src/i18n/locales/fr.json
@@ -30,6 +30,7 @@
     "welcomeStep3Desc": "On vote, on découvre le jeu commun, on joue. Simple.",
     "welcomeCta": "Créer mon premier groupe",
     "logout": "Se déconnecter",
+    "support": "Aide & retours",
     "logoutConfirmTitle": "Se déconnecter ?",
     "logoutConfirmDescription": "Tu seras redirigé vers la page de connexion.",
     "logoutConfirm": "Se déconnecter",


### PR DESCRIPTION
Hide the library's floating launcher and expose a `Support` entry in the
user dropdown that opens the widget. Keeping the widget globally mounted
preserves any in-progress form between opens; the menu item simply
forwards the click to the hidden launcher.