### PR TITLE
Fix dialog centering and remove redundant slide animations

### DIFF
--- a/packages/frontend/src/components/ui/dialog.tsx
+++ b/packages/frontend/src/components/ui/dialog.tsx
@@ -39,7 +39,7 @@ function DialogContent({
         ref={ref}
         data-slot="dialog-content"
         className={cn(
-          'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border border-border bg-card p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+          'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-border bg-card p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg',
           className
         )}
         {...props}


### PR DESCRIPTION
## Summary
Updated the dialog component's positioning and animation classes to use more explicit Tailwind CSS values and remove redundant slide-out/slide-in animations that were conflicting with the fade and zoom animations.

## Key Changes
- Replaced `-translate-x-1/2 -translate-y-1/2` with `translate-x-[-50%] translate-y-[-50%]` for more explicit positioning
- Changed `left-1/2 top-1/2` to `left-[50%] top-[50%]` for consistency with the new translate syntax
- Removed redundant slide animations:
  - `data-[state=closed]:slide-out-to-left-1/2`
  - `data-[state=closed]:slide-out-to-top-[48%]`
  - `data-[state=open]:slide-in-from-left-1/2`
  - `data-[state=open]:slide-in-from-top-[48%]`

## Implementation Details
The slide animations were conflicting with the existing fade and zoom animations, causing unnecessary animation complexity. By removing them and using explicit percentage-based transforms, the dialog now has a cleaner animation behavior (fade + zoom only) while maintaining proper centering on the screen.

https://claude.ai/code/session_01UYDsKdcKXQp1fZatbL69Ga