### PR TITLE
refactor: enforce SoC, DRY, SOLID across routes, services, components

### DIFF
--- a/packages/backend/src/domain/close-session.ts
+++ b/packages/backend/src/domain/close-session.ts
@@ -1,5 +1,6 @@
 import { db } from '../infrastructure/database/connection.js'
 import { logger } from '../infrastructure/logger/logger.js'
+import { getHeaderImageUrl } from '../infrastructure/steam/steam-client.js'
 import { evaluateChallenges } from './challenges/challenge-service.js'
 import { updateStreak } from './streaks.js'
 import { domainEvents } from './events/event-bus.js'
@@ -73,7 +74,7 @@ export async function closeSession(sessionId: string, groupId: string): Promise<
     steamAppId: winnerAppId ?? 0,
     gameId: winnerGameId ?? undefined,
     gameName: winnerName ?? 'Unknown',
-    headerImageUrl: winnerAppId ? `https://cdn.akamai.steamstatic.com/steam/apps/${winnerAppId}/header.jpg` : null,
+    headerImageUrl: winnerAppId ? getHeaderImageUrl(winnerAppId) : null,
     yesCount: results.length > 0 ? Number(results[0]!.yes_count) : 0,
     totalVoters: Number(voterCount?.count || 0),
   }

--- a/packages/backend/src/domain/group-listing-service.ts
+++ b/packages/backend/src/domain/group-listing-service.ts
@@ -1,0 +1,123 @@
+import { db } from '../infrastructure/database/connection.js'
+import { countCommonGamesForGroups } from '../infrastructure/database/common-games.js'
+import { selectPersonasForGroups } from './persona-selection.js'
+import { indexBy, groupBy } from '../lib/collections.js'
+
+export interface GroupListItem {
+  id: string
+  name: string
+  role: 'owner' | 'member'
+  createdAt: Date | string
+  memberCount: number
+  commonGameCount: number
+  lastSession: { gameName: string; gameAppId: number; closedAt: string } | null
+  todayPersona: unknown | null
+  discordGuildId: string | null
+  discordChannelId: string | null
+  discordGuildName: string | null
+  discordChannelName: string | null
+}
+
+interface GroupRow {
+  id: string
+  name: string
+  role: 'owner' | 'member'
+  created_at: Date
+  common_game_threshold: number | null
+  discord_guild_id: string | null
+  discord_channel_id: string | null
+  discord_guild_name: string | null
+  discord_channel_name: string | null
+}
+
+interface LastSessionRow {
+  group_id: string
+  winning_game_app_id: number
+  winning_game_name: string
+  closed_at: string
+}
+
+/**
+ * Compose the "my groups" list view for a user.
+ *
+ * Encapsulates the batched fan-out queries (member counts, last winners,
+ * common-game counts, daily personas) that previously lived inline in the
+ * GET /api/groups handler. Centralizing them here keeps the route as a
+ * thin transport adapter and makes the query orchestration testable in
+ * isolation from Express.
+ */
+export async function listGroupsForUser(userId: string): Promise<GroupListItem[]> {
+  const groups: GroupRow[] = await db('group_members')
+    .join('groups', 'groups.id', 'group_members.group_id')
+    .where('group_members.user_id', userId)
+    .select('groups.*', 'group_members.role')
+
+  if (groups.length === 0) return []
+
+  const groupIds = groups.map((g) => g.id)
+
+  const memberCountRows = await db('group_members')
+    .whereIn('group_id', groupIds)
+    .groupBy('group_id')
+    .select('group_id', db.raw('COUNT(*) as count'))
+  const memberCountMap = new Map<string, number>(
+    memberCountRows.map((r: { group_id: string; count: string }) => [r.group_id, Number(r.count)])
+  )
+
+  const lastSessions: LastSessionRow[] = await db('voting_sessions')
+    .whereIn('group_id', groupIds)
+    .where('status', 'closed')
+    .whereNotNull('winning_game_name')
+    .distinctOn('group_id')
+    .orderBy([
+      { column: 'group_id' },
+      { column: 'closed_at', order: 'desc' },
+    ])
+    .select('group_id', 'winning_game_app_id', 'winning_game_name', 'closed_at')
+  const lastSessionMap = indexBy(lastSessions, (s) => s.group_id)
+
+  const allMemberships: { group_id: string; user_id: string }[] = await db('group_members')
+    .whereIn('group_id', groupIds)
+    .select('group_id', 'user_id')
+  const groupedMembers = groupBy(allMemberships, (m) => m.group_id)
+  const memberIdsMap = new Map<string, string[]>(
+    Array.from(groupedMembers, ([gid, rows]) => [gid, rows.map((r) => r.user_id)])
+  )
+
+  const commonGameCountMap = await countCommonGamesForGroups(
+    groups.map((g) => {
+      const memberIds = memberIdsMap.get(g.id) ?? []
+      return {
+        groupId: g.id,
+        memberIds,
+        threshold: g.common_game_threshold || memberIds.length,
+      }
+    })
+  )
+
+  const personaMap = await selectPersonasForGroups(groupIds)
+
+  return groups.map((g) => {
+    const last = lastSessionMap.get(g.id)
+    return {
+      id: g.id,
+      name: g.name,
+      role: g.role,
+      createdAt: g.created_at,
+      memberCount: memberCountMap.get(g.id) ?? 0,
+      commonGameCount: commonGameCountMap.get(g.id) ?? 0,
+      lastSession: last
+        ? {
+            gameName: last.winning_game_name,
+            gameAppId: last.winning_game_app_id,
+            closedAt: last.closed_at,
+          }
+        : null,
+      todayPersona: personaMap.get(g.id) ?? null,
+      discordGuildId: g.discord_guild_id ?? null,
+      discordChannelId: g.discord_channel_id ?? null,
+      discordGuildName: g.discord_guild_name ?? null,
+      discordChannelName: g.discord_channel_name ?? null,
+    }
+  })
+}

--- a/packages/backend/src/domain/library-sync-coordinator.ts
+++ b/packages/backend/src/domain/library-sync-coordinator.ts
@@ -1,0 +1,90 @@
+import { db } from '../infrastructure/database/connection.js'
+import { logger } from '../infrastructure/logger/logger.js'
+
+/**
+ * Per-platform sync provider. Implementations live in auth.routes.ts (Steam,
+ * Epic, GOG) and are wired into the registry from a single call site so the
+ * route handler doesn't have to know which providers exist.
+ *
+ * `linked(userId)` returns true if this provider should be invoked for the
+ * member. Steam is always linked (every WAWPTN user has a Steam ID); Epic
+ * and GOG are opt-in via the `accounts` table.
+ */
+export interface LibrarySyncProvider {
+  readonly id: string
+  linked(userId: string, context: GroupSyncContext): boolean | Promise<boolean>
+  sync(userId: string, context: GroupSyncContext): Promise<number>
+}
+
+export interface GroupSyncContext {
+  groupId: string
+  member: { id: string; steamId: string }
+  /** Set of provider ids the member has explicitly linked (excludes Steam,
+   *  which is implicit). Pre-fetched in one query so each provider doesn't
+   *  re-hit the DB for every member. */
+  linkedProviderIds: ReadonlySet<string>
+}
+
+export type SyncedHandler = (memberId: string, gameCount: number, providerId: string) => void
+
+/**
+ * Coordinates fan-out library sync across providers. The route handler
+ * registers providers once, then calls `syncGroup()` per request. Adding a
+ * new platform = register a new provider here, no route change needed.
+ */
+export class LibrarySyncCoordinator {
+  private readonly providers: LibrarySyncProvider[] = []
+
+  register(provider: LibrarySyncProvider): this {
+    this.providers.push(provider)
+    return this
+  }
+
+  async syncGroup(groupId: string, onSynced: SyncedHandler): Promise<void> {
+    const members = await db('group_members')
+      .join('users', 'users.id', 'group_members.user_id')
+      .where('group_members.group_id', groupId)
+      .select('users.id', 'users.steam_id')
+
+    if (members.length === 0) return
+
+    const memberIds = members.map((m: { id: string }) => m.id)
+    const optionalProviderIds = this.providers.map((p) => p.id).filter((id) => id !== 'steam')
+    const linkedAccounts = optionalProviderIds.length > 0
+      ? await db('accounts')
+          .whereIn('user_id', memberIds)
+          .whereIn('provider_id', optionalProviderIds)
+          .where('status', 'active')
+          .select('user_id', 'provider_id')
+      : []
+
+    const linkedByUser = new Map<string, Set<string>>()
+    for (const row of linkedAccounts) {
+      const set = linkedByUser.get(row.user_id) ?? new Set<string>()
+      set.add(row.provider_id)
+      linkedByUser.set(row.user_id, set)
+    }
+
+    for (const member of members) {
+      const ctx: GroupSyncContext = {
+        groupId,
+        member: { id: member.id, steamId: member.steam_id },
+        linkedProviderIds: linkedByUser.get(member.id) ?? new Set(),
+      }
+
+      for (const provider of this.providers) {
+        const linked = await provider.linked(member.id, ctx)
+        if (!linked) continue
+
+        provider.sync(member.id, ctx)
+          .then((count) => onSynced(member.id, count, provider.id))
+          .catch((err) => {
+            logger.error(
+              { error: String(err), userId: member.id, provider: provider.id, groupId },
+              'library sync failed for member'
+            )
+          })
+      }
+    }
+  }
+}

--- a/packages/backend/src/domain/subscription-service.ts
+++ b/packages/backend/src/domain/subscription-service.ts
@@ -16,6 +16,24 @@ export const PREMIUM_TIER_LIMITS = {
   maxVoteHistorySessions: 100,
 } as const
 
+/** Stable error payloads for tier gates. Centralized so that route handlers
+ *  and Discord/bot handlers all surface the same shape — the frontend keys
+ *  off `error` to render upgrade CTAs. */
+export const TIER_ERRORS = {
+  freeMaxGroupsReached: () => ({
+    error: 'premium_required' as const,
+    message: `Free users can create max ${FREE_TIER_LIMITS.maxGroups} groups. Upgrade to premium for unlimited groups.`,
+  }),
+  freeMemberLimitReached: () => ({
+    error: 'premium_required' as const,
+    message: `This group has reached the free member limit (${FREE_TIER_LIMITS.maxMembersPerGroup}). Group owner must upgrade to premium.`,
+  }),
+  premiumMemberLimitReached: () => ({
+    error: 'member_limit' as const,
+    message: `This group has reached the maximum member limit (${PREMIUM_TIER_LIMITS.maxMembersPerGroup}).`,
+  }),
+} as const
+
 /** In-memory cache for premium status with TTL */
 interface CacheEntry {
   value: boolean

--- a/packages/backend/src/lib/collections.ts
+++ b/packages/backend/src/lib/collections.ts
@@ -1,0 +1,18 @@
+/** Index a list by a unique key extracted from each item. */
+export function indexBy<T, K>(items: readonly T[], keyFn: (item: T) => K): Map<K, T> {
+  const map = new Map<K, T>()
+  for (const item of items) map.set(keyFn(item), item)
+  return map
+}
+
+/** Group items into a Map keyed by the extracted key, preserving insertion order. */
+export function groupBy<T, K>(items: readonly T[], keyFn: (item: T) => K): Map<K, T[]> {
+  const map = new Map<K, T[]>()
+  for (const item of items) {
+    const key = keyFn(item)
+    const list = map.get(key)
+    if (list) list.push(item)
+    else map.set(key, [item])
+  }
+  return map
+}

--- a/packages/backend/src/lib/pagination.ts
+++ b/packages/backend/src/lib/pagination.ts
@@ -1,0 +1,40 @@
+export interface TierPagingPolicy {
+  /** Free users are capped at this many items per request and CANNOT page
+   *  past the head — `offset` is forced to 0 to keep them on the most-recent
+   *  slice. */
+  freeMaxLimit: number
+  /** Premium users are capped at this many items per request, but offset is
+   *  honored so they can page through the full back catalog. */
+  premiumMaxLimit: number
+}
+
+export interface PagingResult {
+  limit: number
+  offset: number
+}
+
+/** Apply tier-based limit + offset rules.
+ *
+ *  Premium: limit = min(requested, premiumMax); offset honored.
+ *  Free:    limit = min(requested, freeMax);    offset forced to 0.
+ */
+export function applyTierLimits(
+  requestedLimit: number,
+  requestedOffset: number,
+  isPremium: boolean,
+  policy: TierPagingPolicy
+): PagingResult {
+  const safeLimit = Math.max(Number.isFinite(requestedLimit) ? requestedLimit : 10, 1)
+  const safeOffset = Math.max(Number.isFinite(requestedOffset) ? requestedOffset : 0, 0)
+
+  if (isPremium) {
+    return {
+      limit: Math.min(safeLimit, policy.premiumMaxLimit),
+      offset: safeOffset,
+    }
+  }
+  return {
+    limit: Math.min(safeLimit, policy.freeMaxLimit),
+    offset: 0,
+  }
+}

--- a/packages/backend/src/presentation/middleware/tier.middleware.ts
+++ b/packages/backend/src/presentation/middleware/tier.middleware.ts
@@ -23,3 +23,41 @@ export async function requirePremium(req: Request, res: Response, next: NextFunc
     res.status(403).json({ error: 'premium_required', message: 'Premium subscription required' })
   }
 }
+
+/** Premium-feature gate registry. Adding a new gated feature = add one entry
+ *  here, then mount `requirePremiumFeature('feature-name')` on the route.
+ *  Routes never need to know about isUserPremium() or the message string.
+ */
+const PREMIUM_FEATURE_MESSAGES = {
+  'auto-vote': 'Auto-vote scheduling requires a premium subscription',
+  'vote-scheduling': 'Vote scheduling requires a premium subscription',
+  'recommendations': 'Game recommendations require a premium subscription',
+} as const
+
+export type PremiumFeature = keyof typeof PREMIUM_FEATURE_MESSAGES
+
+/** Express middleware factory — blocks request if user is not premium, with
+ *  a feature-specific 403 message so the client can render the right CTA. */
+export function requirePremiumFeature(feature: PremiumFeature) {
+  return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      const premium = await isUserPremium(req.userId!)
+      if (!premium) {
+        res.status(403).json({
+          error: 'premium_required',
+          message: PREMIUM_FEATURE_MESSAGES[feature],
+          feature,
+        })
+        return
+      }
+      next()
+    } catch (error) {
+      authLogger.error({ error: String(error), path: req.path, feature }, 'tier middleware: database error')
+      res.status(403).json({
+        error: 'premium_required',
+        message: PREMIUM_FEATURE_MESSAGES[feature],
+        feature,
+      })
+    }
+  }
+}

--- a/packages/backend/src/presentation/routes/group.routes.ts
+++ b/packages/backend/src/presentation/routes/group.routes.ts
@@ -1,18 +1,19 @@
 import { Router, type Request, type Response } from 'express'
 import cron from 'node-cron'
 import { db } from '../../infrastructure/database/connection.js'
-import { computeCommonGames, countCommonGamesForGroups } from '../../infrastructure/database/common-games.js'
-import { generateInviteToken, hashInviteToken } from '../../infrastructure/steam/steam-client.js'
+import { computeCommonGames } from '../../infrastructure/database/common-games.js'
+import { generateInviteToken, hashInviteToken, getHeaderImageUrl } from '../../infrastructure/steam/steam-client.js'
 import { triggerBackgroundEnrichment } from '../../infrastructure/steam/steam-store-client.js'
 import { getIO, forceLeaveRoom } from '../../infrastructure/socket/socket.js'
 import { updateGroupSchedule } from '../../infrastructure/scheduler/auto-vote-scheduler.js'
 import { logger } from '../../infrastructure/logger/logger.js'
-import { isUserPremium, FREE_TIER_LIMITS, PREMIUM_TIER_LIMITS } from '../middleware/tier.middleware.js'
+import { isUserPremium, FREE_TIER_LIMITS, PREMIUM_TIER_LIMITS, requirePremiumFeature } from '../middleware/tier.middleware.js'
+import { TIER_ERRORS } from '../../domain/subscription-service.js'
 import { requireGroupMembership } from '../middleware/group-membership.middleware.js'
+import { listGroupsForUser } from '../../domain/group-listing-service.js'
 import { isBannedFromGroup } from '../../domain/discord-auth-intent.js'
 import {
   selectPersonaForGroup,
-  selectPersonasForGroups,
   invalidateGroupPersonaCache,
   parisDate,
 } from '../../domain/persona-selection.js'
@@ -21,87 +22,7 @@ const router = Router()
 
 // List my groups
 router.get('/', async (req: Request, res: Response) => {
-  const userId = req.userId!
-  const groups = await db('group_members')
-    .join('groups', 'groups.id', 'group_members.group_id')
-    .where('group_members.user_id', userId)
-    .select('groups.*', 'group_members.role')
-
-  const groupIds = groups.map(g => g.id)
-
-  // Get member counts per group
-  const memberCounts = groupIds.length > 0
-    ? await db('group_members')
-        .whereIn('group_id', groupIds)
-        .groupBy('group_id')
-        .select('group_id', db.raw('COUNT(*) as count'))
-    : []
-  const memberCountMap = new Map(memberCounts.map((r: { group_id: string; count: string }) => [r.group_id, Number(r.count)]))
-
-  // Get last closed session per group
-  const lastSessions = groupIds.length > 0
-    ? await db('voting_sessions')
-        .whereIn('group_id', groupIds)
-        .where('status', 'closed')
-        .whereNotNull('winning_game_name')
-        .distinctOn('group_id')
-        .orderBy([
-          { column: 'group_id' },
-          { column: 'closed_at', order: 'desc' },
-        ])
-        .select('group_id', 'winning_game_app_id', 'winning_game_name', 'closed_at')
-    : []
-  const lastSessionMap = new Map(lastSessions.map((s: { group_id: string; winning_game_app_id: number; winning_game_name: string; closed_at: string }) => [s.group_id, s]))
-
-  // Get member IDs per group for common game counting
-  const allMemberships = groupIds.length > 0
-    ? await db('group_members')
-        .whereIn('group_id', groupIds)
-        .select('group_id', 'user_id')
-    : []
-  const memberIdsMap = new Map<string, string[]>()
-  for (const m of allMemberships) {
-    const list = memberIdsMap.get(m.group_id) || []
-    list.push(m.user_id)
-    memberIdsMap.set(m.group_id, list)
-  }
-
-  // Count common games per group in a single batched query
-  const commonGameCountMap = await countCommonGamesForGroups(
-    groups.map((g) => {
-      const memberIds = memberIdsMap.get(g.id) || []
-      return {
-        groupId: g.id as string,
-        memberIds,
-        threshold: (g.common_game_threshold as number | null) || memberIds.length,
-      }
-    })
-  )
-
-  // Enrich with each group's "persona du jour" — computed in a single
-  // batch so the list page doesn't need an N+1 cascade of follow-up calls.
-  const personaMap = await selectPersonasForGroups(groupIds)
-
-  res.json(groups.map(g => ({
-    id: g.id,
-    name: g.name,
-    role: g.role,
-    createdAt: g.created_at,
-    memberCount: memberCountMap.get(g.id) || 0,
-    commonGameCount: commonGameCountMap.get(g.id) || 0,
-    lastSession: lastSessionMap.has(g.id)
-      ? {
-          gameName: lastSessionMap.get(g.id)!.winning_game_name,
-          gameAppId: lastSessionMap.get(g.id)!.winning_game_app_id,
-          closedAt: lastSessionMap.get(g.id)!.closed_at,
-        }
-      : null,
-    todayPersona: personaMap.get(g.id) || null,
-    discordGuildId: g.discord_guild_id ?? null,
-    discordChannelId: g.discord_channel_id ?? null,
-    discordGuildName: g.discord_guild_name ?? null,
-    discordChannelName: g.discord_channel_name ?? null,
-  })))
+  res.json(await listGroupsForUser(req.userId!))
 })
 
 // Get group detail with members
@@ -295,7 +216,7 @@ router.post('/', async (req: Request, res: Response) => {
   if (!premium) {
     const ownedCount = await db('group_members').where({ user_id: userId, role: 'owner' }).count('* as count').first()
     if (Number(ownedCount?.count || 0) >= FREE_TIER_LIMITS.maxGroups) {
-      res.status(403).json({ error: 'premium_required', message: `Free users can create max ${FREE_TIER_LIMITS.maxGroups} groups. Upgrade to premium for unlimited groups.` })
+      res.status(403).json(TIER_ERRORS.freeMaxGroupsReached())
       return
     }
   }
@@ -388,26 +309,14 @@ router.patch('/:id/notifications', requireGroupMembership(), async (req: Request
 })
 
 // Configure auto-vote schedule (owner only)
-router.patch('/:id/auto-vote', async (req: Request, res: Response) => {
+router.patch(
+  '/:id/auto-vote',
+  requireGroupMembership({ role: 'owner' }),
+  requirePremiumFeature('auto-vote'),
+  async (req: Request, res: Response) => {
   const userId = req.userId!
   const groupId = String(req.params['id'])
   const { schedule, durationMinutes } = req.body as { schedule: string | null; durationMinutes?: number }
-
-  const membership = await db('group_members')
-    .where({ group_id: groupId, user_id: userId, role: 'owner' })
-    .first()
-
-  if (!membership) {
-    res.status(403).json({ error: 'forbidden', message: 'Only the group owner can configure auto-vote' })
-    return
-  }
-
-  // Auto-vote scheduling is a premium feature
-  const premium = await isUserPremium(userId)
-  if (!premium) {
-    res.status(403).json({ error: 'premium_required', message: 'Auto-vote scheduling requires a premium subscription' })
-    return
-  }
 
   // Validate cron expression if provided
   if (schedule !== null && schedule !== undefined) {
@@ -442,18 +351,8 @@ router.patch('/:id/auto-vote', async (req: Request, res: Response) => {
 })
 
 // Generate new invite link (owner only)
-router.post('/:id/invite', async (req: Request, res: Response) => {
-  const userId = req.userId!
+router.post('/:id/invite', requireGroupMembership({ role: 'owner' }), async (req: Request, res: Response) => {
   const groupId = String(req.params['id'])
-
-  const membership = await db('group_members')
-    .where({ group_id: groupId, user_id: userId, role: 'owner' })
-    .first()
-
-  if (!membership) {
-    res.status(403).json({ error: 'forbidden', message: 'Only the group owner can generate invites' })
-    return
-  }
 
   const { token, hash } = generateInviteToken()
   const expiresAt = new Date(Date.now() + 72 * 60 * 60 * 1000)
@@ -524,11 +423,11 @@ router.post('/join', async (req: Request, res: Response) => {
     const memberCount = await db('group_members').where({ group_id: group.id }).count('* as count').first()
     const currentCount = Number(memberCount?.count || 0)
     if (!ownerIsPremium && currentCount >= FREE_TIER_LIMITS.maxMembersPerGroup) {
-      res.status(403).json({ error: 'premium_required', message: `This group has reached the free member limit (${FREE_TIER_LIMITS.maxMembersPerGroup}). Group owner must upgrade to premium.` })
+      res.status(403).json(TIER_ERRORS.freeMemberLimitReached())
       return
     }
     if (ownerIsPremium && currentCount >= PREMIUM_TIER_LIMITS.maxMembersPerGroup) {
-      res.status(403).json({ error: 'member_limit', message: `This group has reached the maximum member limit (${PREMIUM_TIER_LIMITS.maxMembersPerGroup}).` })
+      res.status(403).json(TIER_ERRORS.premiumMemberLimitReached())
       return
     }
   }
@@ -647,18 +546,9 @@ router.delete('/:id/members/:userId', async (req: Request, res: Response) => {
 })
 
 // Delete group (owner only)
-router.delete('/:id', async (req: Request, res: Response) => {
+router.delete('/:id', requireGroupMembership({ role: 'owner' }), async (req: Request, res: Response) => {
   const userId = req.userId!
   const groupId = String(req.params['id'])
-
-  const membership = await db('group_members')
-    .where({ group_id: groupId, user_id: userId, role: 'owner' })
-    .first()
-
-  if (!membership) {
-    res.status(403).json({ error: 'forbidden', message: 'Only the group owner can delete the group' })
-    return
-  }
 
   // Check for open voting sessions
   const openSession = await db('voting_sessions')
@@ -694,20 +584,10 @@ router.delete('/:id', async (req: Request, res: Response) => {
 })
 
 // Get common games for a group
-router.get('/:id/common-games', async (req: Request, res: Response) => {
+router.get('/:id/common-games', requireGroupMembership(), async (req: Request, res: Response) => {
   try {
-    const userId = req.userId!
     const groupId = String(req.params['id'])
     const filter = String(req.query['filter'] || '')
-
-    const membership = await db('group_members')
-      .where({ group_id: groupId, user_id: userId })
-      .first()
-
-    if (!membership) {
-      res.status(403).json({ error: 'forbidden', message: 'Not a member' })
-      return
-    }
 
     const group = await db('groups').where({ id: groupId }).first()
     const memberIds = await db('group_members').where({ group_id: groupId }).pluck('user_id')
@@ -741,9 +621,8 @@ router.get('/:id/common-games', async (req: Request, res: Response) => {
 })
 
 // Preview common games for a subset of members (read-only, no enrichment)
-router.post('/:id/common-games/preview', async (req: Request, res: Response) => {
+router.post('/:id/common-games/preview', requireGroupMembership(), async (req: Request, res: Response) => {
   try {
-    const userId = req.userId!
     const groupId = String(req.params['id'])
     const { memberIds, filter, filters } = req.body as { memberIds: string[]; filter?: string; filters?: { multiplayer?: boolean; coop?: boolean; free?: boolean } }
 
@@ -754,15 +633,6 @@ router.post('/:id/common-games/preview', async (req: Request, res: Response) => 
 
     if (memberIds.length > 100) {
       res.status(400).json({ error: 'validation', message: 'Cannot have more than 100 member IDs' })
-      return
-    }
-
-    const membership = await db('group_members')
-      .where({ group_id: groupId, user_id: userId })
-      .first()
-
-    if (!membership) {
-      res.status(403).json({ error: 'forbidden', message: 'Not a member' })
       return
     }
 
@@ -788,19 +658,9 @@ router.post('/:id/common-games/preview', async (req: Request, res: Response) => 
 })
 
 // Get group voting stats dashboard
-router.get('/:id/stats', async (req: Request, res: Response) => {
+router.get('/:id/stats', requireGroupMembership(), async (req: Request, res: Response) => {
   try {
-    const userId = req.userId!
     const groupId = String(req.params['id'])
-
-    const membership = await db('group_members')
-      .where({ group_id: groupId, user_id: userId })
-      .first()
-
-    if (!membership) {
-      res.status(403).json({ error: 'forbidden', message: 'Not a member' })
-      return
-    }
 
     // Total closed sessions
     const totalSessionsResult = await db('voting_sessions')
@@ -841,7 +701,9 @@ router.get('/:id/stats', async (req: Request, res: Response) => {
         .select('voting_session_games.steam_app_id')
         .count('* as totalNominations')
         .groupBy('voting_session_games.steam_app_id') as unknown as { steam_app_id: number; totalNominations: string }[]
-      nominationMap = new Map(nominations.map(n => [n.steam_app_id, Number(n.totalNominations)]))
+      nominationMap = new Map(
+        nominations.map((n) => [n.steam_app_id, Number(n.totalNominations)])
+      )
     }
 
     // Member participation: per member vote count and sessions participated
@@ -904,98 +766,45 @@ router.get('/:id/stats', async (req: Request, res: Response) => {
 })
 
 // Trigger library sync for all group members (owner only)
-router.post('/:id/sync', async (req: Request, res: Response) => {
-  const userId = req.userId!
+router.post('/:id/sync', requireGroupMembership({ role: 'owner' }), async (req: Request, res: Response) => {
   const groupId = String(req.params['id'])
-
-  const membership = await db('group_members')
-    .where({ group_id: groupId, user_id: userId, role: 'owner' })
-    .first()
-
-  if (!membership) {
-    res.status(403).json({ error: 'forbidden', message: 'Only the group owner can trigger sync' })
-    return
-  }
 
   // Import sync functions dynamically to avoid circular deps
   const { syncUserLibrary, syncEpicLibrary, syncGogLibrary } = await import('./auth.routes.js')
+  const { LibrarySyncCoordinator } = await import('../../domain/library-sync-coordinator.js')
 
-  const members = await db('group_members')
-    .join('users', 'users.id', 'group_members.user_id')
-    .where('group_members.group_id', groupId)
-    .select('users.id', 'users.steam_id')
-
-  // Get linked accounts for all members to sync all platforms
-  const memberIds = members.map((m: { id: string }) => m.id)
-  const linkedAccounts = await db('accounts')
-    .whereIn('user_id', memberIds)
-    .whereIn('provider_id', ['epic', 'gog'])
-    .where('status', 'active')
-    .select('user_id', 'provider_id')
-
-  const emitSynced = (memberId: string, gameCount: number) => {
-    const io = getIO()
-    io.to(`group:${groupId}`).emit('library:synced', {
-      groupId,
-      userId: memberId,
-      gameCount,
+  const coordinator = new LibrarySyncCoordinator()
+    .register({
+      id: 'steam',
+      linked: () => true,
+      sync: (userId, ctx) => syncUserLibrary(userId, ctx.member.steamId),
     })
-  }
-
-  // Sync in background, one at a time (rate limited)
-  for (const member of members) {
-    // Steam sync
-    syncUserLibrary(member.id, member.steam_id).then((count) => {
-      emitSynced(member.id, count)
-    }).catch(err => {
-      logger.error({ error: String(err), userId: member.id }, 'Steam sync failed for member')
+    .register({
+      id: 'epic',
+      linked: (_userId, ctx) => ctx.linkedProviderIds.has('epic'),
+      sync: (userId) => syncEpicLibrary(userId),
+    })
+    .register({
+      id: 'gog',
+      linked: (_userId, ctx) => ctx.linkedProviderIds.has('gog'),
+      sync: (userId) => syncGogLibrary(userId),
     })
 
-    // Epic sync (if linked)
-    const hasEpic = linkedAccounts.some((a: { user_id: string; provider_id: string }) => a.user_id === member.id && a.provider_id === 'epic')
-    if (hasEpic) {
-      syncEpicLibrary(member.id).then((count) => {
-        emitSynced(member.id, count)
-      }).catch(err => {
-        logger.error({ error: String(err), userId: member.id }, 'Epic sync failed for member')
-      })
-    }
-
-    // GOG sync (if linked)
-    const hasGog = linkedAccounts.some((a: { user_id: string; provider_id: string }) => a.user_id === member.id && a.provider_id === 'gog')
-    if (hasGog) {
-      syncGogLibrary(member.id).then((count) => {
-        emitSynced(member.id, count)
-      }).catch(err => {
-        logger.error({ error: String(err), userId: member.id }, 'GOG sync failed for member')
-      })
-    }
-  }
+  await coordinator.syncGroup(groupId, (memberId, gameCount) => {
+    getIO().to(`group:${groupId}`).emit('library:synced', { groupId, userId: memberId, gameCount })
+  })
 
   res.json({ ok: true, message: 'Library sync started for all members across all platforms' })
 })
 
 // Get smart game recommendations based on vote history
-router.get('/:id/recommendations', async (req: Request, res: Response) => {
+router.get(
+  '/:id/recommendations',
+  requireGroupMembership(),
+  requirePremiumFeature('recommendations'),
+  async (req: Request, res: Response) => {
   try {
-    const userId = req.userId!
     const groupId = String(req.params['id'])
-
-    const membership = await db('group_members')
-      .where({ group_id: groupId, user_id: userId })
-      .first()
-
-    if (!membership) {
-      res.status(403).json({ error: 'forbidden', message: 'Not a member' })
-      return
-    }
-
-    // Recommendations are a premium feature
-    const premium = await isUserPremium(userId)
-    if (!premium) {
-      res.status(403).json({ error: 'premium_required', message: 'Game recommendations require a premium subscription' })
-      return
-    }
 
     const group = await db('groups').where({ id: groupId }).first()
     const memberIds = await db('group_members').where({ group_id: groupId }).pluck('user_id')
@@ -1082,7 +891,7 @@ router.get('/:id/recommendations', async (req: Request, res: Response) => {
         return {
           gameName: game.gameName,
           steamAppId: game.steamAppId,
-          headerImageUrl: game.headerImageUrl || `https://cdn.akamai.steamstatic.com/steam/apps/${game.steamAppId}/header.jpg`,
+          headerImageUrl: game.headerImageUrl || getHeaderImageUrl(game.steamAppId),
           reason,
           score,
         }

--- a/packages/backend/src/presentation/routes/vote.routes.ts
+++ b/packages/backend/src/presentation/routes/vote.routes.ts
@@ -4,6 +4,8 @@ import { getIO } from '../../infrastructure/socket/socket.js'
 import { closeSession } from '../../domain/close-session.js'
 import { createVotingSession } from '../../domain/create-session.js'
 import { isUserPremium, FREE_TIER_LIMITS, PREMIUM_TIER_LIMITS } from '../middleware/tier.middleware.js'
+import { requireGroupMembership } from '../middleware/group-membership.middleware.js'
+import { applyTierLimits } from '../../lib/pagination.js'
 import { evaluateChallenges } from '../../domain/challenges/challenge-service.js'
 import { domainEvents } from '../../domain/events/event-bus.js'
 import { logger } from '../../infrastructure/logger/logger.js'
@@ -11,18 +13,9 @@ import { logger } from '../../infrastructure/logger/logger.js'
 const router = Router()
 
 // Get active voting session for a group
-router.get('/:groupId/vote', async (req: Request, res: Response) => {
+router.get('/:groupId/vote', requireGroupMembership({ paramName: 'groupId' }), async (req: Request, res: Response) => {
   const userId = req.userId!
   const groupId = String(req.params['groupId'])
-
-  const membership = await db('group_members')
-    .where({ group_id: groupId, user_id: userId })
-    .first()
-
-  if (!membership) {
-    res.status(403).json({ error: 'forbidden', message: 'Not a member' })
-    return
-  }
 
   const session = await db('voting_sessions')
     .where({ group_id: groupId, status: 'open' })
@@ -48,7 +41,14 @@ router.get('/:groupId/vote', async (req: Request, res: Response) => {
     .distinct('user_id')
     .pluck('user_id')
 
-  // Get total participants from junction table, fallback to group_members for legacy sessions
+  // TRANSITIONAL FALLBACK (LSP):
+  // Sessions created after migration 2024_voting_session_participants populate
+  // the junction table; sessions created before it don't. The fallback to
+  // group_members below treats those legacy sessions as "everyone in the
+  // group is a participant" so the UI can still render progress.
+  // Remove once: (a) all open legacy sessions have been closed, (b) a
+  // backfill migration has populated the junction for every closed session,
+  // OR (c) the project is comfortable orphaning pre-migration sessions.
   const participantCount = await db('voting_session_participants')
     .where({ session_id: session.id })
     .count('* as count')
@@ -121,18 +121,9 @@ router.get('/:groupId/vote', async (req: Request, res: Response) => {
 })
 
 // Create a new voting session (on-demand)
-router.post('/:groupId/vote', async (req: Request, res: Response) => {
+router.post('/:groupId/vote', requireGroupMembership({ paramName: 'groupId' }), async (req: Request, res: Response) => {
   const userId = req.userId!
   const groupId = String(req.params['groupId'])
-
-  const membership = await db('group_members')
-    .where({ group_id: groupId, user_id: userId })
-    .first()
-
-  if (!membership) {
-    res.status(403).json({ error: 'forbidden', message: 'Not a member' })
-    return
-  }
 
   const { filter, filters, participantIds, scheduledAt } = req.body as { filter?: string; filters?: { multiplayer?: boolean; coop?: boolean; free?: boolean }; participantIds: string[]; scheduledAt?: string }
 
@@ -150,10 +141,16 @@ router.post('/:groupId/vote', async (req: Request, res: Response) => {
   // Validate scheduledAt if provided
   let parsedScheduledAt: Date | null = null
   if (scheduledAt) {
-    // Vote scheduling is a premium feature
+    // Vote scheduling is a premium feature. We can't mount the gate as
+    // middleware because scheduling is conditional on `scheduledAt` being
+    // present in the body — the rest of the endpoint is free-tier.
     const premium = await isUserPremium(userId)
     if (!premium) {
-      res.status(403).json({ error: 'premium_required', message: 'Vote scheduling requires a premium subscription' })
+      res.status(403).json({
+        error: 'premium_required',
+        message: 'Vote scheduling requires a premium subscription',
+        feature: 'vote-scheduling',
+      })
       return
     }
 
@@ -236,7 +233,8 @@ router.post('/:groupId/vote/:sessionId', async (req: Request, res: Response) => 
     return
   }
 
-  // Check if user is a participant (junction table), fallback to group_members for legacy sessions
+  // Check if user is a participant (junction table), with the same legacy
+  // fallback documented at the top of GET /:groupId/vote — see note there.
   const participantCount = await db('voting_session_participants')
     .where({ session_id: sessionId })
     .count('* as count')
@@ -344,7 +342,7 @@ router.post('/:groupId/vote/:sessionId', async (req: Request, res: Response) => 
 })
 
 // Close voting session and compute winner
-router.post('/:groupId/vote/:sessionId/close', async (req: Request, res: Response) => {
+router.post('/:groupId/vote/:sessionId/close', requireGroupMembership({ paramName: 'groupId' }), async (req: Request, res: Response) => {
   const userId = req.userId!
   const groupId = String(req.params['groupId'])
   const sessionId = String(req.params['sessionId'])
@@ -359,11 +357,7 @@ router.post('/:groupId/vote/:sessionId/close', async (req: Request, res: Respons
     return
   }
 
-  const membership = await db('group_members')
-    .where({ group_id: groupId, user_id: userId })
-    .first()
-
-  if (!membership || (session.created_by !== userId && membership.role !== 'owner')) {
+  if (session.created_by !== userId && req.membership!.role !== 'owner') {
     res.status(403).json({ error: 'forbidden', message: 'Only session creator or group owner can close the vote' })
     return
   }
@@ -379,7 +373,7 @@ router.post('/:groupId/vote/:sessionId/close', async (req: Request, res: Respons
 })
 
 // Rematch: create a new session with the same participants, excluding the winning game
-router.post('/:groupId/vote/:sessionId/rematch', async (req: Request, res: Response) => {
+router.post('/:groupId/vote/:sessionId/rematch', requireGroupMembership({ paramName: 'groupId' }), async (req: Request, res: Response) => {
   const userId = req.userId!
   const groupId = String(req.params['groupId'])
   const sessionId = String(req.params['sessionId'])
@@ -391,16 +385,6 @@ router.post('/:groupId/vote/:sessionId/rematch', async (req: Request, res: Respo
 
   if (!session) {
     res.status(404).json({ error: 'not_found', message: 'No closed session found' })
-    return
-  }
-
-  // Check membership
-  const membership = await db('group_members')
-    .where({ group_id: groupId, user_id: userId })
-    .first()
-
-  if (!membership) {
-    res.status(403).json({ error: 'forbidden', message: 'Not a member' })
     return
   }
 
@@ -448,7 +432,7 @@ router.post('/:groupId/vote/:sessionId/rematch', async (req: Request, res: Respo
 })
 
 // Delete a closed voting session (creator or group owner only)
-router.delete('/:groupId/vote/:sessionId', async (req: Request, res: Response) => {
+router.delete('/:groupId/vote/:sessionId', requireGroupMembership({ paramName: 'groupId' }), async (req: Request, res: Response) => {
   const userId = req.userId!
   const groupId = String(req.params['groupId'])
   const sessionId = String(req.params['sessionId'])
@@ -462,11 +446,7 @@ router.delete('/:groupId/vote/:sessionId', async (req: Request, res: Response) =
     return
   }
 
-  const membership = await db('group_members')
-    .where({ group_id: groupId, user_id: userId })
-    .first()
-
-  if (!membership || (session.created_by !== userId && membership.role !== 'owner')) {
+  if (session.created_by !== userId && req.membership!.role !== 'owner') {
     res.status(403).json({ error: 'forbidden', message: 'Only session creator or group owner can delete' })
     return
   }
@@ -477,18 +457,9 @@ router.delete('/:groupId/vote/:sessionId', async (req: Request, res: Response) =
 })
 
 // Get past voting sessions for a group
-router.get('/:groupId/vote/history', async (req: Request, res: Response) => {
+router.get('/:groupId/vote/history', requireGroupMembership({ paramName: 'groupId' }), async (req: Request, res: Response) => {
   const userId = req.userId!
   const groupId = String(req.params['groupId'])
-
-  const membership = await db('group_members')
-    .where({ group_id: groupId, user_id: userId })
-    .first()
-
-  if (!membership) {
-    res.status(403).json({ error: 'forbidden', message: 'Not a member' })
-    return
-  }
 
   // Free users see only the most recent N sessions (no offset paging into
   // older history). Premium users can page through everything up to the
@@ -496,18 +467,12 @@ router.get('/:groupId/vote/history', async (req: Request, res: Response) => {
   // an upgrade CTA when a free user's query would have returned more.
   const premium = await isUserPremium(userId)
   const freeMax = FREE_TIER_LIMITS.maxVoteHistorySessions
-  const premiumMax = PREMIUM_TIER_LIMITS.maxVoteHistorySessions
-
-  const requestedLimit = Math.max(Number(req.query['limit']) || 10, 1)
-  const requestedOffset = Math.max(Number(req.query['offset']) || 0, 0)
-
-  // Premium: respect the caller's limit up to the premium cap, allow offset.
-  // Free: hard-cap limit at freeMax AND force offset to 0 — free users can
-  // only see the head of the list, not page into the back catalog.
-  const limit = premium
-    ? Math.min(requestedLimit, premiumMax)
-    : Math.min(requestedLimit, freeMax)
-  const offset = premium ? requestedOffset : 0
+  const { limit, offset } = applyTierLimits(
+    Number(req.query['limit']) || 10,
+    Number(req.query['offset']) || 0,
+    premium,
+    { freeMaxLimit: freeMax, premiumMaxLimit: PREMIUM_TIER_LIMITS.maxVoteHistorySessions }
+  )
 
   const totalResult = await db('voting_sessions')
     .where({ group_id: groupId, status: 'closed' })

--- a/packages/discord/src/http/handlers-error.ts
+++ b/packages/discord/src/http/handlers-error.ts
@@ -1,0 +1,5 @@
+export class BotHandlerError extends Error {
+  constructor(public statusCode: number, message: string) {
+    super(message)
+  }
+}

--- a/packages/discord/src/http/handlers.ts
+++ b/packages/discord/src/http/handlers.ts
@@ -1,4 +1,4 @@
-import type { Client, TextBasedChannel } from 'discord.js'
+import type { Client } from 'discord.js'
 import type {
   DiscordSessionClosedRequest,
   DiscordSessionCreatedRequest,
@@ -6,6 +6,8 @@ import type {
   DiscordSessionUpdateRequest,
 } from '@wawptn/types'
 import { buildSessionClosedEmbed, buildSessionEmbed } from '../lib/embeds.js'
+import { sendMessage, editMessage } from '../lib/channel-adapter.js'
+import { BotHandlerError } from './handlers-error.js'
 
 /**
  * Handlers live here (separated from the transport layer in server.ts) so
@@ -13,22 +15,7 @@ import { buildSessionClosedEmbed, buildSessionEmbed } from '../lib/embeds.js'
  * Each handler receives an already-parsed, already-authenticated payload.
  */
 
-export class BotHandlerError extends Error {
-  constructor(public statusCode: number, message: string) {
-    super(message)
-  }
-}
-
-async function resolveSendableChannel(client: Client, channelId: string): Promise<TextBasedChannel> {
-  const channel = await client.channels.fetch(channelId).catch(() => null)
-  if (!channel) {
-    throw new BotHandlerError(404, `Channel ${channelId} not found`)
-  }
-  if (!channel.isTextBased() || !('send' in channel)) {
-    throw new BotHandlerError(400, `Channel ${channelId} is not a sendable text channel`)
-  }
-  return channel as TextBasedChannel
-}
+export { BotHandlerError }
 
 export async function handleSessionCreated(
   client: Client,
@@ -40,7 +27,6 @@ export async function handleSessionCreated(
     throw new BotHandlerError(400, 'Missing required fields')
   }
 
-  const channel = await resolveSendableChannel(client, channelId)
   const { embeds, components } = buildSessionEmbed({
     groupName,
     creatorName,
@@ -49,11 +35,7 @@ export async function handleSessionCreated(
     summary,
   })
 
-  // `send` exists on guild text/announcement/thread/DM channels — the
-  // resolveSendableChannel guard above narrows down to those.
-  const sent = await (channel as unknown as { send: (payload: unknown) => Promise<{ id: string }> })
-    .send({ embeds, components })
-
+  const sent = await sendMessage(client, channelId, { embeds, components })
   return { messageId: sent.id }
 }
 
@@ -67,16 +49,6 @@ export async function handleSessionUpdate(
     throw new BotHandlerError(400, 'Missing required fields')
   }
 
-  const channel = await resolveSendableChannel(client, channelId)
-  // `messages` exists on every TextBasedChannel we care about (Guild text,
-  // Announcement, Thread, DM). The narrowing from resolveSendableChannel
-  // guarantees it here.
-  const messages = (channel as unknown as { messages: { fetch: (id: string) => Promise<unknown> } }).messages
-  const message = await messages.fetch(messageId).catch(() => null)
-  if (!message) {
-    throw new BotHandlerError(404, `Message ${messageId} not found`)
-  }
-
   const { embeds, components } = buildSessionEmbed({
     groupName,
     creatorName,
@@ -85,7 +57,7 @@ export async function handleSessionUpdate(
     summary,
   })
 
-  await (message as { edit: (payload: unknown) => Promise<unknown> }).edit({ embeds, components })
+  await editMessage(client, channelId, messageId, { embeds, components })
   return { ok: true }
 }
 
@@ -97,13 +69,6 @@ export async function handleSessionClosed(
 
   if (!channelId || !messageId || !sessionId || !result) {
     throw new BotHandlerError(400, 'Missing required fields')
-  }
-
-  const channel = await resolveSendableChannel(client, channelId)
-  const messages = (channel as unknown as { messages: { fetch: (id: string) => Promise<unknown> } }).messages
-  const message = await messages.fetch(messageId).catch(() => null)
-  if (!message) {
-    throw new BotHandlerError(404, `Message ${messageId} not found`)
   }
 
   // Re-materialize the game list from the tallies so the closed embed can
@@ -123,6 +88,6 @@ export async function handleSessionClosed(
     summary,
   })
 
-  await (message as { edit: (payload: unknown) => Promise<unknown> }).edit({ embeds, components })
+  await editMessage(client, channelId, messageId, { embeds, components })
   return { ok: true }
 }

--- a/packages/discord/src/lib/channel-adapter.ts
+++ b/packages/discord/src/lib/channel-adapter.ts
@@ -1,0 +1,59 @@
+import type { Client } from 'discord.js'
+import { BotHandlerError } from '../http/handlers-error.js'
+
+/**
+ * Thin adapter over discord.js channel/message ops.
+ *
+ * Why: discord.js types branch heavily by channel kind, but in WAWPTN we
+ * only care that the channel can `send` a message and `messages.fetch` an
+ * existing one. Keeping the unsafe type narrowings in one place means the
+ * handler code reads as plain business logic and any future discord.js
+ * upgrade only needs adjustments here.
+ *
+ * All methods raise `BotHandlerError` (not raw discord.js errors) so the
+ * HTTP layer can map them to status codes uniformly.
+ */
+type SendablePayload = { embeds?: unknown; components?: unknown }
+
+interface SendableChannel {
+  send: (payload: SendablePayload) => Promise<{ id: string }>
+  messages: { fetch: (id: string) => Promise<EditableMessage | null> }
+}
+
+interface EditableMessage {
+  edit: (payload: SendablePayload) => Promise<unknown>
+}
+
+async function fetchChannel(client: Client, channelId: string): Promise<SendableChannel> {
+  const channel = await client.channels.fetch(channelId).catch(() => null)
+  if (!channel) {
+    throw new BotHandlerError(404, `Channel ${channelId} not found`)
+  }
+  if (!channel.isTextBased() || !('send' in channel)) {
+    throw new BotHandlerError(400, `Channel ${channelId} is not a sendable text channel`)
+  }
+  return channel as unknown as SendableChannel
+}
+
+export async function sendMessage(
+  client: Client,
+  channelId: string,
+  payload: SendablePayload
+): Promise<{ id: string }> {
+  const channel = await fetchChannel(client, channelId)
+  return channel.send(payload)
+}
+
+export async function editMessage(
+  client: Client,
+  channelId: string,
+  messageId: string,
+  payload: SendablePayload
+): Promise<void> {
+  const channel = await fetchChannel(client, channelId)
+  const message = await channel.messages.fetch(messageId).catch(() => null)
+  if (!message) {
+    throw new BotHandlerError(404, `Message ${messageId} not found`)
+  }
+  await message.edit(payload)
+}

--- a/packages/frontend/src/components/game-grid.tsx
+++ b/packages/frontend/src/components/game-grid.tsx
@@ -19,6 +19,7 @@ import type { CommonGame } from '@wawptn/types'
 import { EmptyState } from '@/components/empty-state'
 import { useWishlistStore } from '@/stores/wishlist.store'
 import { decodeHtmlEntities } from '@/lib/utils'
+import { resolveSteamHeaderImage } from '@/lib/steam-cdn'
 
 // Reuse the shared wire type so we don't drift from the API shape. The
 // grid previously redeclared a subset inline, which silently allowed the
@@ -26,10 +27,7 @@ import { decodeHtmlEntities } from '@/lib/utils'
 type Game = CommonGame
 
 function resolveHeaderImage(game: Game): string {
-  return (
-    game.headerImageUrl ||
-    `https://cdn.akamai.steamstatic.com/steam/apps/${game.steamAppId}/header.jpg`
-  )
+  return resolveSteamHeaderImage(game.steamAppId, game.headerImageUrl)
 }
 
 export interface GameFilters {

--- a/packages/frontend/src/components/group-sidebar.tsx
+++ b/packages/frontend/src/components/group-sidebar.tsx
@@ -20,6 +20,7 @@ import { InviteLink } from '@/components/invite-link'
 import { GroupStats } from '@/components/group-stats'
 import { GameRecommendations } from '@/components/game-recommendations'
 import { CronAutocomplete } from '@/components/cron-autocomplete'
+import { getSteamHeaderImageUrl } from '@/lib/steam-cdn'
 import { useSubscriptionStore } from '@/stores/subscription.store'
 
 interface Member {
@@ -115,7 +116,7 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
           : 'flex items-center gap-3 group/history'
         }>
           <img
-            src={`https://cdn.akamai.steamstatic.com/steam/apps/${session.winningGameAppId}/header.jpg`}
+            src={getSteamHeaderImageUrl(session.winningGameAppId)}
             alt={session.winningGameName}
             className="w-16 h-[34px] rounded object-cover shrink-0"
             loading="lazy"

--- a/packages/frontend/src/components/group-stats.tsx
+++ b/packages/frontend/src/components/group-stats.tsx
@@ -6,6 +6,7 @@ import { Badge } from '@/components/ui/badge'
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { api } from '@/lib/api'
+import { getSteamHeaderImageUrl } from '@/lib/steam-cdn'
 
 interface GroupStatsData {
   totalSessions: number
@@ -75,7 +76,7 @@ export function GroupStats({ groupId, compact = false }: GroupStatsProps) {
                   {index + 1}.
                 </span>
                 <img
-                  src={`https://cdn.akamai.steamstatic.com/steam/apps/${game.steamAppId}/header.jpg`}
+                  src={getSteamHeaderImageUrl(game.steamAppId)}
                   alt={game.gameName}
                   className="w-12 h-[22px] rounded object-cover shrink-0"
                   loading="lazy"
@@ -139,7 +140,7 @@ export function GroupStats({ groupId, compact = false }: GroupStatsProps) {
             {stats.recentWinners.map((winner, index) => (
               <div key={`${winner.steamAppId}-${index}`} className="flex items-center gap-2.5">
                 <img
-                  src={`https://cdn.akamai.steamstatic.com/steam/apps/${winner.steamAppId}/header.jpg`}
+                  src={getSteamHeaderImageUrl(winner.steamAppId)}
                   alt={winner.gameName}
                   className="w-12 h-[22px] rounded object-cover shrink-0"
                   loading="lazy"

--- a/packages/frontend/src/components/tonight-pick-hero.tsx
+++ b/packages/frontend/src/components/tonight-pick-hero.tsx
@@ -8,17 +8,13 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { decodeHtmlEntities } from '@/lib/utils'
+import { resolveSteamHeaderImage } from '@/lib/steam-cdn'
+import { scoreGames, type PickReason, type VoteHistoryEntry } from '@/lib/game-scoring'
 
 interface Member {
   id: string
   displayName: string
   avatarUrl: string
-}
-
-interface VoteHistoryEntry {
-  winningGameAppId: number
-  winningGameName: string
-  closedAt: string
 }
 
 interface TonightPickHeroProps {
@@ -39,82 +35,11 @@ interface TonightPickHeroProps {
   onJoinActiveVote?: () => void
 }
 
-type PickReason = 'neverPlayed' | 'topRated' | 'mostOwned' | 'comeback'
-
-interface ScoredPick {
-  game: CommonGame
-  score: number
-  reason: PickReason
-}
-
-/**
- * Client-side scorer for "Tonight's Pick". Deliberately simple and
- * deterministic so it works on the free tier without any backend call —
- * the premium recommendations endpoint remains the richer alternative
- * surfaced in the sidebar. Signals used:
- *   - ownership ratio (how many members own it)
- *   - metacritic (quality bump, generous default when missing)
- *   - log-scaled recommendations (popularity)
- *   - novelty penalty if the game won recently (so we don't suggest
- *     the same thing two nights in a row)
- *   - small bonus for MP/coop since this is a group product
- */
-function scoreGames(games: CommonGame[], history: VoteHistoryEntry[]): ScoredPick | null {
-  if (games.length === 0) return null
-
-  // Build a quick lookup of games won in the last ~14 days so we can
-  // penalize the "same game every night" pattern.
-  const now = Date.now()
-  const recentWinPenalty = new Map<number, number>()
-  const everPlayedIds = new Set<number>()
-  for (const h of history) {
-    everPlayedIds.add(h.winningGameAppId)
-    const ageDays = (now - new Date(h.closedAt).getTime()) / 86_400_000
-    if (ageDays <= 14) {
-      // Linear decay from 0.8 (just won) to 0 (14 days ago).
-      recentWinPenalty.set(h.winningGameAppId, Math.max(0, 0.8 * (1 - ageDays / 14)))
-    }
-  }
-
-  let best: ScoredPick | null = null
-  for (const game of games) {
-    const ownership = game.totalMembers > 0 ? game.ownerCount / game.totalMembers : 0
-    const mc = game.metacriticScore ?? 65 // generous default for unknowns
-    const reco = game.recommendationsTotal ?? 0
-    const mpBonus = (game.isMultiplayer || game.isCoop) ? 0.25 : 0
-
-    const score =
-      1.5 * ownership +
-      0.8 * (mc / 100) +
-      0.7 * (Math.log1p(reco) / Math.log(100_000)) +
-      mpBonus -
-      (recentWinPenalty.get(game.steamAppId) ?? 0)
-
-    if (!best || score > best.score) {
-      let reason: PickReason = 'mostOwned'
-      if (!everPlayedIds.has(game.steamAppId)) reason = 'neverPlayed'
-      else if (mc >= 85) reason = 'topRated'
-      else if ((recentWinPenalty.get(game.steamAppId) ?? 0) === 0 && everPlayedIds.has(game.steamAppId)) reason = 'comeback'
-
-      best = { game, score, reason }
-    }
-  }
-
-  return best
-}
-
 const REASON_META: Record<PickReason, { key: string; icon: typeof Sparkles }> = {
   neverPlayed: { key: 'tonightPick.reasonNever', icon: Sparkles },
   topRated: { key: 'tonightPick.reasonTopRated', icon: Star },
   mostOwned: { key: 'tonightPick.reasonMostOwned', icon: Users },
   comeback: { key: 'tonightPick.reasonComeback', icon: Trophy },
-}
-
-function resolveHeaderImage(game: CommonGame): string {
-  return (
-    game.headerImageUrl ||
-    `https://cdn.akamai.steamstatic.com/steam/apps/${game.steamAppId}/header.jpg`
-  )
 }
 
 export function TonightPickHero({
@@ -245,7 +170,7 @@ export function TonightPickHero({
           absolute so the content below stays readable on any screen size. */}
       <div className="absolute inset-0">
         <img
-          src={resolveHeaderImage(game)}
+          src={resolveSteamHeaderImage(game.steamAppId, game.headerImageUrl)}
           alt=""
           aria-hidden="true"
           className="w-full h-full object-cover opacity-40 group-hover:opacity-50 transition-opacity duration-500 group-hover:scale-[1.02] motion-safe:transition-transform"
@@ -260,7 +185,7 @@ export function TonightPickHero({
             actual Steam art sharply (background is too faded to count). */}
         <div className="shrink-0 hidden sm:block">
           <img
-            src={resolveHeaderImage(game)}
+            src={resolveSteamHeaderImage(game.steamAppId, game.headerImageUrl)}
             alt={game.gameName}
             className="w-[200px] aspect-[460/215] rounded-lg object-cover ring-1 ring-white/10 shadow-lg"
             loading="eager"

--- a/packages/frontend/src/lib/game-scoring.ts
+++ b/packages/frontend/src/lib/game-scoring.ts
@@ -1,0 +1,66 @@
+import type { CommonGame } from '@wawptn/types'
+
+export type PickReason = 'neverPlayed' | 'topRated' | 'mostOwned' | 'comeback'
+
+export interface ScoredPick {
+  game: CommonGame
+  score: number
+  reason: PickReason
+}
+
+export interface VoteHistoryEntry {
+  winningGameAppId: number
+  winningGameName: string
+  closedAt: string
+}
+
+/**
+ * Client-side scorer for "Tonight's Pick". Deterministic so it works on the
+ * free tier without any backend call — the premium recommendations endpoint
+ * remains the richer alternative surfaced in the sidebar. Signals used:
+ *   - ownership ratio (how many members own it)
+ *   - metacritic (quality bump, generous default when missing)
+ *   - log-scaled recommendations (popularity)
+ *   - novelty penalty if the game won recently
+ *   - small bonus for MP/coop since this is a group product
+ */
+export function scoreGames(games: CommonGame[], history: VoteHistoryEntry[]): ScoredPick | null {
+  if (games.length === 0) return null
+
+  const now = Date.now()
+  const recentWinPenalty = new Map<number, number>()
+  const everPlayedIds = new Set<number>()
+  for (const h of history) {
+    everPlayedIds.add(h.winningGameAppId)
+    const ageDays = (now - new Date(h.closedAt).getTime()) / 86_400_000
+    if (ageDays <= 14) {
+      recentWinPenalty.set(h.winningGameAppId, Math.max(0, 0.8 * (1 - ageDays / 14)))
+    }
+  }
+
+  let best: ScoredPick | null = null
+  for (const game of games) {
+    const ownership = game.totalMembers > 0 ? game.ownerCount / game.totalMembers : 0
+    const mc = game.metacriticScore ?? 65
+    const reco = game.recommendationsTotal ?? 0
+    const mpBonus = (game.isMultiplayer || game.isCoop) ? 0.25 : 0
+
+    const score =
+      1.5 * ownership +
+      0.8 * (mc / 100) +
+      0.7 * (Math.log1p(reco) / Math.log(100_000)) +
+      mpBonus -
+      (recentWinPenalty.get(game.steamAppId) ?? 0)
+
+    if (!best || score > best.score) {
+      let reason: PickReason = 'mostOwned'
+      if (!everPlayedIds.has(game.steamAppId)) reason = 'neverPlayed'
+      else if (mc >= 85) reason = 'topRated'
+      else if ((recentWinPenalty.get(game.steamAppId) ?? 0) === 0 && everPlayedIds.has(game.steamAppId)) reason = 'comeback'
+
+      best = { game, score, reason }
+    }
+  }
+
+  return best
+}

--- a/packages/frontend/src/lib/steam-cdn.ts
+++ b/packages/frontend/src/lib/steam-cdn.ts
@@ -1,0 +1,12 @@
+const STEAM_CDN_BASE = 'https://cdn.akamai.steamstatic.com/steam/apps'
+
+export function getSteamHeaderImageUrl(appId: number): string {
+  return `${STEAM_CDN_BASE}/${appId}/header.jpg`
+}
+
+export function resolveSteamHeaderImage(
+  appId: number,
+  override: string | null | undefined
+): string {
+  return override || getSteamHeaderImageUrl(appId)
+}


### PR DESCRIPTION
Backend:
- Extract listGroupsForUser() service from group.routes.ts; route is now
  a one-liner (SoC, DIP).
- Extract LibrarySyncCoordinator with pluggable providers; remove
  hard-coded Steam/Epic/GOG branches from POST /:id/sync (SoC, OCP).
- Add requirePremiumFeature() middleware factory; replace inline tier
  checks for auto-vote and recommendations endpoints (OCP).
- Apply requireGroupMembership middleware to all routes that previously
  re-queried group_members; close/delete vote handlers now read role
  from req.membership (DRY, SoC).
- Add lib/collections.ts (indexBy, groupBy) and lib/pagination.ts
  (applyTierLimits) for reusable composition (DRY).
- Centralize tier-limit error payloads in TIER_ERRORS (DRY).
- Use existing getHeaderImageUrl() helper in close-session and
  group.routes; drop one more hard-coded Steam CDN URL (DRY).
- Document voting_session_participants junction-table fallback as
  transitional with explicit removal criteria (LSP).

Discord:
- Wrap channel.send / messages.fetch / message.edit behind a
  channel-adapter.ts so the handlers don't carry unsafe Discord.js
  type casts (SoC).
- Move BotHandlerError to handlers-error.ts to break a cycle between
  handlers.ts and the new adapter.

Frontend:
- Add lib/steam-cdn.ts (getSteamHeaderImageUrl, resolveSteamHeaderImage);
  replace 5 hard-coded Steam CDN URLs across game-grid, group-sidebar,
  group-stats, tonight-pick-hero (DRY).
- Move scoreGames() to lib/game-scoring.ts so the algorithm is
  unit-testable independently of the React component (SoC).