### PR TITLE
feat(frontend): mobile-first P0 — dvh viewport, iOS input zoom, in-app browser guard

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -73,7 +73,7 @@ function App() {
   if (loading) {
     return (
       <div
-        className="min-h-screen flex flex-col items-center justify-center gap-4"
+        className="min-h-dvh flex flex-col items-center justify-center gap-4"
         role="status"
         aria-busy="true"
         aria-live="polite"

--- a/packages/frontend/src/components/error-boundary.tsx
+++ b/packages/frontend/src/components/error-boundary.tsx
@@ -28,7 +28,7 @@ class ErrorBoundaryInner extends Component<Props, State> {
 
     if (this.state.hasError) {
       return (
-        <main id="main-content" role="alert" className="min-h-screen flex flex-col items-center justify-center px-4">
+        <main id="main-content" role="alert" className="min-h-dvh flex flex-col items-center justify-center px-4">
           <h1 className="text-2xl font-bold mb-2">{t('error.title', "Oups, quelque chose s'est mal passe")}</h1>
           <p className="text-muted-foreground mb-6">{t('error.description', 'Une erreur inattendue est survenue.')}</p>
           <Button type="button" onClick={() => { this.setState({ hasError: false }); window.location.href = '/' }}>

--- a/packages/frontend/src/components/notification-bell.tsx
+++ b/packages/frontend/src/components/notification-bell.tsx
@@ -128,7 +128,7 @@ export function NotificationBell() {
               transition={{ duration: 0.15 }}
               role="dialog"
               aria-label={t('notifications.title')}
-              className="absolute right-0 top-full mt-1 z-50 w-80 max-w-[calc(100vw-2rem)] max-h-[calc(100vh-5rem)] rounded-md border border-border bg-popover shadow-md overflow-hidden flex flex-col"
+              className="absolute right-0 top-full mt-1 z-50 w-80 max-w-[calc(100vw-2rem)] max-h-[calc(100dvh-5rem)] rounded-md border border-border bg-popover shadow-md overflow-hidden flex flex-col"
             >
               {/* Header */}
               <div className="flex items-center justify-between px-3 py-2 border-b border-border">

--- a/packages/frontend/src/i18n/locales/en.json
+++ b/packages/frontend/src/i18n/locales/en.json
@@ -327,7 +327,14 @@
     "memberCount_one": "{{count}} member",
     "memberCount_other": "{{count}} members",
     "lastPlayed": "Last game played:",
-    "popularGames": "Popular games in the group"
+    "popularGames": "Popular games in the group",
+    "inAppBrowserTitle": "Open this link in your browser",
+    "inAppBrowserBody": "Steam sign-in doesn't work inside in-app browsers (Instagram, Messenger, Discord…). Copy the link and open it in Safari or Chrome.",
+    "inAppBrowserIos": "Tap the “⋯” menu in the top-right, then “Open in Safari”.",
+    "inAppBrowserAndroid": "Tap the “⋮” menu in the top-right, then “Open in Chrome”.",
+    "copyLink": "Copy link",
+    "copyLinkSuccess": "Link copied! Paste it in your browser.",
+    "openAnyway": "Try anyway"
   },
   "invite": {
     "shareLink": "Share this link with your friends:",

--- a/packages/frontend/src/i18n/locales/fr.json
+++ b/packages/frontend/src/i18n/locales/fr.json
@@ -336,7 +336,14 @@
     "memberCount_one": "{{count}} membre",
     "memberCount_other": "{{count}} membres",
     "lastPlayed": "Dernier jeu joué :",
-    "popularGames": "Jeux populaires du groupe"
+    "popularGames": "Jeux populaires du groupe",
+    "inAppBrowserTitle": "Ouvre ce lien dans ton navigateur",
+    "inAppBrowserBody": "La connexion Steam ne fonctionne pas dans les navigateurs intégrés (Instagram, Messenger, Discord…). Copie le lien et ouvre-le dans Safari ou Chrome.",
+    "inAppBrowserIos": "Touche le menu « ⋯ » en haut à droite puis « Ouvrir dans Safari ».",
+    "inAppBrowserAndroid": "Touche le menu « ⋮ » en haut à droite puis « Ouvrir dans Chrome ».",
+    "copyLink": "Copier le lien",
+    "copyLinkSuccess": "Lien copié ! Colle-le dans ton navigateur.",
+    "openAnyway": "Essayer quand même"
   },
   "invite": {
     "shareLink": "Partage ce lien avec tes amis :",

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -125,7 +125,11 @@
     @apply text-foreground antialiased;
     font-family: var(--font-sans);
     background-color: var(--background);
+    /* `vh` first as a fallback for browsers that predate dynamic viewport
+       units; `dvh` wins on iOS Safari / Chrome Android where the URL bar
+       chrome otherwise chops the bottom of the page off. */
     min-height: 100vh;
+    min-height: 100dvh;
     padding-bottom: env(safe-area-inset-bottom);
     -webkit-tap-highlight-color: transparent;
   }
@@ -577,8 +581,11 @@
 
 /* ── Mobile touch improvements ── */
 
-/* Prevent iOS input zoom (inputs < 16px trigger zoom) */
-@media screen and (max-width: 640px) {
+/* Prevent iOS input zoom (inputs < 16px trigger zoom). Keyed on pointer
+   capability rather than viewport width so iPads, phablets in landscape
+   and Android tablets — all of which exhibit the zoom — are covered, not
+   just narrow phones. */
+@media (any-pointer: coarse) {
   input, select, textarea {
     font-size: 16px;
   }

--- a/packages/frontend/src/lib/in-app-browser.ts
+++ b/packages/frontend/src/lib/in-app-browser.ts
@@ -1,0 +1,44 @@
+/**
+ * In-app browser detection.
+ *
+ * Social apps (Instagram, Messenger, Discord, TikTok, X, LinkedIn, Line,
+ * WeChat) open links inside sandboxed webviews that reject the third-party
+ * cookie round-trip Steam's OpenID 2.0 flow depends on. Inviting someone
+ * via SMS works; inviting them via Instagram silently fails after the
+ * Steam login redirect.
+ *
+ * Detection is heuristic — user agents lie, webviews vary across OS
+ * versions. We err on the side of false positives: a noisy "open in
+ * Safari/Chrome" prompt for a fringe browser is much better than a silent
+ * broken login in the 95th-percentile case.
+ */
+const IN_APP_UA_PATTERNS: readonly RegExp[] = [
+  /FBAN|FBAV|FB_IAB|FBIOS/i,   // Facebook / Messenger
+  /Instagram/i,                  // Instagram
+  /Twitter|TwitterAndroid/i,     // X / Twitter
+  /Line\//i,                     // Line
+  /MicroMessenger/i,             // WeChat
+  /DiscordBot|Discord\/[0-9]/i,  // Discord in-app link preview
+  /LinkedInApp/i,                // LinkedIn
+  /TikTok|musical_ly|BytedanceWebview/i,
+  /Snapchat/i,
+  /KAKAOTALK/i,
+  /Pinterest/i,
+  /Reddit\//i,
+]
+
+export function isInAppBrowser(userAgent: string = navigator.userAgent): boolean {
+  return IN_APP_UA_PATTERNS.some((re) => re.test(userAgent))
+}
+
+export type MobileOS = 'ios' | 'android' | 'other'
+
+export function detectMobileOS(userAgent: string = navigator.userAgent): MobileOS {
+  if (/iPad|iPhone|iPod/.test(userAgent)) return 'ios'
+  // Modern iPads identify as Mac; fall back to touch capability check.
+  if (/Macintosh/.test(userAgent) && typeof navigator !== 'undefined' && navigator.maxTouchPoints > 1) {
+    return 'ios'
+  }
+  if (/Android/i.test(userAgent)) return 'android'
+  return 'other'
+}

--- a/packages/frontend/src/pages/AdminPage.tsx
+++ b/packages/frontend/src/pages/AdminPage.tsx
@@ -516,7 +516,7 @@ export function AdminPage() {
   if (!user?.isAdmin) return null
 
   return (
-    <div className="min-h-screen flex flex-col bg-background">
+    <div className="min-h-dvh flex flex-col bg-background">
       <AppHeader maxWidth="wide">
         <Button variant="ghost" size="icon" onClick={() => navigate('/')}>
           <ArrowLeft className="h-5 w-5" />

--- a/packages/frontend/src/pages/ComparePage.tsx
+++ b/packages/frontend/src/pages/ComparePage.tsx
@@ -64,7 +64,7 @@ export function ComparePage() {
 
   if (!a || !b || a === b) {
     return (
-      <div className="min-h-screen flex flex-col">
+      <div className="min-h-dvh flex flex-col">
         <AppHeader>
           <Button variant="ghost" size="icon" onClick={() => navigate(-1)}>
             <ArrowLeft className="h-5 w-5" />
@@ -85,7 +85,7 @@ export function ComparePage() {
 
   if (isLoading && !result) {
     return (
-      <div className="min-h-screen flex flex-col">
+      <div className="min-h-dvh flex flex-col">
         <AppHeader>
           <Button variant="ghost" size="icon" onClick={() => navigate(-1)}>
             <ArrowLeft className="h-5 w-5" />
@@ -110,7 +110,7 @@ export function ComparePage() {
 
   if (error || !result) {
     return (
-      <div className="min-h-screen flex flex-col">
+      <div className="min-h-dvh flex flex-col">
         <AppHeader>
           <Button variant="ghost" size="icon" onClick={() => navigate(-1)}>
             <ArrowLeft className="h-5 w-5" />
@@ -138,7 +138,7 @@ export function ComparePage() {
   const nameB = meIsB ? 'Vous' : result.b.displayName
 
   return (
-    <div className="min-h-screen flex flex-col">
+    <div className="min-h-dvh flex flex-col">
       <AppHeader>
         <Button variant="ghost" size="icon" onClick={() => navigate(-1)}>
           <ArrowLeft className="h-5 w-5" />

--- a/packages/frontend/src/pages/DialogTestPage.tsx
+++ b/packages/frontend/src/pages/DialogTestPage.tsx
@@ -19,7 +19,7 @@ export function DialogTestPage() {
   const [activeDialog, setActiveDialog] = useState<string | null>(null)
 
   return (
-    <div className="min-h-screen p-6 space-y-4">
+    <div className="min-h-dvh p-6 space-y-4">
       <h1 className="text-2xl font-bold">Dialog Test Page</h1>
       <p className="text-sm text-muted-foreground">
         Resize browser or use DevTools device toolbar (375px, 390px, 430px) to test mobile.

--- a/packages/frontend/src/pages/DiscordLinkPage.tsx
+++ b/packages/frontend/src/pages/DiscordLinkPage.tsx
@@ -41,7 +41,7 @@ export function DiscordLinkPage() {
   // No code in URL
   if (!code) {
     return (
-      <main id="main-content" className="min-h-screen flex flex-col items-center justify-center px-4">
+      <main id="main-content" className="min-h-dvh flex flex-col items-center justify-center px-4">
         <X className="w-12 h-12 text-destructive mb-4" aria-hidden="true" />
         <h1 className="text-2xl font-bold mb-2">{t('discordLink.invalidCode')}</h1>
         <p className="text-muted-foreground mb-6">{t('discordLink.noCode')}</p>
@@ -53,7 +53,7 @@ export function DiscordLinkPage() {
   // Not logged in — prompt to log in
   if (!user) {
     return (
-      <main id="main-content" className="min-h-screen flex flex-col items-center justify-center px-4">
+      <main id="main-content" className="min-h-dvh flex flex-col items-center justify-center px-4">
         <Gamepad2 className="w-12 h-12 text-primary mb-4" aria-hidden="true" />
         <h1 className="text-2xl font-bold mb-2">{t('discordLink.title')}</h1>
         <p className="text-muted-foreground mb-6">{t('discordLink.loginPrompt')}</p>
@@ -69,7 +69,7 @@ export function DiscordLinkPage() {
     return (
       <main
         id="main-content"
-        className="min-h-screen flex flex-col items-center justify-center"
+        className="min-h-dvh flex flex-col items-center justify-center"
         role="status"
         aria-busy="true"
         aria-live="polite"
@@ -83,7 +83,7 @@ export function DiscordLinkPage() {
   // Success
   if (discordUsername) {
     return (
-      <main id="main-content" className="min-h-screen flex flex-col items-center justify-center px-4">
+      <main id="main-content" className="min-h-dvh flex flex-col items-center justify-center px-4">
         <Check className="w-12 h-12 text-success mb-4" aria-hidden="true" />
         <h1 className="text-2xl font-bold mb-2">{t('discordLink.linked')}</h1>
         <p className="text-muted-foreground mb-6">
@@ -96,7 +96,7 @@ export function DiscordLinkPage() {
 
   // Error
   return (
-    <main id="main-content" className="min-h-screen flex flex-col items-center justify-center px-4" role="alert">
+    <main id="main-content" className="min-h-dvh flex flex-col items-center justify-center px-4" role="alert">
       <X className="w-12 h-12 text-destructive mb-4" aria-hidden="true" />
       <h1 className="text-2xl font-bold mb-2">{t('discordLink.failed')}</h1>
       <p className="text-muted-foreground mb-6">{error}</p>

--- a/packages/frontend/src/pages/GroupPage.tsx
+++ b/packages/frontend/src/pages/GroupPage.tsx
@@ -386,7 +386,7 @@ export function GroupPage() {
 
   if (!currentGroup) {
     return (
-      <div className="min-h-screen flex flex-col">
+      <div className="min-h-dvh flex flex-col">
         <AppHeader maxWidth="wide">
           <Skeleton className="h-5 w-5 rounded" />
         </AppHeader>
@@ -409,7 +409,7 @@ export function GroupPage() {
   }
 
   return (
-    <div className="min-h-screen flex flex-col">
+    <div className="min-h-dvh flex flex-col">
       <AppHeader maxWidth="wide">
         <div className="flex items-center gap-2 min-w-0 flex-1">
           <Button variant="ghost" size="icon" onClick={() => navigate('/')} aria-label={t('group.back')} className="shrink-0">

--- a/packages/frontend/src/pages/GroupsPage.tsx
+++ b/packages/frontend/src/pages/GroupsPage.tsx
@@ -211,7 +211,7 @@ export function GroupsPage() {
 
 
   return (
-    <div className="min-h-screen flex flex-col">
+    <div className="min-h-dvh flex flex-col">
       <AppHeader />
 
       <main

--- a/packages/frontend/src/pages/JoinPage.tsx
+++ b/packages/frontend/src/pages/JoinPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { Gamepad2, Loader2, Users, Trophy } from 'lucide-react'
+import { AlertTriangle, Copy, Gamepad2, Loader2, Trophy, Users } from 'lucide-react'
 import { toast } from 'sonner'
 import { useTranslation } from 'react-i18next'
 import { motion, type Variants } from 'framer-motion'
@@ -10,6 +10,7 @@ import { api } from '@/lib/api'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { useDocumentTitle } from '@/hooks/useDocumentTitle'
+import { detectMobileOS, isInAppBrowser } from '@/lib/in-app-browser'
 
 const fadeUp: Variants = {
   hidden: { opacity: 0, y: 16 },
@@ -34,6 +35,12 @@ export function JoinPage() {
   const [error, setError] = useState<string | null>(null)
   const [preview, setPreview] = useState<InvitePreview | null>(null)
   const [previewLoading, setPreviewLoading] = useState(true)
+  // Users who tap "Try anyway" after the warning fall through to the normal
+  // Steam button. Most of the time the login still fails in the webview,
+  // but we owe them the escape hatch rather than hard-locking the flow.
+  const [overrideInAppBrowser, setOverrideInAppBrowser] = useState(false)
+  const inAppBrowser = typeof navigator !== 'undefined' && isInAppBrowser()
+  const mobileOS = typeof navigator !== 'undefined' ? detectMobileOS() : 'other'
   const joining = !!user && !!token && !error
 
   // Fetch invite preview (public, no auth needed)
@@ -76,7 +83,7 @@ export function JoinPage() {
 
   if (!user) {
     return (
-      <div className="min-h-screen flex flex-col items-center justify-center px-4">
+      <div className="min-h-dvh flex flex-col items-center justify-center px-4">
         <motion.div
           className="flex flex-col items-center w-full max-w-md"
           variants={stagger}
@@ -186,11 +193,58 @@ export function JoinPage() {
             </motion.p>
           )}
 
-          <motion.div variants={fadeUp}>
-            <Button variant="steam" size="lg" asChild>
-              <a href={`/api/auth/steam/login?returnTo=/join/${token}`}>{t('login.signIn')}</a>
-            </Button>
-          </motion.div>
+          {inAppBrowser && !overrideInAppBrowser ? (
+            <motion.div variants={fadeUp} className="w-full">
+              <Card className="p-4 mb-4 border-amber-500/40 bg-amber-500/5">
+                <div className="flex items-start gap-3">
+                  <AlertTriangle className="w-5 h-5 text-amber-500 shrink-0 mt-0.5" aria-hidden="true" />
+                  <div className="min-w-0">
+                    <p className="font-semibold mb-1">{t('join.inAppBrowserTitle')}</p>
+                    <p className="text-sm text-muted-foreground mb-2">{t('join.inAppBrowserBody')}</p>
+                    <p className="text-sm text-muted-foreground">
+                      {mobileOS === 'ios'
+                        ? t('join.inAppBrowserIos')
+                        : mobileOS === 'android'
+                          ? t('join.inAppBrowserAndroid')
+                          : null}
+                    </p>
+                  </div>
+                </div>
+              </Card>
+              <div className="flex flex-col gap-2 w-full">
+                <Button
+                  size="lg"
+                  className="w-full"
+                  onClick={() => {
+                    const url = window.location.href
+                    // Clipboard API isn't available on every in-app webview.
+                    // When it isn't, fall back to a visible toast with the
+                    // URL so the user can long-press and copy manually.
+                    navigator.clipboard
+                      ?.writeText(url)
+                      .then(() => toast.success(t('join.copyLinkSuccess')))
+                      .catch(() => toast.info(url))
+                  }}
+                >
+                  <Copy className="w-4 h-4 mr-2" aria-hidden="true" />
+                  {t('join.copyLink')}
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setOverrideInAppBrowser(true)}
+                >
+                  {t('join.openAnyway')}
+                </Button>
+              </div>
+            </motion.div>
+          ) : (
+            <motion.div variants={fadeUp}>
+              <Button variant="steam" size="lg" asChild>
+                <a href={`/api/auth/steam/login?returnTo=/join/${token}`}>{t('login.signIn')}</a>
+              </Button>
+            </motion.div>
+          )}
         </motion.div>
       </div>
     )
@@ -198,7 +252,7 @@ export function JoinPage() {
 
   if (joining) {
     return (
-      <div className="min-h-screen flex flex-col items-center justify-center">
+      <div className="min-h-dvh flex flex-col items-center justify-center">
         <Loader2 className="w-8 h-8 animate-spin text-primary mb-4" />
         <p className="text-muted-foreground">{t('join.connecting')}</p>
       </div>
@@ -207,7 +261,7 @@ export function JoinPage() {
 
   if (error) {
     return (
-      <div className="min-h-screen flex flex-col items-center justify-center px-4">
+      <div className="min-h-dvh flex flex-col items-center justify-center px-4">
         <h1 className="text-2xl font-bold mb-2 text-destructive">{t('join.failed')}</h1>
         <p className="text-muted-foreground mb-6">{error}</p>
         <Button onClick={() => navigate('/')}>{t('join.goToGroups')}</Button>

--- a/packages/frontend/src/pages/LandingPage.tsx
+++ b/packages/frontend/src/pages/LandingPage.tsx
@@ -55,7 +55,7 @@ export function LandingPage() {
   useDocumentTitle(t('landing.headlineLine2'))
 
   return (
-    <div className="min-h-screen flex flex-col overflow-x-hidden">
+    <div className="min-h-dvh flex flex-col overflow-x-hidden">
       <main id="main-content">
       {/* ═══ HERO ═══ */}
       <section className="relative min-h-[100dvh] flex flex-col items-center justify-center px-4 py-24">

--- a/packages/frontend/src/pages/NotFoundPage.tsx
+++ b/packages/frontend/src/pages/NotFoundPage.tsx
@@ -10,7 +10,7 @@ export function NotFoundPage() {
   const navigate = useNavigate()
 
   return (
-    <main id="main-content" className="min-h-screen flex flex-col items-center justify-center px-4">
+    <main id="main-content" className="min-h-dvh flex flex-col items-center justify-center px-4">
       <SearchX className="w-12 h-12 text-muted-foreground mb-4" aria-hidden="true" />
       <h1 className="text-2xl font-bold mb-2">{t('notFound.title')}</h1>
       <p className="text-muted-foreground mb-6">{t('notFound.description')}</p>

--- a/packages/frontend/src/pages/ProfilePage.tsx
+++ b/packages/frontend/src/pages/ProfilePage.tsx
@@ -331,7 +331,7 @@ export function ProfilePage() {
   /* ── Loading skeleton ── */
   if (loading) {
     return (
-      <div className="min-h-screen flex flex-col">
+      <div className="min-h-dvh flex flex-col">
         <AppHeader>
           <Button variant="ghost" size="icon" onClick={() => navigate('/')}>
             <ArrowLeft className="h-5 w-5" />
@@ -362,7 +362,7 @@ export function ProfilePage() {
   const otherGames = profile.topGames?.slice(1)
 
   return (
-    <div className="min-h-screen flex flex-col">
+    <div className="min-h-dvh flex flex-col">
       <AppHeader>
         <Button variant="ghost" size="icon" onClick={() => navigate('/')}>
           <ArrowLeft className="h-5 w-5" />

--- a/packages/frontend/src/pages/SubscriptionPage.tsx
+++ b/packages/frontend/src/pages/SubscriptionPage.tsx
@@ -56,7 +56,7 @@ export function SubscriptionPage() {
   const isPremium = tier === 'premium' && (status === 'active' || status === 'canceled')
 
   return (
-    <div className="min-h-screen flex flex-col bg-background">
+    <div className="min-h-dvh flex flex-col bg-background">
       <AppHeader />
       <main id="main-content" className="max-w-2xl mx-auto px-4 py-8">
         <Button variant="ghost" size="sm" onClick={() => navigate(-1)} className="mb-4">

--- a/packages/frontend/src/pages/UserProfilePage.tsx
+++ b/packages/frontend/src/pages/UserProfilePage.tsx
@@ -57,7 +57,7 @@ export function UserProfilePage() {
 
   if (isLoading && !profile) {
     return (
-      <div className="min-h-screen flex flex-col">
+      <div className="min-h-dvh flex flex-col">
         <AppHeader>
           <Button variant="ghost" size="icon" onClick={() => navigate(-1)}>
             <ArrowLeft className="h-5 w-5" />
@@ -76,7 +76,7 @@ export function UserProfilePage() {
 
   if (error || !profile) {
     return (
-      <div className="min-h-screen flex flex-col">
+      <div className="min-h-dvh flex flex-col">
         <AppHeader>
           <Button variant="ghost" size="icon" onClick={() => navigate(-1)}>
             <ArrowLeft className="h-5 w-5" />
@@ -103,7 +103,7 @@ export function UserProfilePage() {
   const topCommon = profile.commonGamesWithViewer.slice(0, 3)
 
   return (
-    <div className="min-h-screen flex flex-col">
+    <div className="min-h-dvh flex flex-col">
       <AppHeader>
         <Button variant="ghost" size="icon" onClick={() => navigate(-1)}>
           <ArrowLeft className="h-5 w-5" />

--- a/packages/frontend/src/pages/VotePage.tsx
+++ b/packages/frontend/src/pages/VotePage.tsx
@@ -265,7 +265,7 @@ export function VotePage() {
   // No active session
   if (noSession) {
     return (
-      <div className="min-h-screen flex flex-col">
+      <div className="min-h-dvh flex flex-col">
         <AppHeader>
           <Button variant="ghost" size="icon" onClick={() => navigate(`/groups/${id}`)} aria-label={t('group.back')}>
             <ArrowLeft className="w-5 h-5" />
@@ -314,7 +314,7 @@ export function VotePage() {
     const isScheduledSession = scheduledDate && scheduledDate.getTime() > Date.now()
 
     return (
-      <main id="main-content" className="min-h-screen flex flex-col items-center justify-center px-3 sm:px-4 py-4">
+      <main id="main-content" className="min-h-dvh flex flex-col items-center justify-center px-3 sm:px-4 py-4">
         <Check className="w-16 h-16 text-success mb-4" aria-hidden="true" />
         <h1 className="text-2xl font-heading font-bold mb-2">{t('vote.submitted')}</h1>
 
@@ -393,7 +393,7 @@ export function VotePage() {
   // Non-participant view
   if (!isParticipant) {
     return (
-      <main id="main-content" className="min-h-screen flex flex-col items-center justify-center p-4">
+      <main id="main-content" className="min-h-dvh flex flex-col items-center justify-center p-4">
         <Vote className="w-16 h-16 text-muted-foreground mb-4" aria-hidden="true" />
         <h1 className="text-2xl font-heading font-bold mb-2">{t('vote.sessionInProgress')}</h1>
         <p className="text-muted-foreground mb-6">
@@ -411,7 +411,7 @@ export function VotePage() {
 
   // Game selection interface
   return (
-    <div className="min-h-screen flex flex-col">
+    <div className="min-h-dvh flex flex-col">
       <AppHeader>
         <Button variant="ghost" size="icon" onClick={() => navigate(`/groups/${id}`)} aria-label={t('group.back')}>
           <ArrowLeft className="w-5 h-5" />
@@ -640,7 +640,7 @@ function ResultScreen({
   // the only meaningful forward motion.
   if (!hasWinner) {
     return (
-      <main id="main-content" className="min-h-screen flex flex-col items-center justify-center p-4">
+      <main id="main-content" className="min-h-dvh flex flex-col items-center justify-center p-4">
         <motion.div
           initial={shouldReduceMotion ? false : { opacity: 0, y: 10 }}
           animate={{ opacity: 1, y: 0 }}
@@ -733,7 +733,7 @@ function ResultScreen({
     : t('vote.consensusPercent', { percent: displayPercent })
 
   return (
-    <main id="main-content" className="min-h-screen flex flex-col items-center justify-center p-4">
+    <main id="main-content" className="min-h-dvh flex flex-col items-center justify-center p-4">
       <AnimatePresence>
         <motion.div
           initial="hidden"


### PR DESCRIPTION
Addresses the three ship-blockers from the mobile-first design review (Maya, Théo, Sam, Nico personas).

## Changes

1. **`min-h-screen` → `min-h-dvh` codemod** across every page shell + error boundary + notification bell popover. `body` keeps a `100vh` fallback then overrides with `100dvh` in `index.css` so iOS Safari in standalone PWA mode stops cutting off the bottom under the URL-bar chrome.
2. **iOS input-zoom guard widened** from `max-width: 640px` to `(any-pointer: coarse)` so iPads and phablets in landscape (which also zoom on <16px inputs) are covered, not just narrow phones.
3. **In-app browser detection** in `src/lib/in-app-browser.ts` (Instagram / Messenger / Discord / TikTok / X / LinkedIn / Line / WeChat / Snapchat / Kakao / Pinterest / Reddit) wired into `JoinPage.tsx` as a warning Card with OS-specific instructions, Copy Link, and an "open anyway" escape hatch. Steam OpenID 2.0 cookie round-trip silently breaks in those sandboxed webviews — this was the #1 silent-failure entry point for new groups.

## Test plan
- [ ] Open an invite link in Instagram / Messenger / Discord — warning appears with OS-specific instructions.
- [ ] Tap Copy Link — toast confirms or falls back to raw URL toast if Clipboard API is unavailable.
- [ ] Tap "Try anyway" — original Steam button appears.
- [ ] Real Safari / Chrome — no warning, Steam button unchanged.
- [ ] iPhone Safari standalone PWA — page shells fill the viewport; URL-bar chrome no longer chops the bottom of Vote/Group/Groups pages.
- [ ] iPad portrait — focusing the Vote search input no longer triggers auto-zoom.

---
_Generated by [Claude Code](https://claude.ai/code/session_017SvC4F5y4jD9sZuoUfRG2j)_