### PR TITLE
chore(backend): make Knex connection pool min/max env-tunable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@ DB_USER=wawptn
 DB_PASSWORD=wawptn_secret
 DB_NAME=wawptn
 DATABASE_URL=postgresql://wawptn:wawptn_secret@localhost:5432/wawptn
+# Knex connection pool sizing (defaults: min=2, max=10)
+# DB_POOL_MIN=2
+# DB_POOL_MAX=10
 
 # ── Backend ──────────────────────────────────
 PORT=3000

--- a/packages/backend/knexfile.ts
+++ b/packages/backend/knexfile.ts
@@ -18,8 +18,8 @@ const config: { [key: string]: Knex.Config } = {
     client: 'pg',
     connection: process.env['DATABASE_URL'],
     pool: {
-      min: 2,
-      max: 10,
+      min: parseInt(process.env['DB_POOL_MIN'] || '2', 10),
+      max: parseInt(process.env['DB_POOL_MAX'] || '10', 10),
     },
     migrations: {
       directory: './migrations',

--- a/packages/backend/src/config/env.ts
+++ b/packages/backend/src/config/env.ts
@@ -7,6 +7,8 @@ export const env = {
   PORT: parseInt(process.env['PORT'] || '3000', 10),
   LOG_LEVEL: process.env['LOG_LEVEL'] || 'info',
   DATABASE_URL: process.env['DATABASE_URL'] || 'postgresql://wawptn:wawptn_secret@localhost:5432/wawptn',
+  DB_POOL_MIN: parseInt(process.env['DB_POOL_MIN'] || '2', 10),
+  DB_POOL_MAX: parseInt(process.env['DB_POOL_MAX'] || '10', 10),
   CORS_ORIGIN: process.env['CORS_ORIGIN'] || 'http://localhost:5173',
 
   APP_SECRET: process.env['APP_SECRET'] || 'dev-secret-change-in-production-min-32-chars',

--- a/packages/backend/src/infrastructure/database/connection.ts
+++ b/packages/backend/src/infrastructure/database/connection.ts
@@ -10,8 +10,8 @@ export const db: Knex = knex({
   client: 'pg',
   connection: env.DATABASE_URL,
   pool: {
-    min: 2,
-    max: 10,
+    min: env.DB_POOL_MIN,
+    max: env.DB_POOL_MAX,
     afterCreate: (_conn: unknown, done: (err?: Error) => void) => {
       dbLogger.debug('new connection created in pool')
       done()


### PR DESCRIPTION
Addresses D9 from docs/security-review-2026-05-01.md. Hard-coded
pool sizing (min=2, max=10) now reads from DB_POOL_MIN / DB_POOL_MAX
with the same defaults preserved.

https://claude.ai/code/session_01QHwe8pbmm5PDobWHYSWoSa