### PR TITLE
Add email integration testing UI to admin panel

### DIFF
--- a/packages/backend/src/domain/admin-audit-log.ts
+++ b/packages/backend/src/domain/admin-audit-log.ts
@@ -26,6 +26,7 @@ export type AdminAuditAction =
   | 'persona.toggle'
   | 'bot_settings.update'
   | 'games.dedupe'
+  | 'email.test'
 
 interface RecordAdminActionInput {
   /** Express request, used to extract the actor id and forensic context. */

--- a/packages/backend/src/presentation/routes/admin.routes.ts
+++ b/packages/backend/src/presentation/routes/admin.routes.ts
@@ -2,10 +2,12 @@ import { Router, type Request, type Response } from 'express'
 import { z } from 'zod'
 import { db } from '../../infrastructure/database/connection.js'
 import { authLogger } from '../../infrastructure/logger/logger.js'
+import { env } from '../../config/env.js'
 import { invalidatePremiumCache } from '../../domain/subscription-service.js'
 import { recordAdminAction } from '../../domain/admin-audit-log.js'
 import { invalidateAllUserSessions } from '../../domain/auth-service.js'
 import { notifyPremiumChange } from '../../infrastructure/notifications/premium-notifications.js'
+import { sendEmail } from '../../infrastructure/email/email-service.js'
 import { getHealth as getSteamHealth } from '../../infrastructure/steam/steam-client.js'
 import { getHealth as getEpicHealth } from '../../infrastructure/epic/epic-client.js'
 import { getHealth as getGogHealth } from '../../infrastructure/gog/gog-client.js'
@@ -20,6 +22,12 @@ const ToggleAdminSchema = z.object({
 
 const TogglePremiumSchema = z.object({
   isPremium: z.boolean(),
+})
+
+const TestEmailSchema = z.object({
+  to: z.string().trim().email("Adresse email invalide").max(254),
+  subject: z.string().trim().min(1, 'Sujet requis').max(200).optional(),
+  message: z.string().trim().min(1, 'Message requis').max(2000).optional(),
 })
 
 const CreatePersonaSchema = z.object({
@@ -574,5 +582,75 @@ router.post('/games/dedupe', async (req: Request, res: Response) => {
     res.status(500).json({ error: 'internal', message: 'Failed to run game dedupe pass' })
   }
 })
+
+// ─── Email integration test ──────────────────────────────────────────────────
+// Lets an admin verify the Resend integration end-to-end (config + delivery)
+// without having to trigger a real transactional flow. Useful after rotating
+// RESEND_API_KEY or switching EMAIL_FROM domain.
+
+const PLACEHOLDER_EMAIL_SUFFIX = '@steam.wawptn.app'
+
+router.get('/email/status', (_req: Request, res: Response) => {
+  res.json({
+    configured: Boolean(env.RESEND_API_KEY),
+    from: env.EMAIL_FROM,
+  })
+})
+
+router.post('/email/test', validateBody(TestEmailSchema), async (req: Request, res: Response) => {
+  const { to, subject, message } = req.body as z.infer<typeof TestEmailSchema>
+
+  if (!env.RESEND_API_KEY) {
+    res.status(503).json({
+      error: 'email_not_configured',
+      message: "RESEND_API_KEY n'est pas configuré — aucun email ne peut être envoyé",
+    })
+    return
+  }
+
+  if (to.toLowerCase().endsWith(PLACEHOLDER_EMAIL_SUFFIX)) {
+    res.status(400).json({
+      error: 'placeholder_recipient',
+      message: 'Les adresses Steam placeholder ne reçoivent pas d\'email',
+    })
+    return
+  }
+
+  const finalSubject = subject ?? 'WAWPTN — Test d\'intégration email'
+  const finalMessage = message ?? 'Ceci est un email de test envoyé depuis le panneau d\'administration WAWPTN.'
+
+  const delivered = await sendEmail({
+    to,
+    subject: finalSubject,
+    text: finalMessage,
+    html: `<p>${escapeHtml(finalMessage)}</p><hr /><p style="color:#888;font-size:12px">WAWPTN — email de test administrateur</p>`,
+  })
+
+  await recordAdminAction({
+    req,
+    action: 'email.test',
+    metadata: { to, subject: finalSubject, delivered },
+  })
+
+  if (!delivered) {
+    res.status(502).json({
+      error: 'email_delivery_failed',
+      message: 'Resend a rejeté l\'email — vérifiez la clé API et le domaine expéditeur',
+    })
+    return
+  }
+
+  authLogger.info({ userId: req.userId, to }, 'admin sent test email')
+  res.json({ ok: true, to, subject: finalSubject })
+})
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
 
 export { router as adminRoutes }

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -301,6 +301,15 @@ export const api = {
       body: JSON.stringify({ isPremium }),
     }),
 
+  // Email integration testing — admins only
+  getAdminEmailStatus: () =>
+    request<{ configured: boolean; from: string }>('/admin/email/status'),
+  sendAdminTestEmail: (input: { to: string; subject?: string; message?: string }) =>
+    request<{ ok: true; to: string; subject: string }>('/admin/email/test', {
+      method: 'POST',
+      body: JSON.stringify(input),
+    }),
+
   // Subscription
   getSubscription: () => request<{ tier: 'free' | 'premium'; status: 'active' | 'past_due' | 'canceled' | 'inactive'; currentPeriodEnd: string | null }>('/subscription/me'),
   createCheckout: () => request<{ url: string }>('/subscription/checkout', { method: 'POST' }),

--- a/packages/frontend/src/pages/AdminPage.tsx
+++ b/packages/frontend/src/pages/AdminPage.tsx
@@ -4,7 +4,7 @@ import {
   ArrowLeft, Bot, Users, BarChart3, Save, RefreshCw, ShieldCheck,
   ShieldOff, Theater, Plus, Pencil, Trash2, Lock, Search, X,
   Activity, Zap, Clock, Globe, Terminal, Megaphone, Send,
-  ChevronLeft, ChevronRight, Crown,
+  ChevronLeft, ChevronRight, Crown, Mail, CheckCircle2, AlertTriangle,
 } from 'lucide-react'
 import { toast } from 'sonner'
 import { useTranslation } from 'react-i18next'
@@ -118,11 +118,12 @@ const EMPTY_FORM: PersonaFormData = {
   embedColor: '#5865F2',
 }
 
-type AdminTab = 'overview' | 'bot' | 'personas' | 'users' | 'notifications'
+type AdminTab = 'overview' | 'bot' | 'personas' | 'users' | 'notifications' | 'email'
 
 const TABS: { id: AdminTab; label: string; icon: typeof BarChart3 }[] = [
   { id: 'overview', label: 'Vue d\'ensemble', icon: Activity },
   { id: 'notifications', label: 'Annonces', icon: Megaphone },
+  { id: 'email', label: 'Email', icon: Mail },
   { id: 'bot', label: 'Bot Discord', icon: Bot },
   { id: 'personas', label: 'Personas', icon: Theater },
   { id: 'users', label: 'Utilisateurs', icon: Users },
@@ -643,6 +644,18 @@ export function AdminPage() {
             </motion.div>
           )}
 
+          {activeTab === 'email' && (
+            <motion.div
+              key="email"
+              variants={tabContent}
+              initial="enter"
+              animate="center"
+              exit="exit"
+            >
+              <EmailTab />
+            </motion.div>
+          )}
+
           {activeTab === 'bot' && (
             <motion.div
               key="bot"
@@ -1003,6 +1016,221 @@ function NotificationsTab() {
           </Button>
         </CardContent>
       </Card>
+    </div>
+  )
+}
+
+/* ═══════════════════════════════════════════════════════
+   TAB: Email integration testing
+   ═══════════════════════════════════════════════════════ */
+
+interface EmailStatus {
+  configured: boolean
+  from: string
+}
+
+interface EmailTestResult {
+  ok: boolean
+  to: string
+  subject: string
+  at: string
+}
+
+function EmailTab() {
+  const [status, setStatus] = useState<EmailStatus | null>(null)
+  const [statusLoading, setStatusLoading] = useState(true)
+  const [to, setTo] = useState('')
+  const [subject, setSubject] = useState('')
+  const [message, setMessage] = useState('')
+  const [sending, setSending] = useState(false)
+  const [lastResult, setLastResult] = useState<EmailTestResult | null>(null)
+
+  const loadStatus = useCallback(async () => {
+    setStatusLoading(true)
+    try {
+      const s = await api.getAdminEmailStatus()
+      setStatus(s)
+    } catch {
+      toast.error('Impossible de récupérer la configuration email')
+    } finally {
+      setStatusLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadStatus()
+  }, [loadStatus])
+
+  const emailLooksValid = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(to.trim())
+
+  async function handleSend() {
+    if (!emailLooksValid) {
+      toast.error('Adresse email invalide')
+      return
+    }
+    setSending(true)
+    try {
+      const res = await api.sendAdminTestEmail({
+        to: to.trim(),
+        subject: subject.trim() || undefined,
+        message: message.trim() || undefined,
+      })
+      setLastResult({ ok: true, to: res.to, subject: res.subject, at: new Date().toISOString() })
+      toast.success(`Email de test envoyé à ${res.to}`)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Erreur lors de l\'envoi'
+      setLastResult({ ok: false, to: to.trim(), subject: subject.trim() || '(défaut)', at: new Date().toISOString() })
+      toast.error(msg)
+    } finally {
+      setSending(false)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Status card */}
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Mail className="w-4 h-4" />
+            État de l'intégration email
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {statusLoading ? (
+            <Skeleton className="h-12" />
+          ) : status ? (
+            <div className="space-y-2">
+              <div className="flex items-center gap-2 text-sm">
+                {status.configured ? (
+                  <>
+                    <CheckCircle2 className="w-4 h-4 text-success" />
+                    <span className="text-foreground">Resend configuré</span>
+                    <Badge variant="outline" className="ml-1 text-[10px] font-mono">
+                      RESEND_API_KEY
+                    </Badge>
+                  </>
+                ) : (
+                  <>
+                    <AlertTriangle className="w-4 h-4 text-ember" />
+                    <span className="text-foreground">Resend non configuré</span>
+                    <Badge variant="outline" className="ml-1 text-[10px] font-mono text-muted-foreground">
+                      RESEND_API_KEY manquante
+                    </Badge>
+                  </>
+                )}
+              </div>
+              <div className="text-xs font-mono text-muted-foreground">
+                Expéditeur : <span className="text-foreground">{status.from}</span>
+              </div>
+              {!status.configured && (
+                <p className="text-xs text-muted-foreground">
+                  Les appels à <code className="font-mono">sendEmail()</code> dégradent en no-op tant que la clé n'est pas définie.
+                  Les tests ci-dessous échoueront avec 503.
+                </p>
+              )}
+            </div>
+          ) : null}
+        </CardContent>
+      </Card>
+
+      {/* Test form */}
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Send className="w-4 h-4" />
+            Envoyer un email de test
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="space-y-1.5">
+            <label htmlFor="email-test-to" className="text-sm font-medium">
+              Destinataire
+            </label>
+            <Input
+              id="email-test-to"
+              type="email"
+              autoComplete="email"
+              value={to}
+              onChange={(e) => setTo(e.target.value)}
+              placeholder="admin@example.com"
+              maxLength={254}
+            />
+            {to && !emailLooksValid && (
+              <p className="text-xs text-destructive">Format d'adresse invalide</p>
+            )}
+          </div>
+          <div className="space-y-1.5">
+            <label htmlFor="email-test-subject" className="text-sm font-medium">
+              Sujet (optionnel)
+            </label>
+            <Input
+              id="email-test-subject"
+              value={subject}
+              onChange={(e) => setSubject(e.target.value)}
+              placeholder="WAWPTN — Test d'intégration email"
+              maxLength={200}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <label htmlFor="email-test-message" className="text-sm font-medium">
+              Message (optionnel)
+            </label>
+            <Textarea
+              id="email-test-message"
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              placeholder="Contenu de l'email de test…"
+              rows={4}
+              maxLength={2000}
+            />
+          </div>
+          <Button
+            onClick={handleSend}
+            disabled={!emailLooksValid || sending || (status !== null && !status.configured)}
+            className="w-full"
+          >
+            <Send className="w-4 h-4 mr-2" />
+            {sending ? 'Envoi…' : 'Envoyer'}
+          </Button>
+        </CardContent>
+      </Card>
+
+      {/* Last result */}
+      {lastResult && (
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="flex items-center gap-2 text-base">
+              {lastResult.ok ? (
+                <CheckCircle2 className="w-4 h-4 text-success" />
+              ) : (
+                <AlertTriangle className="w-4 h-4 text-destructive" />
+              )}
+              Dernière tentative
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-1 text-sm font-mono">
+            <div>
+              <span className="text-muted-foreground">Destinataire :</span>{' '}
+              <span className="text-foreground">{lastResult.to}</span>
+            </div>
+            <div>
+              <span className="text-muted-foreground">Sujet :</span>{' '}
+              <span className="text-foreground">{lastResult.subject}</span>
+            </div>
+            <div>
+              <span className="text-muted-foreground">Horodatage :</span>{' '}
+              <span className="text-foreground">{new Date(lastResult.at).toLocaleString('fr-FR')}</span>
+            </div>
+            <div>
+              <span className="text-muted-foreground">Statut :</span>{' '}
+              <span className={lastResult.ok ? 'text-success' : 'text-destructive'}>
+                {lastResult.ok ? 'Livré à Resend' : 'Échec'}
+              </span>
+            </div>
+          </CardContent>
+        </Card>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
Adds a new "Email" tab to the admin panel that allows administrators to test the Resend email integration end-to-end without triggering real transactional flows. This is useful for verifying configuration after rotating API keys or switching email domains.

## Key Changes
- **Frontend (AdminPage.tsx)**
  - Added new `email` tab to the admin panel navigation
  - Implemented `EmailTab` component with:
    - Email configuration status display (shows if Resend is configured and the sender address)
    - Test email form with recipient, subject, and message fields
    - Email validation (basic format check)
    - Last result card showing the outcome of the most recent test
  - Added new icons from lucide-react: `Mail`, `CheckCircle2`, `AlertTriangle`

- **Backend (admin.routes.ts)**
  - Added `GET /admin/email/status` endpoint that returns:
    - Whether `RESEND_API_KEY` is configured
    - The configured `EMAIL_FROM` address
  - Added `POST /admin/email/test` endpoint that:
    - Validates recipient email and optional subject/message via Zod schema
    - Rejects requests if Resend is not configured (503 error)
    - Blocks placeholder Steam email addresses from receiving test emails
    - Sends the test email with sensible defaults (subject and message)
    - Records the action in admin audit logs
    - Returns delivery status to the client
  - Includes HTML escaping utility for safe email content rendering

- **API Client (api.ts)**
  - Added `getAdminEmailStatus()` method
  - Added `sendAdminTestEmail()` method with typed input/output

## Implementation Details
- The test email form is disabled if Resend is not configured, preventing unnecessary failed requests
- Email validation uses a simple regex pattern (`/^[^\s@]+@[^\s@]+\.[^\s@]+$/`)
- Test emails include a footer identifying them as admin test emails
- The UI provides clear feedback on configuration status and test results
- Placeholder Steam email addresses (ending in `@steam.wawptn.app`) are rejected to prevent noise

https://claude.ai/code/session_01Th8kik6GbraJevKSFVyph7