### PR TITLE
feat: streaks UI + landing social-proof strip (B5 + B1)

### DIFF
--- a/packages/backend/src/domain/streaks.ts
+++ b/packages/backend/src/domain/streaks.ts
@@ -119,3 +119,40 @@ export async function getGroupStreaks(groupId: string): Promise<Array<{
     updatedAt: r.updatedAt instanceof Date ? r.updatedAt.toISOString() : String(r.updatedAt),
   }))
 }
+
+/**
+ * Per-user roll-up across every group the user is in. Powers the
+ * GroupsPage streak badge: a single "🔥 N" indicator that shows the
+ * user's best *current* (still-alive) streak, plus the all-time best
+ * for context. Returns zeros when the user hasn't earned any streak yet
+ * — call sites can then suppress rendering.
+ */
+export async function getUserStreakSummary(userId: string): Promise<{
+  bestCurrent: number
+  bestEver: number
+  /** Number of distinct groups where the user has a current_streak >= 2
+   *  (i.e. an active streak — a single session doesn't count). Surfaced
+   *  to give context for the badge tooltip. */
+  activeStreakGroups: number
+}> {
+  const rows = await db('streaks')
+    .where({ user_id: userId })
+    .select<{ current_streak: number; best_streak: number }[]>('current_streak', 'best_streak')
+
+  if (rows.length === 0) {
+    return { bestCurrent: 0, bestEver: 0, activeStreakGroups: 0 }
+  }
+
+  let bestCurrent = 0
+  let bestEver = 0
+  let activeStreakGroups = 0
+  for (const row of rows) {
+    const cur = Number(row.current_streak)
+    const ever = Number(row.best_streak)
+    if (cur > bestCurrent) bestCurrent = cur
+    if (ever > bestEver) bestEver = ever
+    if (cur >= 2) activeStreakGroups++
+  }
+
+  return { bestCurrent, bestEver, activeStreakGroups }
+}

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -20,6 +20,7 @@ import { voteRoutes } from './presentation/routes/vote.routes.js'
 import { inviteRoutes } from './presentation/routes/invite.routes.js'
 import { ogRoutes } from './presentation/routes/og.routes.js'
 import { shareRoutes } from './presentation/routes/share.routes.js'
+import { statsRoutes } from './presentation/routes/stats.routes.js'
 import { requireAuth } from './presentation/middleware/auth.middleware.js'
 import { requireBotAuth } from './presentation/middleware/bot-auth.middleware.js'
 import { requireAdmin } from './presentation/middleware/admin.middleware.js'
@@ -155,6 +156,11 @@ async function main() {
   // (e.g. landing-page → login clicks) and so a dead session never prevents
   // the final vote.completed event from being recorded.
   app.use('/api/events', eventRoutes)
+
+  // Public marketing stats (unauth). Aggregates only — no PII, no per-user
+  // data. Powers the LandingPage social-proof strip. Cached server-side
+  // for 5 minutes; the global apiLimiter still applies upstream.
+  app.use('/api/stats', statsRoutes)
 
   // Strict rate limiter for admin mutation endpoints (privilege grants,
   // persona CRUD, bot settings). Capped well below normal usage so a

--- a/packages/backend/src/presentation/routes/stats.routes.ts
+++ b/packages/backend/src/presentation/routes/stats.routes.ts
@@ -1,0 +1,88 @@
+import { Router, type Request, type Response } from 'express'
+import { db } from '../../infrastructure/database/connection.js'
+import { logger } from '../../infrastructure/logger/logger.js'
+
+const router = Router()
+const statsLogger = logger.child({ module: 'stats' })
+
+/** Lightweight cache so the LandingPage social-proof strip doesn't run
+ *  three COUNT(*) queries per page load. The numbers move slowly; one
+ *  refresh per 5 minutes is plenty for a marketing surface. */
+let cache: { value: PublicStats; expiresAt: number } | null = null
+const TTL_MS = 5 * 60_000
+
+interface PublicStats {
+  /** Total registered users — proxy for "join X gamers". */
+  users: number
+  /** Total groups created — proxy for "Y groupes décident ensemble". */
+  groups: number
+  /** Closed voting sessions, all-time — proxy for "Z parties choisies". */
+  votesClosed: number
+  /** Closed voting sessions in the last 7 days — proxy for "active right now". */
+  votesClosed7d: number
+  /** Server timestamp — surfaced for cache-debug. */
+  generatedAt: string
+}
+
+async function computeStats(): Promise<PublicStats> {
+  const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60_000)
+
+  const [users, groups, votesAll, votes7d] = await Promise.all([
+    db('users').count<{ count: string }[]>('* as count').first(),
+    db('groups').count<{ count: string }[]>('* as count').first(),
+    db('voting_sessions').where({ status: 'closed' }).count<{ count: string }[]>('* as count').first(),
+    db('voting_sessions')
+      .where({ status: 'closed' })
+      .where('closed_at', '>=', sevenDaysAgo)
+      .count<{ count: string }[]>('* as count')
+      .first(),
+  ])
+
+  return {
+    users: Number(users?.count ?? 0),
+    groups: Number(groups?.count ?? 0),
+    votesClosed: Number(votesAll?.count ?? 0),
+    votesClosed7d: Number(votes7d?.count ?? 0),
+    generatedAt: new Date().toISOString(),
+  }
+}
+
+/**
+ * GET /api/stats/public — unauthenticated landing-page social-proof
+ * aggregates. No PII, no per-user data; only roll-ups that cannot
+ * identify any individual.
+ *
+ * Cached in-memory for 5 minutes (these numbers move slowly and the
+ * landing page is the highest-traffic surface). Failures fall back to
+ * the cached value if available, otherwise return zeros — analytics
+ * must never block the marketing page from rendering.
+ */
+router.get('/public', async (_req: Request, res: Response) => {
+  const now = Date.now()
+  if (cache && cache.expiresAt > now) {
+    res.json(cache.value)
+    return
+  }
+
+  try {
+    const stats = await computeStats()
+    cache = { value: stats, expiresAt: now + TTL_MS }
+    res.json(stats)
+  } catch (error) {
+    statsLogger.warn({ error: String(error) }, 'failed to compute public stats')
+    if (cache) {
+      // Stale-while-error: better to show last-known numbers than zero.
+      res.json(cache.value)
+      return
+    }
+    res.json({
+      users: 0,
+      groups: 0,
+      votesClosed: 0,
+      votesClosed7d: 0,
+      generatedAt: new Date().toISOString(),
+    })
+  }
+})
+
+export { router as statsRoutes }

--- a/packages/backend/src/presentation/routes/user-profile.routes.ts
+++ b/packages/backend/src/presentation/routes/user-profile.routes.ts
@@ -213,6 +213,15 @@ router.get('/me/visibility', async (req: Request, res: Response) => {
   })
 })
 
+// GET /api/users/me/streaks — per-user streak roll-up across every group.
+// Powers the GroupsPage retention badge ("🔥 N"). Returns zeros when the
+// user has never closed a session — call sites suppress rendering then.
+router.get('/me/streaks', async (req: Request, res: Response) => {
+  const { getUserStreakSummary } = await import('../../domain/streaks.js')
+  const summary = await getUserStreakSummary(req.userId!)
+  res.json(summary)
+})
+
 // PATCH /api/users/me/visibility — update own visibility toggles
 router.patch('/me/visibility', async (req: Request, res: Response) => {
   const { visibilityFullLibrary, visibilityLastPlayed } = req.body as {

--- a/packages/frontend/src/components/social-proof-strip.tsx
+++ b/packages/frontend/src/components/social-proof-strip.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { motion } from 'framer-motion'
+import { api } from '@/lib/api'
+
+interface PublicStats {
+  users: number
+  groups: number
+  votesClosed: number
+  votesClosed7d: number
+}
+
+/**
+ * Landing-page social-proof strip — addresses B1 from the conversion
+ * review (no-social-proof was flagged as the single biggest conversion
+ * blocker on the marketing surface).
+ *
+ * Fetches `/api/stats/public` (5-min server cache) and renders three
+ * compact tiles. Suppressed entirely when the numbers are below a
+ * minimum credible threshold — early-stage product, an honest "1 vote
+ * closed" looks worse than no proof at all.
+ *
+ * Graceful failure: errors swallow silently and the strip just doesn't
+ * render. Falls back to a fade-in animation so the LCP isn't blocked
+ * by the network request.
+ */
+const MIN_CREDIBLE_USERS = 25
+const MIN_CREDIBLE_VOTES = 10
+
+function formatNumber(n: number, locale = 'fr-FR'): string {
+  if (n >= 10_000) return `${(n / 1_000).toFixed(0)}k`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`.replace('.0k', 'k')
+  return new Intl.NumberFormat(locale).format(n)
+}
+
+export function SocialProofStrip() {
+  const { t } = useTranslation()
+  const [stats, setStats] = useState<PublicStats | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    api
+      .getPublicStats()
+      .then((s) => { if (!cancelled) setStats(s) })
+      .catch(() => { /* swallow — never block the hero */ })
+    return () => { cancelled = true }
+  }, [])
+
+  if (!stats) return null
+  if (stats.users < MIN_CREDIBLE_USERS && stats.votesClosed < MIN_CREDIBLE_VOTES) return null
+
+  return (
+    <motion.div
+      className="mt-8 sm:mt-10 flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-xs text-muted-foreground"
+      initial={{ opacity: 0, y: 6 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4, delay: 0.2, ease: 'easeOut' }}
+    >
+      <Stat value={formatNumber(stats.users)} label={t('socialProof.users')} />
+      <span aria-hidden="true" className="opacity-30">·</span>
+      <Stat value={formatNumber(stats.groups)} label={t('socialProof.groups')} />
+      <span aria-hidden="true" className="opacity-30">·</span>
+      <Stat
+        value={formatNumber(stats.votesClosed7d > 0 ? stats.votesClosed7d : stats.votesClosed)}
+        label={stats.votesClosed7d > 0 ? t('socialProof.votes7d') : t('socialProof.votes')}
+      />
+    </motion.div>
+  )
+}
+
+function Stat({ value, label }: { value: string; label: string }) {
+  return (
+    <span className="inline-flex items-baseline gap-1.5">
+      <strong className="text-foreground font-heading font-bold tabular-nums text-sm">
+        {value}
+      </strong>
+      <span>{label}</span>
+    </span>
+  )
+}

--- a/packages/frontend/src/components/streak-badge.tsx
+++ b/packages/frontend/src/components/streak-badge.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
+import { api } from '@/lib/api'
+
+/**
+ * Compact retention indicator surfaced on the GroupsPage header.
+ *
+ * Shows the user's best *current* streak across every group, with a
+ * tooltip that adds the all-time best for context. Hidden when the
+ * user has no streak yet (current < 2) so it doesn't clutter the
+ * empty-handed first-run state.
+ *
+ * Fetches its own data: the badge is the only consumer, the response
+ * is tiny, and adding a global Zustand store for one number would be
+ * over-engineering. Errors swallow silently — analytics/retention
+ * surfaces must never break the page.
+ */
+export function StreakBadge() {
+  const { t } = useTranslation()
+  const [data, setData] = useState<{ bestCurrent: number; bestEver: number; activeStreakGroups: number } | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    api
+      .getMyStreaks()
+      .then((d) => { if (!cancelled) setData(d) })
+      .catch(() => { /* swallow — never break the header */ })
+    return () => { cancelled = true }
+  }, [])
+
+  if (!data || data.bestCurrent < 2) return null
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className="inline-flex items-center gap-1 rounded-full border border-reward/30 bg-reward/10 px-2.5 py-0.5 text-xs font-semibold text-reward tabular-nums"
+          aria-label={t('streak.ariaLabel', { count: data.bestCurrent })}
+        >
+          <span aria-hidden="true">🔥</span>
+          {data.bestCurrent}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>
+        <div className="text-xs leading-snug">
+          <div>{t('streak.tooltipCurrent', { count: data.bestCurrent })}</div>
+          {data.bestEver > data.bestCurrent && (
+            <div className="text-muted-foreground mt-0.5">
+              {t('streak.tooltipBest', { count: data.bestEver })}
+            </div>
+          )}
+          {data.activeStreakGroups > 1 && (
+            <div className="text-muted-foreground mt-0.5">
+              {t('streak.tooltipGroups', { count: data.activeStreakGroups })}
+            </div>
+          )}
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/packages/frontend/src/i18n/locales/fr.json
+++ b/packages/frontend/src/i18n/locales/fr.json
@@ -624,6 +624,21 @@
     "gamesCount": "{{count}} jeux",
     "nothingToShow": "Rien à afficher."
   },
+  "streak": {
+    "ariaLabel": "Streak actuel : {{count}} sessions consécutives",
+    "tooltipCurrent_one": "{{count}} session d'affilée",
+    "tooltipCurrent_other": "{{count}} sessions d'affilée",
+    "tooltipBest_one": "Record : {{count}} session",
+    "tooltipBest_other": "Record : {{count}} sessions",
+    "tooltipGroups_one": "Actif dans {{count}} groupe",
+    "tooltipGroups_other": "Actif dans {{count}} groupes"
+  },
+  "socialProof": {
+    "users": "joueurs",
+    "groups": "groupes",
+    "votes": "parties choisies",
+    "votes7d": "parties cette semaine"
+  },
   "share": {
     "button": "Partager",
     "copyLink": "Copier le lien",

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -324,6 +324,12 @@ export const api = {
   createCheckout: () => request<{ url: string }>('/subscription/checkout', { method: 'POST' }),
   createPortal: () => request<{ url: string }>('/subscription/portal', { method: 'POST' }),
 
+  // Per-user streak roll-up (powers the GroupsPage streak badge)
+  getMyStreaks: () => request<{ bestCurrent: number; bestEver: number; activeStreakGroups: number }>('/users/me/streaks'),
+
+  // Unauthenticated public stats — feeds the LandingPage social-proof strip.
+  getPublicStats: () => request<{ users: number; groups: number; votesClosed: number; votesClosed7d: number; generatedAt: string }>('/stats/public'),
+
   // Personas
   getAdminPersonas: () => request<{
     id: string; name: string; systemPromptOverlay: string;

--- a/packages/frontend/src/pages/GroupsPage.tsx
+++ b/packages/frontend/src/pages/GroupsPage.tsx
@@ -23,6 +23,7 @@ import { AppHeader } from '@/components/app-header'
 import { AppFooter } from '@/components/app-footer'
 import { InviteLink } from '@/components/invite-link'
 import { PersonaBadge } from '@/components/persona-badge'
+import { StreakBadge } from '@/components/streak-badge'
 import { useDocumentTitle } from '@/hooks/useDocumentTitle'
 
 const fadeUp: Variants = {
@@ -242,7 +243,10 @@ export function GroupsPage() {
           </div>
         )}
         <div className="flex flex-wrap items-center justify-between gap-2 mb-6">
-          <h1 className="text-2xl font-heading font-bold tracking-[-0.03em]">{t('groups.title')}</h1>
+          <div className="flex items-center gap-2 flex-wrap">
+            <h1 className="text-2xl font-heading font-bold tracking-[-0.03em]">{t('groups.title')}</h1>
+            <StreakBadge />
+          </div>
           {/* Desktop-only top-right actions. On mobile these are duplicated
               into a thumb-zone bottom bar (below) so the primary CTAs
               aren't stranded in the top-right unreachable zone. */}

--- a/packages/frontend/src/pages/LandingPage.tsx
+++ b/packages/frontend/src/pages/LandingPage.tsx
@@ -12,6 +12,7 @@ import { motion, type Variants } from 'framer-motion'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { WawptnLogo } from '@/components/icons/wawptn-logo'
+import { SocialProofStrip } from '@/components/social-proof-strip'
 import { useDocumentTitle } from '@/hooks/useDocumentTitle'
 
 const fadeUp: Variants = {
@@ -167,6 +168,7 @@ export function LandingPage() {
             <p className="text-xs text-muted-foreground">
               {t('landing.ctaSubtext')}
             </p>
+            <SocialProofStrip />
           </motion.div>
         </motion.div>
 


### PR DESCRIPTION
## Summary

Closes 2 of the 3 deferred Critical conversion findings from the 2026-05-08 design review.

- **B5 — Retention loop made visible.** Backend's streaks domain has been silently tracking per-(user, group) streaks for closed sessions, but the frontend never surfaced any of it. New `getUserStreakSummary()` + `GET /api/users/me/streaks` + new `<StreakBadge>` "🔥 N" pill on the GroupsPage header.
- **B1 — Landing social-proof strip.** New unauthenticated `GET /api/stats/public` (5-min cache + stale-while-error) + new `<SocialProofStrip>` rendering "X joueurs · Y groupes · Z parties cette semaine" below the hero CTA. Suppressed under credibility thresholds (25 users / 10 votes) — early-stage product, an honest "1 vote" looks worse than no proof at all.

Both components fetch their own data and swallow errors silently — a flaky stats endpoint must never block the marketing page or the groups dashboard.

## Test plan

- [x] Backend `tsc --noEmit` clean
- [x] Frontend `tsc --noEmit -p .` clean
- [x] Backend `vitest run` 42/42 passing
- [x] `npm run lint` shows only the 5 pre-existing warnings
- [x] `fr.json` parses (new `streak.*` and `socialProof.*` trees with proper plural forms)

https://claude.ai/code/session_01QHwe8pbmm5PDobWHYSWoSa

---
_Generated by [Claude Code](https://claude.ai/code/session_01QHwe8pbmm5PDobWHYSWoSa)_