### PR TITLE
fix(discord): announce persona rotation at 07:00 instead of midnight

### DIFF
--- a/packages/discord/src/personas.ts
+++ b/packages/discord/src/personas.ts
@@ -29,7 +29,7 @@ export interface Persona {
   weekendVibes: string[]
   /** Reply when someone @mentions the bot with an empty message */
   emptyMentionReply: string
-  /** Sent at midnight when persona rotation changes the active persona */
+  /** Sent at 07:00 local time to announce the day's active persona */
   introMessage: string
   /** Discord embed accent color */
   embedColor: number

--- a/packages/discord/src/scheduler.ts
+++ b/packages/discord/src/scheduler.ts
@@ -120,7 +120,7 @@ async function sendPersonaAnnouncement(client: Client): Promise<void> {
     }
 
     // Each linked channel announces *its own group's* persona. With 50
-    // groups this means 50 distinct intro messages at midnight — the bot
+    // groups this means 50 distinct intro messages each morning — the bot
     // no longer broadcasts a single global persona to every server.
     for (const channel of channels) {
       try {
@@ -416,19 +416,22 @@ function scheduleCrons(client: Client, settings: BotSettings): void {
     console.error('[scheduler] rebuildGuildCrons failed:', err)
   })
 
-  // Persona change announcement at midnight (global, not per-guild).
+  // Persona change announcement at 07:00 local time (global, not per-guild).
+  // The persona itself still rotates at midnight (date-based hash), but we
+  // wait until morning to announce it so the message lands when people are
+  // awake instead of waking them up or getting buried overnight.
   personaAnnounceTask?.stop()
   const timezone = settings.schedule_timezone || 'Europe/Paris'
   if (settings.announce_persona_change && settings.persona_rotation_enabled) {
     personaAnnounceTask = cron.schedule(
-      '0 0 * * *',
+      '0 7 * * *',
       () => {
-        console.log('[scheduler] Midnight persona announcement triggered')
+        console.log('[scheduler] 07:00 persona announcement triggered')
         void sendPersonaAnnouncement(client)
       },
       { timezone },
     )
-    console.log(`[scheduler] Persona announcement: 0 0 * * * (${timezone})`)
+    console.log(`[scheduler] Persona announcement: 0 7 * * * (${timezone})`)
   } else {
     personaAnnounceTask = null
     console.log('[scheduler] Persona announcement: disabled')


### PR DESCRIPTION
The daily persona announcement was firing at 00:00 local time, which
wakes nothing but notification badges and gets buried by the time
users read the channel in the morning. Move it to 07:00 so the
"persona du jour" message lands when people are actually around.

The persona itself still rotates at midnight (date-based hash), only
the announcement time shifts.

Refs #185