### PR TITLE
feat(join): auto-route to /vote when the group has an in-flight session

### DIFF
--- a/packages/backend/src/presentation/routes/group.routes.ts
+++ b/packages/backend/src/presentation/routes/group.routes.ts
@@ -389,13 +389,30 @@ router.post('/join', async (req: Request, res: Response) => {
     return
   }
 
+  // Look up an in-flight vote session so the frontend can route the user
+  // straight to the vote page instead of forcing a group-detail detour.
+  // A `scheduled_at` in the future still reports as open but shouldn't
+  // trigger the auto-route — the user would land on a vote page that
+  // isn't accepting ballots yet. Mirrors the `activeVoteSession` shape
+  // the frontend already uses on `GroupPage`.
+  const getActiveVoteSession = async () => {
+    const row = await db('voting_sessions')
+      .where({ group_id: group.id, status: 'open' })
+      .andWhere((b) => b.whereNull('scheduled_at').orWhere('scheduled_at', '<=', new Date()))
+      .select('id', 'scheduled_at')
+      .first()
+    if (!row) return null
+    return { id: row.id as string, scheduledAt: (row.scheduled_at as Date | null)?.toISOString() ?? null }
+  }
+
   // Check if already a member (before claiming an invite use)
   const existing = await db('group_members')
     .where({ group_id: group.id, user_id: userId })
     .first()
 
   if (existing) {
-    res.json({ id: group.id, name: group.name, alreadyMember: true })
+    const activeVoteSession = await getActiveVoteSession()
+    res.json({ id: group.id, name: group.name, alreadyMember: true, activeVoteSession })
     return
   }
 
@@ -481,7 +498,8 @@ router.post('/join', async (req: Request, res: Response) => {
   }
 
   logger.info({ userId, groupId: group.id }, 'user joined group')
-  res.json({ id: group.id, name: group.name, alreadyMember: false })
+  const activeVoteSession = await getActiveVoteSession()
+  res.json({ id: group.id, name: group.name, alreadyMember: false, activeVoteSession })
 })
 
 // Leave group (self) or kick member (owner only)

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -100,7 +100,16 @@ export const api = {
     method: 'PATCH',
     body: JSON.stringify({ name }),
   }),
-  joinGroup: (token: string) => request<{ id: string; name: string; alreadyMember: boolean }>('/groups/join', {
+  joinGroup: (token: string) => request<{
+    id: string
+    name: string
+    alreadyMember: boolean
+    // When a vote is in flight for this group the backend includes it so the
+    // caller can route the user straight to the ballot. `scheduledAt` is set
+    // for pre-scheduled sessions; we only auto-route when the session is
+    // actually accepting votes now.
+    activeVoteSession: { id: string; scheduledAt: string | null } | null
+  }>('/groups/join', {
     method: 'POST',
     body: JSON.stringify({ token }),
   }),

--- a/packages/frontend/src/pages/GroupsPage.tsx
+++ b/packages/frontend/src/pages/GroupsPage.tsx
@@ -176,7 +176,10 @@ export function GroupsPage() {
       setInviteToken('')
       setShowJoin(false)
       fetchGroups()
-      navigate(`/groups/${result.id}`)
+      // Mirror JoinPage: if a vote is already running in the target group,
+      // drop the user straight on the ballot instead of walking them
+      // through the group detail page first.
+      navigate(result.activeVoteSession ? `/groups/${result.id}/vote` : `/groups/${result.id}`)
       toast.success(t('joinGroup.success'))
       track('group.joined')
     } catch (err) {

--- a/packages/frontend/src/pages/JoinPage.tsx
+++ b/packages/frontend/src/pages/JoinPage.tsx
@@ -70,7 +70,16 @@ export function JoinPage() {
       (result) => {
         if (cancelled) return
         toast.success(t('joinGroup.success'))
-        navigate(`/groups/${result.id}`)
+        // If a vote is already in flight, skip the group-detail detour and
+        // drop the user straight on the ballot. The backend only returns
+        // `activeVoteSession` when `status='open'` AND the session is
+        // actually accepting votes now (scheduled_at null or in the past),
+        // so this won't land anyone on a not-yet-started vote.
+        if (result.activeVoteSession) {
+          navigate(`/groups/${result.id}/vote`)
+        } else {
+          navigate(`/groups/${result.id}`)
+        }
       },
       (err) => {
         if (cancelled) return

--- a/packages/frontend/src/stores/group.store.ts
+++ b/packages/frontend/src/stores/group.store.ts
@@ -18,7 +18,11 @@ interface GroupState {
   fetchGroup: (id: string) => Promise<void>
   createGroup: (input: { name: string }) => Promise<{ id: string; inviteToken: string }>
   renameGroup: (groupId: string, name: string) => Promise<void>
-  joinGroup: (token: string) => Promise<{ id: string; name: string }>
+  joinGroup: (token: string) => Promise<{
+    id: string
+    name: string
+    activeVoteSession: { id: string; scheduledAt: string | null } | null
+  }>
   leaveGroup: (groupId: string, userId: string) => Promise<void>
   deleteGroup: (groupId: string) => Promise<void>
 }
@@ -50,7 +54,7 @@ export const useGroupStore = create<GroupState>((set) => ({
   },
   joinGroup: async (token: string) => {
     const result = await api.joinGroup(token)
-    return { id: result.id, name: result.name }
+    return { id: result.id, name: result.name, activeVoteSession: result.activeVoteSession }
   },
   leaveGroup: async (groupId: string, userId: string) => {
     await api.leaveGroup(groupId, userId)


### PR DESCRIPTION
Closes Nico's P3 item from the mobile-first review (#188-#192). A user tapping an invite link during an active vote previously landed on `/groups/:id`, had to find the "Join active vote" CTA, and tap it — the vote was four screens deep from the SMS tap. Now the ballot is reached directly when a session is open and accepting votes.

## Changes

### Backend (`packages/backend/src/presentation/routes/group.routes.ts`)
`POST /api/groups/join` response gains an `activeVoteSession: { id, scheduledAt } | null` field, queried from `voting_sessions` where `status='open'` **and** `scheduled_at` is NULL or `<=` NOW.

The `scheduled_at <= NOW` predicate is important — scheduled-but-not-yet-started sessions report as `open` in the schema but shouldn't trigger the redirect, otherwise users would land on a vote page that isn't accepting ballots yet.

The field is returned on **both** the "already a member" early-return and the newly-joined response, so re-joiners get the same behaviour.

### Frontend
- `api.joinGroup` return type picks up the new field.
- `group.store#joinGroup` forwards it through.
- `JoinPage` (fresh invite link tap after Steam login) routes to `/groups/:id/vote` when present, `/groups/:id` otherwise.
- `GroupsPage`'s in-app "Join via token" dialog mirrors the same branching so the experience is consistent wherever the token came from.

## Not included
Nico's other two P3 items — `Profile` / `UserProfile` collapse and `Compare` / `Subscription` scope cut — need product scoping (viewer-mode vs. deletion, what exactly "first-session path" means) and are parked for your call.

## Test plan
- [ ] SMS an invite link while a vote is active → after Steam login, user lands on `/groups/:id/vote`, not the group-detail page.
- [ ] Same invite link, no active vote → user lands on `/groups/:id` as before.
- [ ] Scheduled-for-tomorrow vote → user lands on `/groups/:id`, not the pre-start vote page.
- [ ] Already-a-member invite tap (e.g. sharing the link back to an existing group): same auto-route behaviour.
- [ ] In-app `Join via token` dialog on `GroupsPage`: same behaviour as the external link.

---
_Generated by [Claude Code](https://claude.ai/code/session_017SvC4F5y4jD9sZuoUfRG2j)_