### PR TITLE
fix(discord): stop responding to @everyone, rebuild per-guild crons, validate close payload

### DIFF
--- a/packages/discord/src/http/handlers.ts
+++ b/packages/discord/src/http/handlers.ts
@@ -71,6 +71,15 @@ export async function handleSessionClosed(
     throw new BotHandlerError(400, 'Missing required fields')
   }
 
+  // `summary.tallies` is dereferenced below to rebuild the game list, so a
+  // malformed payload (e.g. summary missing, or tallies not an array) would
+  // crash the handler with a 500. The request type marks summary as required,
+  // but the HTTP boundary is the right place to defend against drift between
+  // the backend and the bot.
+  if (!summary || !Array.isArray(summary.tallies)) {
+    throw new BotHandlerError(400, 'Missing or invalid summary.tallies')
+  }
+
   // Re-materialize the game list from the tallies so the closed embed can
   // show every game row that was in the original message even if we don't
   // re-fetch the source game list.

--- a/packages/discord/src/index.ts
+++ b/packages/discord/src/index.ts
@@ -268,8 +268,21 @@ client.on(Events.MessageCreate, async (message: Message) => {
   // Ignore bot messages
   if (message.author.bot) return
 
-  // Only respond when the bot is @mentioned
-  if (!client.user || !message.mentions.has(client.user)) return
+  // Only respond on an explicit @mention of the bot. The discord.js default
+  // for `mentions.has()` also matches @everyone/@here, any role the bot
+  // happens to carry, and the replied-user on every reply to one of our
+  // own messages — which made the bot spam-reply to every @everyone
+  // announcement and every thread reply. Narrow the match to direct
+  // user-mentions only.
+  if (
+    !client.user ||
+    !message.mentions.has(client.user, {
+      ignoreEveryone: true,
+      ignoreRoles: true,
+      ignoreRepliedUser: true,
+    })
+  )
+    return
 
   // Channel cooldown
   const now = Date.now()

--- a/packages/discord/src/scheduler.ts
+++ b/packages/discord/src/scheduler.ts
@@ -486,7 +486,7 @@ export async function startScheduler(client: Client): Promise<void> {
   setInterval(async () => {
     try {
       const newSettings = await getBotSettings()
-      const changed =
+      const globalChanged =
         newSettings.friday_schedule !== currentSettings!.friday_schedule ||
         newSettings.wednesday_schedule !== currentSettings!.wednesday_schedule ||
         newSettings.schedule_timezone !== currentSettings!.schedule_timezone ||
@@ -496,9 +496,18 @@ export async function startScheduler(client: Client): Promise<void> {
 
       currentSettings = newSettings
 
-      if (changed) {
-        console.log('[scheduler] Settings changed, rescheduling crons')
+      if (globalChanged) {
+        console.log('[scheduler] Global settings changed, rescheduling crons')
         scheduleCrons(client, newSettings)
+      } else {
+        // Per-guild schedule overrides set via `/wawptn-config set` don't
+        // change any global field, so `globalChanged` stays false and the
+        // old path never rebuilt guild crons. Rebuild them every tick so
+        // per-guild edits take effect within the refresh interval instead
+        // of requiring a full bot restart.
+        rebuildGuildCrons(client, newSettings).catch((err) => {
+          console.error('[scheduler] Periodic rebuildGuildCrons failed:', err)
+        })
       }
     } catch (err) {
       console.error('[scheduler] Failed to refresh settings:', err)


### PR DESCRIPTION
Three bugs found in the Discord bot:

1. The chat handler used `message.mentions.has(client.user)` with defaults,
   which matches @everyone/@here, any role the bot carries, and the
   replied-user on every reply to a bot message. The bot therefore spammed
   a reply to every @everyone announcement and every thread reply. Pass
   `ignoreEveryone`, `ignoreRoles` and `ignoreRepliedUser` so only direct
   @mentions trigger a response.

2. `startScheduler`'s 5-minute refresh only rebuilt crons when a global
   setting changed. Per-guild schedule overrides set via
   `/wawptn-config set` don't touch any global field, so edits were
   silently ignored until the next bot restart. Rebuild guild crons on
   every refresh tick when globals are stable.

3. `handleSessionClosed` dereferenced `summary.tallies` without checking
   that `summary` was present, so a malformed backend payload crashed the
   handler with a 500 instead of a clean 400.