### PR TITLE
refactor(frontend): tighten LandingPage hero question mark on narrow phones

### DIFF
--- a/packages/frontend/src/pages/LandingPage.tsx
+++ b/packages/frontend/src/pages/LandingPage.tsx
@@ -66,7 +66,12 @@ export function LandingPage() {
         {/* Giant "?" watermark — more subtle, more depth */}
         <div className="absolute inset-0 flex items-center justify-center pointer-events-none select-none overflow-hidden">
           <motion.span
-            className="landing-question-mark font-heading font-extrabold text-[50vw] sm:text-[38vw] lg:text-[30vw] leading-none"
+            // On narrow phones `text-[50vw]` rendered as a ~195px glyph that
+            // visually outweighed the headline + CTA behind it. `35vw` keeps
+            // the dramatic scale (~135px on a 390px viewport) without
+            // competing for primary focus; sm:/lg: breakpoints restore the
+            // original desktop sizing.
+            className="landing-question-mark font-heading font-extrabold text-[35vw] sm:text-[38vw] lg:text-[30vw] leading-none"
             initial={{ opacity: 0, scale: 0.85 }}
             animate={{
               opacity: 1,


### PR DESCRIPTION
Small follow-up polish from Maya's mobile-first review (#188-#190).

## Change
Hero "?" watermark on `LandingPage` drops from `text-[50vw]` → `text-[35vw]` on narrow phones only. At 390px viewport that's ~135px instead of ~195px — still dramatic, no longer visually outweighing the headline + CTA behind it. `sm:text-[38vw]` and `lg:text-[30vw]` breakpoints are unchanged, so the desktop hero is identical.

## What I chose **not** to ship
Maya's other LandingPage finding (grid density + accidental Info-button tap on `VotePage`) was in scope, but the current implementation already separates the image toggle button and the 44px Info button with 8px padding and a 12px gap — the risk is theoretical. A fix would mean redesigning the card footer (e.g. moving Info to a corner overlay), which is a UX decision rather than a tech-debt cleanup.

## Also parked
True P3 (Nico's scope cut — Profile/UserProfile collapse, Compare/Subscription scope cut, Join auto-route to active vote) still needs product input. Listed in the meeting minutes; not included here.

## Test plan
- [ ] iPhone 390-430px width: question mark no longer visually dominates the CTA.
- [ ] ≥640px: hero unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_017SvC4F5y4jD9sZuoUfRG2j)_