### PR TITLE
fix(frontend): bypass SW for /api/* navigations to fix Steam login 404

### DIFF
--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -93,9 +93,16 @@ export default defineConfig({
             // is offline, which is exactly the "tab frozen after Discord
             // switch" case mobile users hit. Short network timeout
             // (3s) so we don't stall the UI waiting for a dead radio.
+            //
+            // Excludes navigation requests (request.mode === 'navigate')
+            // because endpoints like /api/auth/steam/login respond with a
+            // 3xx redirect to a cross-origin OpenID URL, and a SW cannot
+            // return a redirected Response for a navigation — the browser
+            // then falls back to the SPA shell and renders the 404 page.
             urlPattern: ({ sameOrigin, url, request }) =>
               sameOrigin &&
               request.method === 'GET' &&
+              request.mode !== 'navigate' &&
               url.pathname.startsWith('/api/'),
             handler: 'NetworkFirst',
             options: {


### PR DESCRIPTION
## Summary

- Clicking "Login with Steam" returned a 404 because the PWA service worker intercepted the `<a href="/api/auth/steam/login">` navigation. The runtime-cache rule in `vite.config.ts` matched all same-origin GETs under `/api/`, and NetworkFirst followed the 302 to `steamcommunity.com`. A service worker cannot return a redirected Response for a navigation request, so the browser fell through to the SPA shell and rendered `NotFoundPage`.
- Adds `request.mode !== 'navigate'` to the API runtime-cache `urlPattern` so link navigations bypass the SW. Fetch/XHR API calls still benefit from the NetworkFirst offline cache.

## Test plan

- [ ] Build the frontend (`npm run build`) and serve it (`npm run preview`) so the SW is active.
- [ ] On the landing page, click "Login with Steam" and confirm the browser navigates to `steamcommunity.com/openid/login` instead of rendering the 404 page.
- [ ] Complete the Steam OpenID flow and confirm the callback redirects back to the app and creates a session.
- [ ] Reload an authenticated page offline and confirm cached `/api/*` GETs still serve from the runtime cache (NetworkFirst fallback still works for non-navigation requests).
- [ ] Verify existing users get the new SW after one refresh (registerType: `autoUpdate`).


---
_Generated by [Claude Code](https://claude.ai/code/session_0171HgLTXzaYEtzsizPnH4aW)_