### PR TITLE
fix(discord): stop spamming generic error on @mention failures

### DIFF
--- a/packages/discord/src/index.ts
+++ b/packages/discord/src/index.ts
@@ -1,6 +1,6 @@
 import { Client, GatewayIntentBits, Events, REST, Routes, type Interaction, type Message } from 'discord.js'
 import { validateEnv, env } from './env.js'
-import { backendApi } from './lib/api.js'
+import { backendApi, BackendApiError } from './lib/api.js'
 import { startHttpApi } from './http/server.js'
 import { startScheduler, notifyBackOnline } from './scheduler.js'
 import { getTodayPersona, getDefaultPersona, getPersonaById, type Persona } from './personas.js'
@@ -249,20 +249,28 @@ client.on(Events.MessageCreate, async (message: Message) => {
 
     await message.reply(response.reply)
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : 'Erreur inconnue'
-
-    // Rate limited
-    if (errorMessage.includes('trop de questions') || errorMessage.includes('rate')) {
-      await message.reply('Doucement ! Laisse-moi respirer deux secondes. Réessaie dans quelques minutes.')
+    // Rate limit is the only error worth surfacing to the user — everything
+    // else (LLM disabled, premium gate, LLM provider 5xx, transient bugs)
+    // is either a server-side problem or a configuration the user can't
+    // act on from the channel. For those, stay silent instead of spamming
+    // a cryptic "j'ai perdu le fil" reply on every @mention.
+    if (error instanceof BackendApiError) {
+      if (error.status === 429 || error.code === 'rate_limited') {
+        await message.reply('Doucement ! Laisse-moi respirer deux secondes. Réessaie dans quelques minutes.')
+        return
+      }
+      // Known silent cases: 501 not_configured, 403 premium_required,
+      // 503 llm_error, 4xx validation. Log at info so ops can still see
+      // what's happening without the user seeing an error.
+      console.warn('[chat] suppressed error', {
+        status: error.status,
+        code: error.code,
+        message: error.message,
+      })
       return
     }
 
-    // LLM not configured
-    if (errorMessage.includes('not_configured') || errorMessage.includes('not enabled')) {
-      return // Silently ignore if LLM is not set up
-    }
-
-    await message.reply('Oups, j\'ai perdu le fil. Réessaie dans un instant !')
+    // Unexpected (network / Discord-side) error — log loudly, stay silent.
     console.error('[chat] Error handling message:', error)
   }
 })

--- a/packages/discord/src/lib/api.ts
+++ b/packages/discord/src/lib/api.ts
@@ -6,6 +6,23 @@ interface ApiOptions {
   discordUserId?: string
 }
 
+/**
+ * Error thrown by `backendApi` for non-2xx responses. Callers (notably the
+ * `@mention` chat handler) need to distinguish between "LLM unavailable",
+ * "premium required", "rate limit", etc. to pick the right user-facing
+ * response instead of collapsing every failure into a generic message.
+ */
+export class BackendApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly code: string | undefined,
+    message: string,
+  ) {
+    super(message)
+    this.name = 'BackendApiError'
+  }
+}
+
 export async function backendApi<T>(path: string, options: ApiOptions = {}): Promise<T> {
   const { method = 'GET', body, discordUserId } = options
 
@@ -25,8 +42,12 @@ export async function backendApi<T>(path: string, options: ApiOptions = {}): Pro
   })
 
   if (!res.ok) {
-    const error = await res.json().catch(() => ({ message: res.statusText }))
-    throw new Error((error as { message?: string }).message || `API error ${res.status}`)
+    const payload = (await res.json().catch(() => ({}))) as { error?: string; message?: string }
+    throw new BackendApiError(
+      res.status,
+      payload.error,
+      payload.message || res.statusText || `API error ${res.status}`,
+    )
   }
 
   return res.json() as Promise<T>


### PR DESCRIPTION
## Summary

The Discord bot replied with `"Oups, j'ai perdu le fil. Réessaie dans un instant !"` to every `@mention`, even when the backend chat endpoint returned an expected error (premium gate on linked channels, transient LLM provider error, validation issue). The bot looked perpetually broken because the `catch` block flattened every backend failure into that single fallback message.

- Added `BackendApiError` in `packages/discord/src/lib/api.ts` carrying `status` and `code` so callers can branch on the actual failure instead of grepping the message string.
- Rewrote the `@mention` `catch` block in `packages/discord/src/index.ts`: rate-limit hits still get the friendly "Doucement !" reply; every other backend failure is logged and silently skipped instead of producing a confusing user-facing error.
- Other `backendApi` callers continue to work unchanged because `BackendApiError extends Error`.

## Test plan

- [ ] `npm run build:types && npm run -w packages/discord build && npm run -w packages/backend build` (passes locally)
- [ ] Manually @mention the bot in a channel bound to a non-premium group — bot stays silent (no "Oups…" spam) and a `[chat] suppressed error` log line appears
- [ ] Manually @mention the bot in a channel bound to a premium group — bot replies normally via the LLM
- [ ] Trigger the per-user 5/5min rate limit — bot still replies with "Doucement ! Laisse-moi respirer…"