### PR TITLE
feat(frontend): sprint 2 from design review (tokens + a11y + i18n)

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, lazy, Suspense } from 'react'
-import { Routes, Route, Navigate } from 'react-router-dom'
+import { Routes, Route, Navigate, useParams } from 'react-router-dom'
 import { useAuthStore } from '@/stores/auth.store'
 import { connectSocket, disconnectSocket } from '@/lib/socket'
 import { LandingPage } from '@/pages/LandingPage'
@@ -36,6 +36,17 @@ function RequireAdmin({ children }: { children: React.ReactNode }) {
   const user = useAuthStore((s) => s.user)
   if (!user?.isAdmin) return <Navigate to="/" replace />
   return <>{children}</>
+}
+
+/** Bridges the OG-rich `/invite/:token` URL (used in Discord/Slack/Twitter
+ *  unfurls) onto the SPA's `/join/:token` route. The server handles the
+ *  unauthenticated meta-tag preview directly; this client-side component
+ *  just guarantees that an authenticated user clicking the link from a
+ *  rich embed lands on the join screen instead of the 404 fallback. */
+function InviteRedirect() {
+  const { token } = useParams<{ token: string }>()
+  if (!token) return <Navigate to="/" replace />
+  return <Navigate to={`/join/${token}`} replace />
 }
 
 function App() {
@@ -106,6 +117,10 @@ function App() {
       <Routes>
         <Route path="/" element={<LandingPage />} />
         <Route path="/join/:token" element={<JoinPage />} />
+        {/* /invite/:token is the OG-rich URL surfaced by InviteLink — point
+            it at the SPA join page so a deep-linked invitee from Discord
+            doesn't hit the 404 fallback. */}
+        <Route path="/invite/:token" element={<InviteRedirect />} />
         <Route path="/discord/link" element={<DiscordLinkPage />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
@@ -124,6 +139,7 @@ function App() {
         <Route path="/groups/:id" element={<GroupPage />} />
         <Route path="/groups/:id/vote" element={<VotePage />} />
         <Route path="/join/:token" element={<JoinPage />} />
+        <Route path="/invite/:token" element={<InviteRedirect />} />
         <Route path="/discord/link" element={<DiscordLinkPage />} />
         <Route path="*" element={<NotFoundPage />} />
       </Routes>

--- a/packages/frontend/src/components/admin-health-card.tsx
+++ b/packages/frontend/src/components/admin-health-card.tsx
@@ -40,8 +40,8 @@ function IntegrationRow({ label, health }: IntegrationRowProps) {
   const tone = disabled
     ? { dotClass: 'bg-muted-foreground/40', textClass: 'text-muted-foreground/70', label: 'désactivé' }
     : open
-      ? { dotClass: 'bg-destructive shadow-[0_0_10px_rgba(239,68,68,0.45)]', textClass: 'text-destructive', label: 'dégradé' }
-      : { dotClass: 'bg-success shadow-[0_0_10px_rgba(74,222,128,0.45)]', textClass: 'text-success', label: 'opérationnel' }
+      ? { dotClass: 'bg-destructive shadow-[0_0_10px_oklch(0.65_0.22_25_/_0.45)]', textClass: 'text-destructive', label: 'dégradé' }
+      : { dotClass: 'bg-success shadow-[0_0_10px_oklch(0.723_0.191_142.5_/_0.45)]', textClass: 'text-success', label: 'opérationnel' }
 
   return (
     <div className="flex items-center justify-between gap-3 rounded-md border border-border/50 bg-card/40 px-3 py-2">

--- a/packages/frontend/src/components/challenge-card.tsx
+++ b/packages/frontend/src/components/challenge-card.tsx
@@ -4,10 +4,14 @@ import { Progress } from '@/components/ui/progress'
 import { Badge } from '@/components/ui/badge'
 import type { ChallengeProgress } from '@wawptn/types'
 
-const TIER_STYLES: Record<number, { border: string; badge: string; label: string }> = {
-  1: { border: 'border-l-amber-700/60', badge: 'bg-amber-900/30 text-amber-400 border-amber-700/40', label: 'Bronze' },
-  2: { border: 'border-l-slate-400/60', badge: 'bg-slate-700/30 text-slate-300 border-slate-500/40', label: 'Argent' },
-  3: { border: 'border-l-yellow-500/60', badge: 'bg-yellow-900/30 text-yellow-400 border-yellow-600/40', label: 'Or' },
+// Tier styling uses the existing warm-cool-warm semantic tokens rather
+// than raw amber/slate/yellow Tailwind hues so future palette tweaks
+// flow through to challenges automatically. ember=Bronze, neon=Argent
+// (cool metallic), reward=Or.
+const TIER_STYLES: Record<number, { border: string; badgeVariant: 'reward' | 'info' | 'success'; label: string }> = {
+  1: { border: 'border-l-ember/60', badgeVariant: 'reward', label: 'Bronze' },
+  2: { border: 'border-l-neon/60', badgeVariant: 'info', label: 'Argent' },
+  3: { border: 'border-l-reward/60', badgeVariant: 'reward', label: 'Or' },
 }
 
 const unlockPop: Variants = {
@@ -40,7 +44,7 @@ export function ChallengeCard({ challenge }: { challenge: ChallengeProgress }) {
         flex items-center gap-3 p-3.5 rounded-xl border border-border/50 bg-card/50 backdrop-blur-sm
         border-l-[3px] transition-all duration-300 hover:bg-card/80 hover:border-border/70
         ${tier.border}
-        ${isUnlocked ? 'ring-1 ring-inset ring-yellow-500/10' : ''}
+        ${isUnlocked ? 'ring-1 ring-inset ring-reward/10' : ''}
       `}
     >
       {/* Icon */}
@@ -53,7 +57,7 @@ export function ChallengeCard({ challenge }: { challenge: ChallengeProgress }) {
         <div className="flex items-center gap-2 mb-0.5">
           <span className="font-medium text-sm truncate">{challenge.title}</span>
           {isUnlocked && (
-            <Badge variant="outline" className={`text-[10px] py-0 h-5 shrink-0 ${tier.badge}`}>
+            <Badge variant={tier.badgeVariant} className="text-[10px] py-0 h-5 shrink-0">
               {tier.label}
             </Badge>
           )}

--- a/packages/frontend/src/components/game-grid.tsx
+++ b/packages/frontend/src/components/game-grid.tsx
@@ -627,15 +627,15 @@ export function GameGrid({ games, loading, filters, onToggleMultiplayer, onToggl
           hint={(
             <ul className="space-y-2 text-xs text-muted-foreground">
               <li className="flex items-start gap-2">
-                <ShieldAlert className="w-3.5 h-3.5 text-amber-500 mt-0.5 shrink-0" />
+                <ShieldAlert className="w-3.5 h-3.5 text-warning mt-0.5 shrink-0" />
                 <span>{t('group.noCommonGamesHint1')}</span>
               </li>
               <li className="flex items-start gap-2">
-                <EyeOff className="w-3.5 h-3.5 text-amber-500 mt-0.5 shrink-0" />
+                <EyeOff className="w-3.5 h-3.5 text-warning mt-0.5 shrink-0" />
                 <span>{t('group.noCommonGamesHint2')}</span>
               </li>
               <li className="flex items-start gap-2">
-                <Users className="w-3.5 h-3.5 text-amber-500 mt-0.5 shrink-0" />
+                <Users className="w-3.5 h-3.5 text-warning mt-0.5 shrink-0" />
                 <span>{t('group.noCommonGamesHint3')}</span>
               </li>
             </ul>

--- a/packages/frontend/src/components/group-sidebar.tsx
+++ b/packages/frontend/src/components/group-sidebar.tsx
@@ -71,14 +71,17 @@ interface GroupSidebarProps {
   compact?: boolean
 }
 
-function getLastSeenLabel(lastSeenTs: number | undefined): string {
-  if (!lastSeenTs) return 'Hors ligne'
+function getLastSeenLabel(
+  lastSeenTs: number | undefined,
+  t: (key: string, options?: Record<string, unknown>) => string,
+): string {
+  if (!lastSeenTs) return t('groups.lastSeen.offline')
   const diffMs = Date.now() - lastSeenTs
   const diffMinutes = Math.floor(diffMs / 60000)
-  if (diffMinutes < 1) return 'Vu à l\u2019instant'
-  if (diffMinutes < 5) return 'Vu il y a quelques minutes'
-  if (diffMinutes < 60) return `Vu il y a ${diffMinutes} min`
-  return 'Hors ligne'
+  if (diffMinutes < 1) return t('groups.lastSeen.justNow')
+  if (diffMinutes < 5) return t('groups.lastSeen.fewMinutes')
+  if (diffMinutes < 60) return t('groups.lastSeen.minutesAgo', { count: diffMinutes })
+  return t('groups.lastSeen.offline')
 }
 
 export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken, voteHistory, voteHistoryTruncated, onlineMembers, lastSeenMap, currentUserId, currentUserRole, autoVoteSchedule, autoVoteDurationMinutes, onSync, onGenerateInvite, onLeaveGroup, onKickMember, onDeleteGroup, onRenameGroup, onDeleteHistory, onToggleNotifications, onUpdateAutoVote, onStartVote, compact = false }: GroupSidebarProps) {
@@ -185,7 +188,7 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
         {onlineCount > 0 && (
           <Badge variant="secondary" className="text-[10px] px-1.5 py-0 gap-1 font-normal">
             <span className="w-1.5 h-1.5 rounded-full bg-online animate-pulse" />
-            {onlineCount} en ligne
+            {t('groups.onlineCount', { count: onlineCount })}
           </Badge>
         )}
       </div>
@@ -208,8 +211,8 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
         const isOnline = onlineMembers.has(member.id)
         const isSelf = member.id === currentUserId
         const presenceLabel = isOnline
-          ? 'En ligne'
-          : getLastSeenLabel(lastSeenMap.get(member.id))
+          ? t('groups.lastSeen.online')
+          : getLastSeenLabel(lastSeenMap.get(member.id), t)
         return (
           <div key={member.id} className={`flex items-center gap-3 min-h-[48px] py-1.5 px-1 -mx-1 rounded-md group transition-opacity ${!isOnline ? 'opacity-60' : ''}`}>
             <button

--- a/packages/frontend/src/components/tonight-pick-hero.tsx
+++ b/packages/frontend/src/components/tonight-pick-hero.tsx
@@ -186,7 +186,10 @@ export function TonightPickHero({
         <div className="shrink-0 hidden sm:block">
           <img
             src={resolveSteamHeaderImage(game.steamAppId, game.headerImageUrl)}
-            alt={game.gameName}
+            // Decorative — the adjacent <h2> already announces the game
+            // name, so an alt here causes screen readers to hear it twice.
+            alt=""
+            aria-hidden="true"
             className="w-[200px] aspect-[460/215] rounded-lg object-cover ring-1 ring-white/10 shadow-lg"
             loading="eager"
           />

--- a/packages/frontend/src/components/ui/badge.tsx
+++ b/packages/frontend/src/components/ui/badge.tsx
@@ -11,6 +11,17 @@ const badgeVariants = cva(
         secondary: 'border-transparent bg-secondary text-secondary-foreground',
         destructive: 'border-transparent bg-destructive text-destructive-foreground',
         outline: 'text-foreground',
+        // Semantic surfaces. Tinted background + matching text + a subtle
+        // border, so call sites stop reaching for `bg-primary/10
+        // text-primary border-primary/20` triplets and the design system
+        // owns the contrast.
+        success: 'border-success/30 bg-success/15 text-success',
+        warning: 'border-warning/30 bg-warning/15 text-warning',
+        info: 'border-info/30 bg-info/15 text-info',
+        reward: 'border-reward/30 bg-reward/15 text-reward',
+        scoreGood: 'border-score-good/30 bg-score-good/15 text-score-good',
+        scoreMixed: 'border-score-mixed/30 bg-score-mixed/15 text-score-mixed',
+        scoreBad: 'border-score-bad/30 bg-score-bad/15 text-score-bad',
       },
     },
     defaultVariants: {

--- a/packages/frontend/src/components/ui/dialog.tsx
+++ b/packages/frontend/src/components/ui/dialog.tsx
@@ -39,13 +39,19 @@ function DialogContent({
         ref={ref}
         data-slot="dialog-content"
         className={cn(
-          'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-border bg-card p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg',
+          // max-h prevents content from overflowing the viewport on tablet
+          // portrait (640-768px), where ResponsiveDialog still uses Dialog
+          // rather than Drawer.
+          'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg max-h-[calc(100dvh-2rem)] overflow-y-auto translate-x-[-50%] translate-y-[-50%] gap-4 border border-border bg-card p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg',
           className
         )}
         {...props}
       >
         {children}
-        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus-visible:ring-[3px] focus-visible:ring-ring disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <DialogPrimitive.Close
+          aria-label="Fermer"
+          className="absolute right-2 top-2 inline-flex items-center justify-center h-11 w-11 min-h-[44px] min-w-[44px] rounded-md opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus-visible:ring-[3px] focus-visible:ring-ring disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground"
+        >
           <X className="h-4 w-4" />
           <span className="sr-only">Close</span>
         </DialogPrimitive.Close>

--- a/packages/frontend/src/components/vote-setup-dialog.tsx
+++ b/packages/frontend/src/components/vote-setup-dialog.tsx
@@ -261,21 +261,21 @@ export function VoteSetupDialog({ open, onOpenChange, members, groupId, onlineMe
             <div className="mt-3 flex items-center gap-2 text-sm">
               {selectedIds.size < 2 ? (
                 <span className="text-muted-foreground">
-                  Sélectionnez au moins 2 membres
+                  {t('voteSetup.selectAtLeastTwoMembers')}
                 </span>
               ) : loadingLivePreview ? (
                 <span className="flex items-center gap-2 text-muted-foreground">
                   <Loader2 className="w-4 h-4 animate-spin" />
-                  Calcul des jeux en commun…
+                  {t('voteSetup.calculatingCommonGames')}
                 </span>
               ) : livePreviewCount !== null && livePreviewCount === 0 ? (
-                <span className="flex items-center gap-2 text-amber-500">
+                <span className="flex items-center gap-2 text-warning">
                   <AlertTriangle className="w-4 h-4" />
-                  Aucun jeu en commun trouvé
+                  {t('voteSetup.noCommonGames')}
                 </span>
               ) : livePreviewCount !== null ? (
                 <span className="text-muted-foreground">
-                  🎮 {livePreviewCount} {livePreviewCount === 1 ? 'jeu' : 'jeux'} en commun
+                  🎮 {t('voteSetup.commonGamesCount', { count: livePreviewCount })}
                 </span>
               ) : null}
             </div>

--- a/packages/frontend/src/i18n/locales/fr.json
+++ b/packages/frontend/src/i18n/locales/fr.json
@@ -39,6 +39,14 @@
     "searchGroups": "Rechercher un groupe...",
     "noSearchResults": "Aucun groupe ne correspond à ta recherche.",
     "clearSearch": "Effacer la recherche",
+    "lastSeen": {
+      "online": "En ligne",
+      "offline": "Hors ligne",
+      "justNow": "Vu à l’instant",
+      "fewMinutes": "Vu il y a quelques minutes",
+      "minutesAgo_one": "Vu il y a {{count}} min",
+      "minutesAgo_other": "Vu il y a {{count}} min"
+    },
     "pullToRefresh": "Tirer pour actualiser",
     "releaseToRefresh": "Relâcher pour actualiser",
     "refreshing": "Actualisation..."
@@ -264,7 +272,12 @@
     "scheduleLater": "Planifier pour plus tard",
     "scheduleDateLabel": "Date et heure de la soirée",
     "scheduleHint": "Le vote se fermera automatiquement à cette date.",
-    "scheduleVote": "Planifier la soirée"
+    "scheduleVote": "Planifier la soirée",
+    "selectAtLeastTwoMembers": "Sélectionnez au moins 2 membres",
+    "calculatingCommonGames": "Calcul des jeux en commun…",
+    "noCommonGames": "Aucun jeu en commun trouvé",
+    "commonGamesCount_one": "{{count}} jeu en commun",
+    "commonGamesCount_other": "{{count}} jeux en commun"
   },
   "randomPick": {
     "title": "Choix aléatoire",

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -53,6 +53,13 @@
   /* New: Warm ember accent */
   --ember: oklch(0.72 0.18 50);
   --ember-foreground: oklch(0.15 0.05 50);
+  /* Semantic: cautionary/info surfaces. `--warning` replaces ad-hoc
+     amber-500 usage in invite-error / no-common-games / network-warning
+     contexts; `--info` for neutral attention-grab without alarm. */
+  --warning: oklch(0.78 0.17 80);
+  --warning-foreground: oklch(0.20 0.06 80);
+  --info: oklch(0.70 0.13 230);
+  --info-foreground: oklch(0.15 0.04 230);
 }
 
 @theme inline {
@@ -103,6 +110,10 @@
   --color-online: var(--online);
   --color-ember: var(--ember);
   --color-ember-foreground: var(--ember-foreground);
+  --color-warning: var(--warning);
+  --color-warning-foreground: var(--warning-foreground);
+  --color-info: var(--info);
+  --color-info-foreground: var(--info-foreground);
   --radius-sm: calc(var(--radius) * 0.6);
   --radius-md: calc(var(--radius) * 0.8);
   --radius-lg: var(--radius);

--- a/packages/frontend/src/pages/JoinPage.tsx
+++ b/packages/frontend/src/pages/JoinPage.tsx
@@ -204,9 +204,9 @@ export function JoinPage() {
 
           {inAppBrowser && !overrideInAppBrowser ? (
             <motion.div variants={fadeUp} className="w-full">
-              <Card className="p-4 mb-4 border-amber-500/40 bg-amber-500/5">
+              <Card className="p-4 mb-4 border-warning/40 bg-warning/5">
                 <div className="flex items-start gap-3">
-                  <AlertTriangle className="w-5 h-5 text-amber-500 shrink-0 mt-0.5" aria-hidden="true" />
+                  <AlertTriangle className="w-5 h-5 text-warning shrink-0 mt-0.5" aria-hidden="true" />
                   <div className="min-w-0">
                     <p className="font-semibold mb-1">{t('join.inAppBrowserTitle')}</p>
                     <p className="text-sm text-muted-foreground mb-2">{t('join.inAppBrowserBody')}</p>

--- a/packages/frontend/src/pages/LandingPage.tsx
+++ b/packages/frontend/src/pages/LandingPage.tsx
@@ -72,6 +72,7 @@ export function LandingPage() {
             // competing for primary focus; sm:/lg: breakpoints restore the
             // original desktop sizing.
             className="landing-question-mark font-heading font-extrabold text-[35vw] sm:text-[38vw] lg:text-[30vw] leading-none"
+            aria-hidden="true"
             initial={{ opacity: 0, scale: 0.85 }}
             animate={{
               opacity: 1,

--- a/packages/frontend/src/pages/SubscriptionPage.tsx
+++ b/packages/frontend/src/pages/SubscriptionPage.tsx
@@ -137,18 +137,12 @@ export function SubscriptionPage() {
                   {t('subscription.freeDescription')}
                 </p>
                 <ul className="space-y-2 text-sm">
-                  <li className="flex items-center gap-2">
-                    <Crown className="w-4 h-4 text-reward" />
-                    {t('landing.premiumFeature1')}
-                  </li>
-                  <li className="flex items-center gap-2">
-                    <Crown className="w-4 h-4 text-reward" />
-                    {t('landing.premiumFeature2')}
-                  </li>
-                  <li className="flex items-center gap-2">
-                    <Crown className="w-4 h-4 text-reward" />
-                    {t('landing.premiumFeature3')}
-                  </li>
+                  {[1, 2, 3, 4, 5, 6].map((n) => (
+                    <li key={n} className="flex items-center gap-2">
+                      <Crown className="w-4 h-4 text-reward shrink-0" />
+                      {t(`landing.premiumFeature${n}`)}
+                    </li>
+                  ))}
                 </ul>
                 <Button onClick={handleCheckout} disabled={actionLoading} className="mt-2">
                   <Crown className="w-4 h-4 mr-2" />

--- a/packages/frontend/src/pages/VotePage.tsx
+++ b/packages/frontend/src/pages/VotePage.tsx
@@ -449,8 +449,13 @@ export function VotePage() {
               scrolling thumb, so this pill keeps the context visible at the
               top of the viewport. */}
           {selectedGames.size > 0 && (
+            // Polite live region instead of aria-hidden — screen reader users
+            // also need the count, especially on long ballots where the
+            // bottom bar duplicate scrolls out of view.
             <div
-              aria-hidden="true"
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
               className="sticky top-0 z-10 -mx-1 mb-3 flex justify-center pointer-events-none"
             >
               <span className="rounded-full border border-primary/40 bg-background/85 px-3 py-1 text-xs font-medium text-foreground shadow-sm backdrop-blur">
@@ -828,7 +833,7 @@ function ResultScreen({
                 className="h-2 w-full overflow-hidden rounded-full bg-secondary"
               >
                 <motion.div
-                  className="h-full rounded-full bg-gradient-to-r from-reward to-amber-300 shadow-[0_0_12px_rgba(255,215,128,0.45)]"
+                  className="h-full rounded-full bg-gradient-to-r from-reward to-warning shadow-[0_0_12px_oklch(0.82_0.17_70_/_0.45)]"
                   initial={{ width: '0%' }}
                   animate={{ width: `${percent}%` }}
                   transition={{


### PR DESCRIPTION
A6 i18n migration of the highest-impact hardcoded French strings:
   group-sidebar online status (lastSeen.* keys with proper plural forms),
   onlineCount badge now uses existing groups.onlineCount, vote-setup-
   dialog "calculating common games" / "no common games" / count.

A10 Dialog close button bumped from ~16px to a 44×44 button with
   visible aria-label and rounded hit area; DialogContent now caps at
   100dvh-2rem so long forms scroll instead of overflowing the viewport
   on tablet portrait.

D3 Badge variants extended with `success`, `warning`, `info`, `reward`,
   `scoreGood`, `scoreMixed`, `scoreBad` so call sites stop reaching
   for `bg-primary/10 text-primary border-primary/20` triplets.

Tokens: --warning + --info added to index.css and registered in
   @theme inline. Migrated all four amber-500 surfaces (JoinPage in-app
   browser warning, vote-setup-dialog "no games" warning, three
   game-grid no-common-games hints) to text-warning / bg-warning. Two
   rgba(...) shadows in admin-health-card and one in VotePage migrated
   to oklch(...). VotePage gradient mixed-token (from-reward to-amber-300)
   collapsed to from-reward to-warning.

challenge-card amber-700 / slate-400 / yellow-500 hardcoded tier
   styling replaced by a TIER_STYLES record that consumes ember / neon /
   reward semantic tokens + the new badge variants. ring-yellow-500/10
   → ring-reward/10.

E2 VotePage sticky selection counter: aria-hidden replaced with
   role="status" aria-live="polite" so screen-reader users also get the
   count instead of being silenced.

E4 LandingPage giant `?` watermark gets aria-hidden="true".

E5 tonight-pick-hero visible thumb gets alt="" + aria-hidden so the
   game name isn't announced twice (the adjacent <h2> already carries it).

E7 New `/invite/:token` route handled by an InviteRedirect component
   that bridges the OG-rich URL onto the SPA's /join/:token route, both
   for unauthenticated and authenticated users — no more 404 fallback
   when a Discord-unfurled invite is clicked.

B6 SubscriptionPage features list expanded from 3 to all 6 premium
   features; switched to a 1..6 map so adding/removing features only
   needs i18n changes.

UserProfilePage / ComparePage full i18n migration deferred — those pages
have no useTranslation wiring yet and need a dedicated refactor.

https://claude.ai/code/session_01QHwe8pbmm5PDobWHYSWoSa