### PR TITLE
chore(deps): bump @wifsimster/koe to 1.32.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8693,9 +8693,9 @@
       "link": true
     },
     "node_modules/@wifsimster/koe": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/@wifsimster/koe/-/koe-1.30.2.tgz",
-      "integrity": "sha512-2fsSgbuM6r4TSouGVJkqct31xmoqR3s16zxX9jr/WhaejMOjBWPKGW9h6jJzi/ZbT9XDE7ha4XBD30Q5wXxxJQ==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@wifsimster/koe/-/koe-1.32.0.tgz",
+      "integrity": "sha512-gQKI/RYiEqqwopJfHBqkrjmq2/WCqDepkPVFl363JzGXyMXhWJzzOs22jTHZnf2ShFMtXSI20BUGr709jaBveA==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.1.1",
@@ -18138,7 +18138,7 @@
         "@radix-ui/react-tooltip": "^1.1.8",
         "@tanstack/react-virtual": "^3.13.21",
         "@wawptn/types": "*",
-        "@wifsimster/koe": "^1.30.2",
+        "@wifsimster/koe": "^1.32.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "framer-motion": "^12.25.0",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -19,7 +19,7 @@
     "@radix-ui/react-tooltip": "^1.1.8",
     "@tanstack/react-virtual": "^3.13.21",
     "@wawptn/types": "*",
-    "@wifsimster/koe": "^1.30.2",
+    "@wifsimster/koe": "^1.32.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.25.0",

--- a/packages/frontend/src/components/KoeSupport.tsx
+++ b/packages/frontend/src/components/KoeSupport.tsx
@@ -31,15 +31,15 @@ const FR_LOCALE = {
   bugForm: {
     title: 'Titre',
     description: 'Description',
-    steps: 'Étapes pour reproduire',
-    expected: 'Comportement attendu',
-    actual: 'Comportement observé',
+    reproduce: 'Comment reproduire le bug ? (facultatif)',
+    email: 'Email (facultatif)',
     submit: 'Envoyer',
     success: 'Merci, votre signalement a bien été reçu.',
   },
   featureForm: {
     title: 'Titre',
     description: 'Description',
+    email: 'Email (facultatif)',
     submit: 'Envoyer',
     success: 'Merci, votre proposition a bien été reçue.',
   },


### PR DESCRIPTION
Consolidates the bug repro locale into a single `reproduce` field and
adds the optional email label introduced upstream.