### PR TITLE
Fix vote query to explicitly select steam_app_id column

### DIFF
--- a/packages/backend/src/presentation/routes/discord.routes.ts
+++ b/packages/backend/src/presentation/routes/discord.routes.ts
@@ -758,12 +758,13 @@ router.post('/chat', async (req: Request, res: Response) => {
           const topVote = await db('votes')
             .where({ session_id: session.id, vote: true })
             .groupBy('steam_app_id')
+            .select('steam_app_id')
             .count('* as vote_count')
             .orderBy('vote_count', 'desc')
             .first()
 
           let winner: string | undefined
-          if (topVote) {
+          if (topVote?.steam_app_id != null) {
             const game = await db('user_games')
               .where({ steam_app_id: topVote.steam_app_id })
               .first()


### PR DESCRIPTION
## Summary
Fixed a bug in the Discord chat route's vote tallying logic where the `steam_app_id` column was not being explicitly selected in the database query, causing it to be undefined in the result object.

## Key Changes
- Added explicit `.select('steam_app_id')` to the votes query to ensure the column is included in the result
- Updated the null check from `if (topVote)` to `if (topVote?.steam_app_id != null)` to properly validate that the required field exists before using it

## Implementation Details
The query groups votes by `steam_app_id` and orders by vote count to find the winning game. However, without explicitly selecting `steam_app_id`, the column was missing from the query result even though it was used for grouping. This caused the subsequent game lookup to fail silently. The updated null check now properly validates the presence of the `steam_app_id` field before attempting to use it.

https://claude.ai/code/session_01TxLwfknDiCTaoHc7yeLmeH