### PR TITLE
Reduce max games per Discord message from 12 to 10

### DIFF
--- a/packages/discord/src/lib/embeds.ts
+++ b/packages/discord/src/lib/embeds.ts
@@ -8,11 +8,11 @@ export interface SessionGame {
   headerImageUrl: string | null
 }
 
-/** Discord hard limit: 5 action rows × 5 buttons per row. Two buttons per
- *  game (👍/👎) means 12 games per message max. We cap early and display a
- *  "vote on the web" hint when truncation happens so Discord voters know
- *  the overflow exists. */
-const MAX_GAMES_WITH_BUTTONS = 12
+/** Discord hard limit: 5 action rows × 5 buttons per row. We pack 2 games
+ *  (4 buttons) per row, so 5 rows × 2 games = 10 games max per message.
+ *  We cap early and display a "vote on the web" hint when truncation
+ *  happens so Discord voters know the overflow exists. */
+const MAX_GAMES_WITH_BUTTONS = 10
 
 function truncate(text: string, max: number): string {
   if (text.length <= max) return text


### PR DESCRIPTION
## Summary
Adjusted the maximum number of games that can be displayed per Discord message from 12 to 10 to better align with the actual button layout constraints.

## Changes
- Updated `MAX_GAMES_WITH_BUTTONS` constant from 12 to 10
- Revised the comment documentation to accurately reflect the button packing strategy: 2 games (4 buttons) per row across 5 action rows, resulting in a maximum of 10 games per message

## Details
The previous implementation claimed to support 12 games but the comment now clarifies that with 2 games per row (using 4 buttons for the 👍/👎 voting buttons), the Discord hard limit of 5 action rows × 5 buttons per row actually allows for only 10 games maximum. This change ensures the code behavior matches the documented constraints and prevents potential layout issues.

https://claude.ai/code/session_012UMEXVruXfsWynCr1L5PLK