### PR TITLE
chore(frontend): D10 — collapse w-N h-N icon pairs to size-N

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -106,7 +106,7 @@ function App() {
         aria-live="polite"
         aria-label="Chargement de l'application"
       >
-        <Skeleton className="h-12 w-12 rounded-full" />
+        <Skeleton className="size-12 rounded-full" />
         <Skeleton className="h-4 w-32" />
       </div>
     )

--- a/packages/frontend/src/components/admin-health-card.tsx
+++ b/packages/frontend/src/components/admin-health-card.tsx
@@ -46,7 +46,7 @@ function IntegrationRow({ label, health }: IntegrationRowProps) {
   return (
     <div className="flex items-center justify-between gap-3 rounded-md border border-border/50 bg-card/40 px-3 py-2">
       <div className="flex items-center gap-2 min-w-0">
-        <span className={`h-2.5 w-2.5 rounded-full shrink-0 ${tone.dotClass}`} aria-hidden="true" />
+        <span className={`size-2.5 rounded-full shrink-0 ${tone.dotClass}`} aria-hidden="true" />
         <span className="text-sm font-medium truncate">{label}</span>
       </div>
       <div className="flex items-center gap-3 text-xs text-muted-foreground shrink-0">
@@ -121,7 +121,7 @@ export function AdminHealthCard() {
         <CardHeader className="pb-3">
           <div className="flex items-center justify-between">
             <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-2">
-              <Activity className="h-4 w-4" />
+              <Activity className="size-4" />
               Santé des intégrations
             </CardTitle>
             <Button
@@ -132,7 +132,7 @@ export function AdminHealthCard() {
               disabled={loading}
               aria-label="Rafraîchir"
             >
-              <RefreshCw className={`h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`} />
+              <RefreshCw className={`size-3.5 ${loading ? 'animate-spin' : ''}`} />
             </Button>
           </div>
         </CardHeader>
@@ -143,7 +143,7 @@ export function AdminHealthCard() {
             </div>
           ) : error && !snapshot ? (
             <div className="flex items-center gap-2 rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-sm text-destructive">
-              <AlertTriangle className="h-4 w-4 shrink-0" />
+              <AlertTriangle className="size-4 shrink-0" />
               Impossible de récupérer l'état des intégrations.
             </div>
           ) : snapshot ? (
@@ -153,7 +153,7 @@ export function AdminHealthCard() {
                   breaker state. */}
               <div className="flex items-center justify-between gap-3 rounded-md border border-border/50 bg-card/40 px-3 py-2">
                 <div className="flex items-center gap-2 min-w-0">
-                  <Database className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+                  <Database className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
                   <span className="text-sm font-medium">Base de données</span>
                 </div>
                 <div className="flex items-center gap-3 text-xs text-muted-foreground shrink-0">
@@ -166,9 +166,9 @@ export function AdminHealthCard() {
                     }`}
                   >
                     {snapshot.database.status === 'up' ? (
-                      <CheckCircle2 className="h-3 w-3" />
+                      <CheckCircle2 className="size-3" />
                     ) : (
-                      <AlertTriangle className="h-3 w-3" />
+                      <AlertTriangle className="size-3" />
                     )}
                     {snapshot.database.status === 'up' ? 'opérationnel' : 'indisponible'}
                   </span>

--- a/packages/frontend/src/components/app-header.tsx
+++ b/packages/frontend/src/components/app-header.tsx
@@ -79,13 +79,13 @@ export function AppHeader({ children, className, maxWidth = 'narrow' }: AppHeade
               aria-label={t('profile.title')}
             >
               {user ? (
-                <Avatar className="w-8 h-8">
+                <Avatar className="size-8">
                   <AvatarImage src={user.avatarUrl} alt={user.displayName} />
                   <AvatarFallback>{user.displayName.charAt(0).toUpperCase()}</AvatarFallback>
                 </Avatar>
               ) : (
-                <div className="w-8 h-8 rounded-full bg-muted flex items-center justify-center">
-                  <User className="w-4 h-4" />
+                <div className="size-8 rounded-full bg-muted flex items-center justify-center">
+                  <User className="size-4" />
                 </div>
               )}
             </button>

--- a/packages/frontend/src/components/challenge-card.tsx
+++ b/packages/frontend/src/components/challenge-card.tsx
@@ -48,7 +48,7 @@ export function ChallengeCard({ challenge }: { challenge: ChallengeProgress }) {
       `}
     >
       {/* Icon */}
-      <div className="text-2xl shrink-0 w-10 h-10 flex items-center justify-center rounded-lg bg-muted/30">
+      <div className="text-2xl shrink-0 size-10 flex items-center justify-center rounded-lg bg-muted/30">
         {challenge.icon}
       </div>
 

--- a/packages/frontend/src/components/cron-autocomplete.tsx
+++ b/packages/frontend/src/components/cron-autocomplete.tsx
@@ -153,7 +153,7 @@ export function CronAutocomplete({ id, value, onChange, placeholder, autoFocus }
           }}
           className="absolute inset-y-0 right-0 flex items-center px-2 text-muted-foreground hover:text-foreground transition-colors"
         >
-          <ChevronDown className={cn('h-4 w-4 transition-transform', open && 'rotate-180')} />
+          <ChevronDown className={cn('size-4 transition-transform', open && 'rotate-180')} />
         </button>
       </div>
 
@@ -194,7 +194,7 @@ export function CronAutocomplete({ id, value, onChange, placeholder, autoFocus }
                       isActive ? 'bg-primary/15 text-foreground' : 'text-foreground/90'
                     )}
                   >
-                    <Check className={cn('h-4 w-4 shrink-0', isSelected ? 'opacity-100 text-primary' : 'opacity-0')} />
+                    <Check className={cn('size-4 shrink-0', isSelected ? 'opacity-100 text-primary' : 'opacity-0')} />
                     <div className="flex-1 min-w-0">
                       <div className="truncate">{t(preset.labelKey)}</div>
                       <div className="text-xs text-muted-foreground font-mono truncate">{preset.expression}</div>

--- a/packages/frontend/src/components/discord-setup-instructions.tsx
+++ b/packages/frontend/src/components/discord-setup-instructions.tsx
@@ -36,15 +36,15 @@ export function DiscordSetupInstructions() {
     <div className="rounded-md border border-border/60 bg-muted/20 p-3 space-y-3 text-sm">
       <ol className="space-y-3">
         <li className="flex items-start gap-3">
-          <div className="flex items-center justify-center w-7 h-7 rounded-full bg-primary/10 border border-primary/20 text-primary shrink-0">
-            <UserPlus className="w-3.5 h-3.5" />
+          <div className="flex items-center justify-center size-7 rounded-full bg-primary/10 border border-primary/20 text-primary shrink-0">
+            <UserPlus className="size-3.5" />
           </div>
           <div className="flex-1 min-w-0 space-y-2">
             <p className="text-sm">{t('discordSetup.step1')}</p>
             {enabled && inviteUrl && (
               <Button asChild size="sm" variant="secondary">
                 <a href={inviteUrl} target="_blank" rel="noopener noreferrer">
-                  <ExternalLink className="w-3.5 h-3.5" />
+                  <ExternalLink className="size-3.5" />
                   {t('discordSetup.inviteBot')}
                 </a>
               </Button>
@@ -57,8 +57,8 @@ export function DiscordSetupInstructions() {
           </div>
         </li>
         <li className="flex items-start gap-3">
-          <div className="flex items-center justify-center w-7 h-7 rounded-full bg-primary/10 border border-primary/20 text-primary shrink-0">
-            <Terminal className="w-3.5 h-3.5" />
+          <div className="flex items-center justify-center size-7 rounded-full bg-primary/10 border border-primary/20 text-primary shrink-0">
+            <Terminal className="size-3.5" />
           </div>
           <div className="flex-1 min-w-0">
             <p className="text-sm">

--- a/packages/frontend/src/components/empty-state.tsx
+++ b/packages/frontend/src/components/empty-state.tsx
@@ -69,10 +69,10 @@ export function EmptyState({
 
       <div className="relative z-10 flex flex-col items-center max-w-sm">
         <div className={cn(
-          'w-14 h-14 rounded-full bg-card/60 border border-border/60 backdrop-blur-sm flex items-center justify-center mb-4',
+          'size-14 rounded-full bg-card/60 border border-border/60 backdrop-blur-sm flex items-center justify-center mb-4',
           ringTone,
         )}>
-          <Icon className="w-7 h-7" />
+          <Icon className="size-7" />
         </div>
         <h3 className="text-lg font-heading font-semibold mb-1">{title}</h3>
         <p className="text-sm text-muted-foreground">{description}</p>
@@ -84,7 +84,7 @@ export function EmptyState({
                 onClick={action.onClick}
                 disabled={action.loading}
               >
-                {ActionIcon && <ActionIcon className={`w-4 h-4 ${action.loading ? 'animate-spin' : ''}`} />}
+                {ActionIcon && <ActionIcon className={`size-4 ${action.loading ? 'animate-spin' : ''}`} />}
                 {action.label}
               </Button>
             )}
@@ -93,7 +93,7 @@ export function EmptyState({
                 variant="ghost"
                 onClick={secondaryAction.onClick}
               >
-                {SecondaryActionIcon && <SecondaryActionIcon className="w-4 h-4" />}
+                {SecondaryActionIcon && <SecondaryActionIcon className="size-4" />}
                 {secondaryAction.label}
               </Button>
             )}

--- a/packages/frontend/src/components/game-grid.tsx
+++ b/packages/frontend/src/components/game-grid.tsx
@@ -282,7 +282,7 @@ export function GameGrid({ games, loading, filters, onToggleMultiplayer, onToggl
               sort, genres, gamesOnly, controllerOnly) into a drawer. */}
           <div className="flex items-center gap-2">
             <div className="relative flex-1 min-w-0" role="search">
-              <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground pointer-events-none" />
               <Input
                 type="search"
                 inputMode="search"
@@ -304,7 +304,7 @@ export function GameGrid({ games, loading, filters, onToggleMultiplayer, onToggl
                   className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
                   aria-label={t('group.clearSearch')}
                 >
-                  <X className="w-4 h-4" />
+                  <X className="size-4" />
                 </button>
               )}
             </div>
@@ -316,7 +316,7 @@ export function GameGrid({ games, loading, filters, onToggleMultiplayer, onToggl
               aria-haspopup="dialog"
               aria-expanded={filtersDrawerOpen}
             >
-              <SlidersHorizontal className="w-3.5 h-3.5" />
+              <SlidersHorizontal className="size-3.5" />
               <span className="hidden sm:inline">{t('group.moreFilters')}</span>
               {advancedFilterCount > 0 && (
                 <Badge variant="secondary" className="ml-0.5 h-4 px-1.5 text-[10px]">
@@ -338,7 +338,7 @@ export function GameGrid({ games, loading, filters, onToggleMultiplayer, onToggl
               className="gap-1.5"
               aria-pressed={filters.multiplayerOnly}
             >
-              <Users className="w-3.5 h-3.5" />
+              <Users className="size-3.5" />
               {t('group.multiplayerOnly')}
             </Button>
             <Button
@@ -348,7 +348,7 @@ export function GameGrid({ games, loading, filters, onToggleMultiplayer, onToggl
               className="gap-1.5"
               aria-pressed={filters.coopOnly}
             >
-              <Handshake className="w-3.5 h-3.5" />
+              <Handshake className="size-3.5" />
               {t('group.coopOnly')}
             </Button>
           </div>
@@ -358,7 +358,7 @@ export function GameGrid({ games, loading, filters, onToggleMultiplayer, onToggl
               so all presets stay reachable without wrapping. */}
           <div className="flex gap-1.5 overflow-x-auto scrollbar-none -mx-1 px-1 pb-0.5">
             <span className="text-[11px] uppercase tracking-wider text-muted-foreground font-semibold flex items-center gap-1 shrink-0 pr-1">
-              <Sparkles className="w-3 h-3" />
+              <Sparkles className="size-3" />
               {t('filterPresets.label')}
             </span>
             {FILTER_PRESETS.map((preset) => {
@@ -376,7 +376,7 @@ export function GameGrid({ games, loading, filters, onToggleMultiplayer, onToggl
                       : 'bg-secondary/60 text-secondary-foreground hover:bg-secondary'
                   }`}
                 >
-                  <Icon className="w-3 h-3" />
+                  <Icon className="size-3" />
                   {t(preset.labelKey)}
                 </button>
               )
@@ -394,9 +394,9 @@ export function GameGrid({ games, loading, filters, onToggleMultiplayer, onToggl
                   className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground hover:text-foreground"
                   aria-label={t('group.clearFilter', { name: `Metacritic ${filters.minMetacritic}+` })}
                 >
-                  <Star className="w-3 h-3" />
+                  <Star className="size-3" />
                   {filters.minMetacritic}+
-                  <X className="w-3 h-3" />
+                  <X className="size-3" />
                 </button>
               )}
               {filters.controllerOnly && (
@@ -406,9 +406,9 @@ export function GameGrid({ games, loading, filters, onToggleMultiplayer, onToggl
                   className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground hover:text-foreground"
                   aria-label={t('group.clearFilter', { name: t('group.controllerSupport') })}
                 >
-                  <Gamepad2 className="w-3 h-3" />
+                  <Gamepad2 className="size-3" />
                   {t('group.controllerSupport')}
-                  <X className="w-3 h-3" />
+                  <X className="size-3" />
                 </button>
               )}
               {!filters.gamesOnly && (
@@ -418,9 +418,9 @@ export function GameGrid({ games, loading, filters, onToggleMultiplayer, onToggl
                   className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground hover:text-foreground"
                   aria-label={t('group.clearFilter', { name: t('group.gamesOnly') })}
                 >
-                  <Monitor className="w-3 h-3" />
+                  <Monitor className="size-3" />
                   {t('group.includeDLC')}
-                  <X className="w-3 h-3" />
+                  <X className="size-3" />
                 </button>
               )}
               {filters.sortBy !== 'popularity' && (
@@ -430,9 +430,9 @@ export function GameGrid({ games, loading, filters, onToggleMultiplayer, onToggl
                   className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground hover:text-foreground"
                   aria-label={t('group.clearFilter', { name: t('group.sortBy') })}
                 >
-                  <TrendingUp className="w-3 h-3" />
+                  <TrendingUp className="size-3" />
                   {t(`group.sort_${filters.sortBy}`)}
-                  <X className="w-3 h-3" />
+                  <X className="size-3" />
                 </button>
               )}
               {filters.selectedGenres.length > 0 && (
@@ -443,7 +443,7 @@ export function GameGrid({ games, loading, filters, onToggleMultiplayer, onToggl
                   aria-label={t('group.clearGenres')}
                 >
                   {t('group.genres')} · {filters.selectedGenres.length}
-                  <X className="w-3 h-3" />
+                  <X className="size-3" />
                 </button>
               )}
             </div>
@@ -464,7 +464,7 @@ export function GameGrid({ games, loading, filters, onToggleMultiplayer, onToggl
             {/* Metacritic */}
             <section>
               <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider flex items-center gap-1 mb-2">
-                <Star className="w-3 h-3" />
+                <Star className="size-3" />
                 {t('group.metacritic')}
               </h3>
               <div className="flex flex-wrap items-center gap-1.5">
@@ -486,7 +486,7 @@ export function GameGrid({ games, loading, filters, onToggleMultiplayer, onToggl
             {/* Sort */}
             <section>
               <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider flex items-center gap-1 mb-2">
-                <TrendingUp className="w-3 h-3" />
+                <TrendingUp className="size-3" />
                 {t('group.sortBy')}
               </h3>
               <div className="flex flex-wrap items-center gap-1.5">
@@ -518,7 +518,7 @@ export function GameGrid({ games, loading, filters, onToggleMultiplayer, onToggl
                   className="gap-1.5"
                   aria-pressed={filters.gamesOnly}
                 >
-                  <Monitor className="w-3.5 h-3.5" />
+                  <Monitor className="size-3.5" />
                   {t('group.gamesOnly')}
                 </Button>
                 <Button
@@ -528,7 +528,7 @@ export function GameGrid({ games, loading, filters, onToggleMultiplayer, onToggl
                   className="gap-1.5"
                   aria-pressed={filters.controllerOnly}
                 >
-                  <Gamepad2 className="w-3.5 h-3.5" />
+                  <Gamepad2 className="size-3.5" />
                   {t('group.controllerSupport')}
                 </Button>
               </div>
@@ -543,7 +543,7 @@ export function GameGrid({ games, loading, filters, onToggleMultiplayer, onToggl
                   onClick={() => setGenreExpanded(!genreExpanded)}
                   aria-expanded={genreExpanded}
                 >
-                  <ChevronDown className={`w-3 h-3 transition-transform ${genreExpanded ? 'rotate-180' : ''}`} />
+                  <ChevronDown className={`size-3 transition-transform ${genreExpanded ? 'rotate-180' : ''}`} />
                   {t('group.genres')}
                   {filters.selectedGenres.length > 0 && (
                     <Badge variant="secondary" className="ml-1 h-4 px-1.5 text-xs">
@@ -600,7 +600,7 @@ export function GameGrid({ games, loading, filters, onToggleMultiplayer, onToggl
       {!loading && hiddenByMetacritic > 0 && (
         <div className="flex items-center justify-between gap-2 rounded-md border border-border/60 bg-muted/40 px-3 py-1.5 text-xs text-muted-foreground">
           <span className="flex items-center gap-1.5">
-            <Star className="w-3.5 h-3.5 shrink-0" />
+            <Star className="size-3.5 shrink-0" />
             {t('group.metacriticHidden', { count: hiddenByMetacritic })}
           </span>
           <Button
@@ -634,15 +634,15 @@ export function GameGrid({ games, loading, filters, onToggleMultiplayer, onToggl
           hint={(
             <ul className="space-y-2 text-xs text-muted-foreground">
               <li className="flex items-start gap-2">
-                <ShieldAlert className="w-3.5 h-3.5 text-warning mt-0.5 shrink-0" />
+                <ShieldAlert className="size-3.5 text-warning mt-0.5 shrink-0" />
                 <span>{t('group.noCommonGamesHint1')}</span>
               </li>
               <li className="flex items-start gap-2">
-                <EyeOff className="w-3.5 h-3.5 text-warning mt-0.5 shrink-0" />
+                <EyeOff className="size-3.5 text-warning mt-0.5 shrink-0" />
                 <span>{t('group.noCommonGamesHint2')}</span>
               </li>
               <li className="flex items-start gap-2">
-                <Users className="w-3.5 h-3.5 text-warning mt-0.5 shrink-0" />
+                <Users className="size-3.5 text-warning mt-0.5 shrink-0" />
                 <span>{t('group.noCommonGamesHint3')}</span>
               </li>
             </ul>
@@ -778,7 +778,7 @@ function GameCard({ game, t }: { game: Game; t: (key: string, options?: Record<s
         <Tooltip>
           <TooltipTrigger asChild>
             <span className="absolute top-1 right-1 text-xs bg-black/70 text-white px-1.5 py-0.5 rounded flex items-center gap-0.5 cursor-help">
-              <Users className="w-2.5 h-2.5" />
+              <Users className="size-2.5" />
               {game.ownerCount}/{game.totalMembers}
             </span>
           </TooltipTrigger>
@@ -797,11 +797,11 @@ function GameCard({ game, t }: { game: Game; t: (key: string, options?: Record<s
             onClick={handleWishlistClick}
             aria-label={isWishlisted ? t('wishlist.removeLabel') : t('wishlist.addLabel')}
             aria-pressed={isWishlisted}
-            className={`absolute ${game.ownerCount < game.totalMembers ? 'top-8' : 'top-1'} right-1 flex h-7 w-7 items-center justify-center rounded-full bg-black/60 backdrop-blur-sm transition-all hover:bg-black/80 ${
+            className={`absolute ${game.ownerCount < game.totalMembers ? 'top-8' : 'top-1'} right-1 flex size-7 items-center justify-center rounded-full bg-black/60 backdrop-blur-sm transition-all hover:bg-black/80 ${
               isWishlisted ? 'text-reward' : 'text-white/60 hover:text-white'
             }`}
           >
-            <Star className={`w-3.5 h-3.5 ${isWishlisted ? 'fill-current' : ''}`} />
+            <Star className={`size-3.5 ${isWishlisted ? 'fill-current' : ''}`} />
           </button>
         </TooltipTrigger>
         <TooltipContent side="left" className="text-xs">
@@ -818,7 +818,7 @@ function GameCard({ game, t }: { game: Game; t: (key: string, options?: Record<s
           <Tooltip>
             <TooltipTrigger asChild>
               <span className="text-xs bg-black/70 text-white px-1 py-0.5 rounded cursor-help">
-                <Gamepad2 className="w-2.5 h-2.5" />
+                <Gamepad2 className="size-2.5" />
               </span>
             </TooltipTrigger>
             <TooltipContent>

--- a/packages/frontend/src/components/game-recommendations.tsx
+++ b/packages/frontend/src/components/game-recommendations.tsx
@@ -57,7 +57,7 @@ export function GameRecommendations({ groupId, onStartVote, compact = false }: G
       return (
         <div className="space-y-2">
           <h2 className="font-semibold flex items-center gap-2 text-sm">
-            <Lightbulb className="w-4 h-4" />
+            <Lightbulb className="size-4" />
             {t('recommendations.title')}
           </h2>
           {content}
@@ -68,7 +68,7 @@ export function GameRecommendations({ groupId, onStartVote, compact = false }: G
       <Card>
         <CardHeader className="pb-3">
           <h2 className="font-semibold flex items-center gap-2 text-sm">
-            <Lightbulb className="w-4 h-4" />
+            <Lightbulb className="size-4" />
             {t('recommendations.title')}
           </h2>
         </CardHeader>
@@ -103,7 +103,7 @@ export function GameRecommendations({ groupId, onStartVote, compact = false }: G
                 className="w-full mt-2"
                 onClick={onStartVote}
               >
-                <Vote className="w-4 h-4 mr-2" />
+                <Vote className="size-4 mr-2" />
                 {t('recommendations.startVote')}
               </Button>
             </TooltipTrigger>

--- a/packages/frontend/src/components/group-sidebar.tsx
+++ b/packages/frontend/src/components/group-sidebar.tsx
@@ -144,17 +144,17 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
                 <Button
                   variant="ghost"
                   size="icon"
-                  className={`h-8 w-8 min-h-[44px] min-w-[44px] text-muted-foreground hover:text-destructive active:bg-accent/10 ${compact ? 'opacity-100' : 'opacity-0 group-hover/history:opacity-100'} transition-opacity shrink-0`}
+                  className={`size-8 min-h-[44px] min-w-[44px] text-muted-foreground hover:text-destructive active:bg-accent/10 ${compact ? 'opacity-100' : 'opacity-0 group-hover/history:opacity-100'} transition-opacity shrink-0`}
                   onClick={() => setConfirmDeleteHistory(session)}
                   aria-label={t('group.deleteHistory')}
                 >
-                  <Trash2 className="w-3.5 h-3.5" />
+                  <Trash2 className="size-3.5" />
                 </Button>
               </TooltipTrigger>
               <TooltipContent>{t('group.deleteHistory')}</TooltipContent>
             </Tooltip>
           ) : index === 0 ? (
-            <Trophy className="w-4 h-4 text-primary shrink-0" />
+            <Trophy className="size-4 text-primary shrink-0" />
           ) : null}
         </div>
       ))}
@@ -174,7 +174,7 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
       }}
       className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-primary transition-colors w-full text-left px-1"
     >
-      <Lock className="w-3 h-3 shrink-0" />
+      <Lock className="size-3 shrink-0" />
       <span>{t('group.historyUpgradeCta')}</span>
     </button>
   )
@@ -185,12 +185,12 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
     <div className="flex items-center justify-between">
       <div className="flex items-center gap-2">
         <h2 className="font-semibold flex items-center gap-2 text-sm">
-          <Users className="w-4 h-4" />
+          <Users className="size-4" />
           {t('group.members', { count: members.length })}
         </h2>
         {onlineCount > 0 && (
           <Badge variant="secondary" className="text-[10px] px-1.5 py-0 gap-1 font-normal">
-            <span className="w-1.5 h-1.5 rounded-full bg-online animate-pulse" />
+            <span className="size-1.5 rounded-full bg-online animate-pulse" />
             {t('groups.onlineCount', { count: onlineCount })}
           </Badge>
         )}
@@ -198,8 +198,8 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
       {!compact && (
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button variant="ghost" size="icon" onClick={onSync} disabled={syncing} aria-label={t('group.syncLibraries')} className="h-11 w-11 min-h-[44px] min-w-[44px] active:bg-accent/10">
-              <RefreshCw className={`w-4 h-4 ${syncing ? 'animate-spin text-primary' : ''}`} />
+            <Button variant="ghost" size="icon" onClick={onSync} disabled={syncing} aria-label={t('group.syncLibraries')} className="size-11 min-h-[44px] min-w-[44px] active:bg-accent/10">
+              <RefreshCw className={`size-4 ${syncing ? 'animate-spin text-primary' : ''}`} />
             </Button>
           </TooltipTrigger>
           <TooltipContent>{t('group.syncLibraries')}</TooltipContent>
@@ -225,12 +225,12 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
               className={`relative shrink-0 rounded-full ${isSelf ? 'cursor-default' : 'hover:ring-2 hover:ring-primary/40 transition-shadow cursor-pointer'}`}
               aria-label={isSelf ? member.displayName : `Voir le profil de ${member.displayName}`}
             >
-              <Avatar className="w-8 h-8">
+              <Avatar className="size-8">
                 <AvatarImage src={member.avatarUrl} alt={member.displayName} />
                 <AvatarFallback>{member.displayName.charAt(0).toUpperCase()}</AvatarFallback>
               </Avatar>
               <span
-                className={`absolute bottom-0 right-0 w-2.5 h-2.5 rounded-full border-2 ${compact ? 'border-background' : 'border-card'} ${isOnline ? 'bg-online animate-pulse' : 'bg-muted-foreground/40'}`}
+                className={`absolute bottom-0 right-0 size-2.5 rounded-full border-2 ${compact ? 'border-background' : 'border-card'} ${isOnline ? 'bg-online animate-pulse' : 'bg-muted-foreground/40'}`}
                 aria-label={presenceLabel}
               />
             </button>
@@ -255,7 +255,7 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
                   </TooltipContent>
                 </Tooltip>
                 {member.role === 'owner' && (
-                  <Crown className="w-4 h-4 text-reward shrink-0" aria-label={t('group.roleOwner')} />
+                  <Crown className="size-4 text-reward shrink-0" aria-label={t('group.roleOwner')} />
                 )}
               </div>
               <p className={`text-[11px] leading-tight ${isOnline ? 'text-emerald-500' : 'text-muted-foreground'}`}>
@@ -271,11 +271,11 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
                   <Button
                     variant="ghost"
                     size="icon"
-                    className={`h-11 w-11 min-h-[44px] min-w-[44px] text-muted-foreground hover:text-destructive active:bg-accent/10 ${compact ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'} transition-opacity`}
+                    className={`size-11 min-h-[44px] min-w-[44px] text-muted-foreground hover:text-destructive active:bg-accent/10 ${compact ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'} transition-opacity`}
                     onClick={() => setConfirmKick(member)}
                     aria-label={t('group.kickMember', { name: member.displayName })}
                   >
-                    <UserMinus className="w-4 h-4" />
+                    <UserMinus className="size-4" />
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent side="left" className="text-xs">
@@ -298,7 +298,7 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
           onClick={onSync}
           disabled={syncing}
         >
-          <RefreshCw className={`w-4 h-4 mr-2 ${syncing ? 'animate-spin text-primary' : ''}`} />
+          <RefreshCw className={`size-4 mr-2 ${syncing ? 'animate-spin text-primary' : ''}`} />
           {t('group.syncLibraries')}
         </Button>
       )}
@@ -309,7 +309,7 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
           className="w-full"
           onClick={() => { setRenameName(groupName); setRenameOpen(true) }}
         >
-          <Pencil className="w-4 h-4 mr-2" />
+          <Pencil className="size-4 mr-2" />
           {t('group.renameGroup')}
         </Button>
       )}
@@ -320,7 +320,7 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
           className="w-full"
           onClick={onGenerateInvite}
         >
-          <UserPlus className="w-4 h-4 mr-2" />
+          <UserPlus className="size-4 mr-2" />
           {t('group.inviteFriend')}
         </Button>
       )}
@@ -338,9 +338,9 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
             onClick={() => onToggleNotifications(!enabled)}
           >
             {enabled ? (
-              <Bell className="w-4 h-4 mr-2" />
+              <Bell className="size-4 mr-2" />
             ) : (
-              <BellOff className="w-4 h-4 mr-2" />
+              <BellOff className="size-4 mr-2" />
             )}
             {enabled ? t('group.notificationsEnabled') : t('group.notificationsDisabled')}
           </Button>
@@ -359,7 +359,7 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
               setAutoVoteOpen(true)
             }}
           >
-            <CalendarClock className="w-4 h-4 mr-2" />
+            <CalendarClock className="size-4 mr-2" />
             {t('group.autoVote')}
             {autoVoteSchedule && (
               <Badge variant="secondary" className="ml-2 text-[10px] px-1.5 py-0">{t('group.autoVoteEnabled')}</Badge>
@@ -374,7 +374,7 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
               window.location.href = '/subscription?from=auto_vote'
             }}
           >
-            <Lock className="w-4 h-4 mr-2 text-muted-foreground" />
+            <Lock className="size-4 mr-2 text-muted-foreground" />
             {t('group.autoVote')}
             <Badge variant="secondary" className="ml-2 text-[10px] px-1.5 py-0">{t('premium.featureLocked')}</Badge>
           </Button>
@@ -388,7 +388,7 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
             className="w-full text-muted-foreground hover:text-destructive hover:bg-destructive/10"
             onClick={() => setConfirmLeave(true)}
           >
-            <LogOut className="w-4 h-4 mr-2" />
+            <LogOut className="size-4 mr-2" />
             {t('group.leaveGroup')}
           </Button>
         )}
@@ -398,7 +398,7 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
             className="w-full text-muted-foreground hover:text-destructive hover:bg-destructive/10"
             onClick={() => setConfirmDelete(true)}
           >
-            <Trash2 className="w-4 h-4 mr-2" />
+            <Trash2 className="size-4 mr-2" />
             {t('group.deleteGroup')}
           </Button>
         )}
@@ -414,7 +414,7 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
           {historySection && (
             <div className="space-y-2">
               <h2 className="font-semibold flex items-center gap-2 text-sm">
-                <History className="w-4 h-4" />
+                <History className="size-4" />
                 {t('group.history')}
               </h2>
               {historySection}
@@ -434,7 +434,7 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
             <Card>
               <CardHeader className="p-3 sm:p-4 pb-2 sm:pb-3">
                 <h2 className="font-semibold flex items-center gap-2 text-sm">
-                  <History className="w-4 h-4" />
+                  <History className="size-4" />
                   {t('group.history')}
                 </h2>
               </CardHeader>

--- a/packages/frontend/src/components/group-stats.tsx
+++ b/packages/frontend/src/components/group-stats.tsx
@@ -47,14 +47,14 @@ export function GroupStats({ groupId, compact = false }: GroupStatsProps) {
       {/* Summary counters */}
       <div className="grid grid-cols-2 gap-3">
         <div className="flex items-center gap-2 rounded-md bg-muted/50 p-2.5">
-          <Vote className="w-4 h-4 text-primary shrink-0" />
+          <Vote className="size-4 text-primary shrink-0" />
           <div>
             <p className="text-lg font-bold leading-tight">{stats.totalSessions}</p>
             <p className="text-xs text-muted-foreground">{t('stats.sessions')}</p>
           </div>
         </div>
         <div className="flex items-center gap-2 rounded-md bg-muted/50 p-2.5">
-          <BarChart3 className="w-4 h-4 text-primary shrink-0" />
+          <BarChart3 className="size-4 text-primary shrink-0" />
           <div>
             <p className="text-lg font-bold leading-tight">{stats.totalVotes}</p>
             <p className="text-xs text-muted-foreground">{t('stats.votes')}</p>
@@ -66,7 +66,7 @@ export function GroupStats({ groupId, compact = false }: GroupStatsProps) {
       {stats.topGames.length > 0 && (
         <div className="space-y-2">
           <h3 className="text-xs font-semibold uppercase text-muted-foreground tracking-wide flex items-center gap-1.5">
-            <Trophy className="w-3.5 h-3.5" />
+            <Trophy className="size-3.5" />
             {t('stats.topGames')}
           </h3>
           <div className="space-y-1.5">
@@ -102,13 +102,13 @@ export function GroupStats({ groupId, compact = false }: GroupStatsProps) {
       {stats.memberParticipation.length > 0 && (
         <div className="space-y-2">
           <h3 className="text-xs font-semibold uppercase text-muted-foreground tracking-wide flex items-center gap-1.5">
-            <Users className="w-3.5 h-3.5" />
+            <Users className="size-3.5" />
             {t('stats.participation')}
           </h3>
           <div className="space-y-1.5">
             {stats.memberParticipation.map((member) => (
               <div key={member.userId} className="flex items-center gap-2.5">
-                <Avatar className="w-6 h-6 shrink-0">
+                <Avatar className="size-6 shrink-0">
                   <AvatarImage src={member.avatarUrl} alt={member.displayName} />
                   <AvatarFallback className="text-xs">{member.displayName.charAt(0).toUpperCase()}</AvatarFallback>
                 </Avatar>
@@ -133,7 +133,7 @@ export function GroupStats({ groupId, compact = false }: GroupStatsProps) {
       {stats.recentWinners.length > 0 && (
         <div className="space-y-2">
           <h3 className="text-xs font-semibold uppercase text-muted-foreground tracking-wide flex items-center gap-1.5">
-            <Trophy className="w-3.5 h-3.5" />
+            <Trophy className="size-3.5" />
             {t('stats.recentWinners')}
           </h3>
           <div className="space-y-1.5">
@@ -175,10 +175,10 @@ export function GroupStats({ groupId, compact = false }: GroupStatsProps) {
           aria-controls="group-stats-panel-compact"
         >
           <h2 className="font-semibold flex items-center gap-2 text-sm">
-            <BarChart3 className="w-4 h-4" aria-hidden="true" />
+            <BarChart3 className="size-4" aria-hidden="true" />
             {t('stats.title')}
           </h2>
-          {expanded ? <ChevronUp className="w-4 h-4 text-muted-foreground" aria-hidden="true" /> : <ChevronDown className="w-4 h-4 text-muted-foreground" aria-hidden="true" />}
+          {expanded ? <ChevronUp className="size-4 text-muted-foreground" aria-hidden="true" /> : <ChevronDown className="size-4 text-muted-foreground" aria-hidden="true" />}
         </button>
         {expanded && <div id="group-stats-panel-compact">{content}</div>}
       </div>
@@ -196,10 +196,10 @@ export function GroupStats({ groupId, compact = false }: GroupStatsProps) {
           aria-controls="group-stats-panel"
         >
           <h2 className="font-semibold flex items-center gap-2 text-sm">
-            <BarChart3 className="w-4 h-4" aria-hidden="true" />
+            <BarChart3 className="size-4" aria-hidden="true" />
             {t('stats.title')}
           </h2>
-          {expanded ? <ChevronUp className="w-4 h-4 text-muted-foreground" aria-hidden="true" /> : <ChevronDown className="w-4 h-4 text-muted-foreground" aria-hidden="true" />}
+          {expanded ? <ChevronUp className="size-4 text-muted-foreground" aria-hidden="true" /> : <ChevronDown className="size-4 text-muted-foreground" aria-hidden="true" />}
         </button>
       </CardHeader>
       {expanded && (

--- a/packages/frontend/src/components/invite-link.tsx
+++ b/packages/frontend/src/components/invite-link.tsx
@@ -89,12 +89,12 @@ export function InviteLink({ token, prominent = false, onContinue, continueLabel
         </code>
         <div className="flex flex-col sm:flex-row gap-2">
           <Button onClick={handleDiscordShare} className="gap-2 sm:flex-1">
-            <DiscordIcon className="w-4 h-4" />
+            <DiscordIcon className="size-4" />
             {t('invite.shareOnDiscord')}
           </Button>
           {canShare && (
             <Button variant="secondary" onClick={handleShare} aria-label={t('invite.share')}>
-              <Share2 className="w-4 h-4" />
+              <Share2 className="size-4" />
             </Button>
           )}
           <Button variant="ghost" onClick={handleCopy}>
@@ -105,7 +105,7 @@ export function InviteLink({ token, prominent = false, onContinue, continueLabel
           <div className="mt-3 flex justify-end">
             <Button variant="ghost" size="sm" onClick={onContinue}>
               {continueLabel ?? t('invite.continueToGroup')}
-              <ChevronRight className="w-4 h-4" />
+              <ChevronRight className="size-4" />
             </Button>
           </div>
         )}
@@ -124,11 +124,11 @@ export function InviteLink({ token, prominent = false, onContinue, continueLabel
           {t('invite.copy')}
         </Button>
         <Button size="sm" variant="secondary" onClick={handleDiscordShare} aria-label={t('invite.discord')}>
-          <DiscordIcon className="w-3.5 h-3.5" />
+          <DiscordIcon className="size-3.5" />
         </Button>
         {canShare && (
           <Button size="sm" variant="secondary" onClick={handleShare} aria-label={t('invite.share')}>
-            <Share2 className="w-3.5 h-3.5" />
+            <Share2 className="size-3.5" />
           </Button>
         )}
       </div>

--- a/packages/frontend/src/components/notification-bell.tsx
+++ b/packages/frontend/src/components/notification-bell.tsx
@@ -137,7 +137,7 @@ export function NotificationBell() {
           animate={{ rotate: [0, 12, -12, 8, -8, 0] }}
           transition={{ duration: 0.4 }}
         >
-          <Bell className="w-5 h-5" aria-hidden="true" />
+          <Bell className="size-5" aria-hidden="true" />
         </motion.div>
         <AnimatePresence>
           {unreadCount > 0 && (
@@ -146,7 +146,7 @@ export function NotificationBell() {
               animate={{ scale: [0, 1.2, 1] }}
               exit={{ scale: 0 }}
               aria-hidden="true"
-              className="absolute top-1.5 right-1.5 w-2.5 h-2.5 bg-destructive rounded-full"
+              className="absolute top-1.5 right-1.5 size-2.5 bg-destructive rounded-full"
             />
           )}
         </AnimatePresence>
@@ -179,7 +179,7 @@ export function NotificationBell() {
                     onClick={() => markAllAsRead()}
                     className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
                   >
-                    <CheckCheck className="w-3.5 h-3.5" aria-hidden="true" />
+                    <CheckCheck className="size-3.5" aria-hidden="true" />
                     {t('notifications.markAllRead')}
                   </button>
                 )}
@@ -195,7 +195,7 @@ export function NotificationBell() {
                   onClick={handleEnableNotifications}
                   className="flex items-center gap-2 px-3 py-2 border-b border-border text-xs text-muted-foreground hover:text-foreground hover:bg-accent/30 transition-colors"
                 >
-                  <BellRing className="w-3.5 h-3.5 text-primary" aria-hidden="true" />
+                  <BellRing className="size-3.5 text-primary" aria-hidden="true" />
                   {t('pwa.enableNotifications')}
                 </button>
               )}
@@ -236,7 +236,7 @@ export function NotificationBell() {
                           </p>
                         </div>
                         {!notification.read && (
-                          <span className="w-2 h-2 bg-primary rounded-full mt-1.5 flex-shrink-0" />
+                          <span className="size-2 bg-primary rounded-full mt-1.5 flex-shrink-0" />
                         )}
                       </motion.button>
                     ))}

--- a/packages/frontend/src/components/persona-badge.tsx
+++ b/packages/frontend/src/components/persona-badge.tsx
@@ -90,7 +90,7 @@ export function PersonaBadge({ groupId, persona: initialPersona, variant = 'hero
         aria-label={t('persona.todayGroup')}
         title={persona.introMessage}
       >
-        <Sparkles className="w-3 h-3" />
+        <Sparkles className="size-3" />
         <span className="truncate max-w-[140px]">{persona.name}</span>
       </span>
     )
@@ -110,11 +110,11 @@ export function PersonaBadge({ groupId, persona: initialPersona, variant = 'hero
     >
       <div className="flex items-start gap-3">
         <div
-          className="flex items-center justify-center w-9 h-9 rounded-full shrink-0 mt-0.5"
+          className="flex items-center justify-center size-9 rounded-full shrink-0 mt-0.5"
           style={{ backgroundColor: `${color}26`, color }}
           aria-hidden="true"
         >
-          <Sparkles className="w-4 h-4" />
+          <Sparkles className="size-4" />
         </div>
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 mb-1">

--- a/packages/frontend/src/components/premium-gate.tsx
+++ b/packages/frontend/src/components/premium-gate.tsx
@@ -60,7 +60,7 @@ function PremiumGateFallback({ from, feature }: { from: PremiumFromKey; feature?
   return (
     <div className="flex flex-col items-center gap-3 py-6 px-4 rounded-lg border border-dashed border-primary/30 bg-gradient-to-b from-primary/5 to-transparent">
       <div className="flex items-center gap-2 text-foreground">
-        <Lock className="w-5 h-5 text-reward" />
+        <Lock className="size-5 text-reward" />
         <span className="text-sm font-semibold">{title}</span>
       </div>
 
@@ -74,7 +74,7 @@ function PremiumGateFallback({ from, feature }: { from: PremiumFromKey; feature?
         <ul className="text-xs text-muted-foreground space-y-1 max-w-xs w-full">
           {benefits.map((b) => (
             <li key={b} className="flex items-start gap-2">
-              <Check className="w-3.5 h-3.5 text-success shrink-0 mt-0.5" />
+              <Check className="size-3.5 text-success shrink-0 mt-0.5" />
               <span>{b}</span>
             </li>
           ))}
@@ -82,7 +82,7 @@ function PremiumGateFallback({ from, feature }: { from: PremiumFromKey; feature?
       )}
 
       <Button size="sm" onClick={handleUpgrade}>
-        <Crown className="w-4 h-4 mr-1.5 text-reward" />
+        <Crown className="size-4 mr-1.5 text-reward" />
         {t('premium.unlock')}
       </Button>
     </div>
@@ -95,7 +95,7 @@ export function PremiumLockIcon() {
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <Lock className="w-3.5 h-3.5 text-muted-foreground inline ml-1" />
+        <Lock className="size-3.5 text-muted-foreground inline ml-1" />
       </TooltipTrigger>
       <TooltipContent>{t('premium.featureLocked')}</TooltipContent>
     </Tooltip>

--- a/packages/frontend/src/components/random-pick-modal.tsx
+++ b/packages/frontend/src/components/random-pick-modal.tsx
@@ -113,14 +113,14 @@ function RandomPickContent({ games }: { games: Game[] }) {
                 onClick={reroll}
                 disabled={games.length <= 1}
               >
-                <RotateCcw className="w-4 h-4" />
+                <RotateCcw className="size-4" />
                 {t('randomPick.reroll')}
               </Button>
 
               {Number.isInteger(currentGame.steamAppId) && currentGame.steamAppId > 0 && (
                 <Button variant="steam" className="w-full sm:w-auto sm:flex-1 gap-2" asChild>
                   <a href={`steam://run/${currentGame.steamAppId}`}>
-                    <ExternalLink className="w-4 h-4" />
+                    <ExternalLink className="size-4" />
                     {t('randomPick.launch')}
                   </a>
                 </Button>

--- a/packages/frontend/src/components/share-button.tsx
+++ b/packages/frontend/src/components/share-button.tsx
@@ -152,7 +152,7 @@ export function ShareButton({
         aria-expanded={open}
         className="gap-2"
       >
-        <Share2 className="w-4 h-4" />
+        <Share2 className="size-4" />
         {prominent ? t('share.promoteCta') : t('share.button')}
       </Button>
 
@@ -172,23 +172,23 @@ export function ShareButton({
             )}
           >
             <ShareMenuItem
-              icon={<Link2 className="w-4 h-4" />}
+              icon={<Link2 className="size-4" />}
               label={t('share.copyLink')}
               onClick={handleCopyLink}
             />
             <ShareMenuItem
-              icon={<Twitter className="w-4 h-4" />}
+              icon={<Twitter className="size-4" />}
               label={t('share.shareOnTwitter')}
               onClick={handleTwitterShare}
             />
             <ShareMenuItem
-              icon={<DiscordIcon className="w-4 h-4" />}
+              icon={<DiscordIcon className="size-4" />}
               label={t('share.shareOnDiscord')}
               onClick={handleDiscordShare}
             />
             {canWebShare && (
               <ShareMenuItem
-                icon={<Share2 className="w-4 h-4" />}
+                icon={<Share2 className="size-4" />}
                 label={t('share.webShare')}
                 onClick={handleWebShare}
               />
@@ -220,7 +220,7 @@ function ShareMenuItem({
         'focus-visible:bg-accent focus-visible:text-accent-foreground focus-visible:ring-[2px] focus-visible:ring-ring/60'
       )}
     >
-      <span className="flex h-4 w-4 items-center justify-center text-muted-foreground">
+      <span className="flex size-4 items-center justify-center text-muted-foreground">
         {icon}
       </span>
       <span className="flex-1 text-left">{label}</span>

--- a/packages/frontend/src/components/tonight-pick-hero.tsx
+++ b/packages/frontend/src/components/tonight-pick-hero.tsx
@@ -81,14 +81,14 @@ export function TonightPickHero({
           className="absolute inset-0 bg-gradient-to-r from-primary/20 via-primary/5 to-transparent pointer-events-none"
         />
         <div className="relative p-4 sm:p-6 flex flex-col sm:flex-row gap-4 sm:gap-5 items-start sm:items-center">
-          <div className="shrink-0 w-12 h-12 rounded-full bg-primary/15 flex items-center justify-center">
-            <Vote className="w-6 h-6 text-primary" />
+          <div className="shrink-0 size-12 rounded-full bg-primary/15 flex items-center justify-center">
+            <Vote className="size-6 text-primary" />
           </div>
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 mb-1.5">
-              <span className="relative flex h-2 w-2">
+              <span className="relative flex size-2">
                 <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-primary/60" />
-                <span className="relative inline-flex rounded-full h-2 w-2 bg-primary" />
+                <span className="relative inline-flex rounded-full size-2 bg-primary" />
               </span>
               <span className="text-[11px] uppercase tracking-wider text-primary font-bold">
                 {t('tonightPick.voteInProgressEyebrow')}
@@ -110,13 +110,13 @@ export function TonightPickHero({
               onClick={onJoinActiveVote}
               className="h-11 px-5 gap-2 font-heading font-bold text-base shrink-0 card-hover-glow w-full sm:w-auto"
             >
-              <Vote className="w-4 h-4" />
+              <Vote className="size-4" />
               {t('group.joinActiveVote')}
             </Button>
             {members.length > 0 && (
               <div className="flex -space-x-2 self-center sm:self-end">
                 {avatars.map((member) => (
-                  <Avatar key={member.id} className="w-6 h-6 ring-2 ring-background">
+                  <Avatar key={member.id} className="size-6 ring-2 ring-background">
                     <AvatarImage src={member.avatarUrl} alt={member.displayName} />
                     <AvatarFallback className="text-[10px]">
                       {member.displayName.charAt(0).toUpperCase()}
@@ -124,7 +124,7 @@ export function TonightPickHero({
                   </Avatar>
                 ))}
                 {members.length > 5 && (
-                  <div className="w-6 h-6 rounded-full bg-muted ring-2 ring-background flex items-center justify-center text-[9px] text-muted-foreground font-medium">
+                  <div className="size-6 rounded-full bg-muted ring-2 ring-background flex items-center justify-center text-[9px] text-muted-foreground font-medium">
                     +{members.length - 5}
                   </div>
                 )}
@@ -141,7 +141,7 @@ export function TonightPickHero({
     return (
       <div className="rounded-xl border border-border/60 bg-card/40 p-5 sm:p-6">
         <div className="flex items-center gap-2 mb-2">
-          <Sparkles className="w-4 h-4 text-primary" />
+          <Sparkles className="size-4 text-primary" />
           <span className="text-xs uppercase tracking-wider text-muted-foreground font-semibold">
             {t('tonightPick.eyebrow')}
           </span>
@@ -151,7 +151,7 @@ export function TonightPickHero({
         </h2>
         <p className="text-sm text-muted-foreground mb-4">{t('tonightPick.emptyDescription')}</p>
         <Button onClick={onStartVote} className="w-full sm:w-auto h-11 px-6">
-          <Vote className="w-4 h-4 mr-2" />
+          <Vote className="size-4 mr-2" />
           {t('group.startVote')}
         </Button>
       </div>
@@ -199,7 +199,7 @@ export function TonightPickHero({
         <div className="flex-1 min-w-0 flex flex-col justify-between gap-3">
           <div className="min-w-0">
             <div className="flex items-center gap-2 mb-1.5">
-              <Sparkles className="w-3.5 h-3.5 text-primary" />
+              <Sparkles className="size-3.5 text-primary" />
               <span className="text-[11px] uppercase tracking-wider text-primary font-bold">
                 {t('tonightPick.eyebrow')}
               </span>
@@ -209,7 +209,7 @@ export function TonightPickHero({
             </h2>
             <div className="flex items-center gap-2 mt-2 flex-wrap">
               <Badge variant="secondary" className="gap-1 text-[11px] px-2 py-0.5">
-                <ReasonIcon className="w-3 h-3" />
+                <ReasonIcon className="size-3" />
                 {t(REASON_META[reason].key)}
               </Badge>
               {game.metacriticScore !== null && (
@@ -234,7 +234,7 @@ export function TonightPickHero({
                 </Tooltip>
               )}
               <span className="text-[11px] text-muted-foreground flex items-center gap-1">
-                <Users className="w-3 h-3" />
+                <Users className="size-3" />
                 {ownershipComplete
                   ? t('tonightPick.everyoneOwns')
                   : t('group.ownerCountHint', { owned: game.ownerCount, total: game.totalMembers })}
@@ -253,7 +253,7 @@ export function TonightPickHero({
               onClick={onStartVote}
               className="h-11 px-5 gap-2 font-heading font-bold text-base shrink-0 card-hover-glow"
             >
-              <Vote className="w-4 h-4" />
+              <Vote className="size-4" />
               {t('group.startVote')}
             </Button>
             <Tooltip>
@@ -262,10 +262,10 @@ export function TonightPickHero({
                   variant="secondary"
                   size="icon"
                   onClick={onRandomPick}
-                  className="h-11 w-11 shrink-0"
+                  className="size-11 shrink-0"
                   aria-label={t('group.randomPick')}
                 >
-                  <Dices className="w-5 h-5" />
+                  <Dices className="size-5" />
                 </Button>
               </TooltipTrigger>
               <TooltipContent>{t('group.randomPick')}</TooltipContent>
@@ -274,7 +274,7 @@ export function TonightPickHero({
             <div className="flex items-center gap-2 min-w-0 ml-auto">
               <div className="flex -space-x-2">
                 {avatars.map((member) => (
-                  <Avatar key={member.id} className="w-7 h-7 ring-2 ring-background">
+                  <Avatar key={member.id} className="size-7 ring-2 ring-background">
                     <AvatarImage src={member.avatarUrl} alt={member.displayName} />
                     <AvatarFallback className="text-[10px]">
                       {member.displayName.charAt(0).toUpperCase()}
@@ -282,13 +282,13 @@ export function TonightPickHero({
                   </Avatar>
                 ))}
                 {members.length > 5 && (
-                  <div className="w-7 h-7 rounded-full bg-muted ring-2 ring-background flex items-center justify-center text-[10px] text-muted-foreground font-medium">
+                  <div className="size-7 rounded-full bg-muted ring-2 ring-background flex items-center justify-center text-[10px] text-muted-foreground font-medium">
                     +{members.length - 5}
                   </div>
                 )}
               </div>
               <span className="text-xs text-muted-foreground hidden md:inline-flex items-center gap-1">
-                <Zap className="w-3 h-3 text-primary" />
+                <Zap className="size-3 text-primary" />
                 {t('tonightPick.ready')}
               </span>
             </div>

--- a/packages/frontend/src/components/ui/avatar.tsx
+++ b/packages/frontend/src/components/ui/avatar.tsx
@@ -11,7 +11,7 @@ function Avatar({
     <AvatarPrimitive.Root
       ref={ref}
       data-slot="avatar"
-      className={cn('relative flex h-8 w-8 shrink-0 overflow-hidden rounded-full', className)}
+      className={cn('relative flex size-8 shrink-0 overflow-hidden rounded-full', className)}
       {...props}
     />
   )

--- a/packages/frontend/src/components/ui/button.tsx
+++ b/packages/frontend/src/components/ui/button.tsx
@@ -20,7 +20,7 @@ const buttonVariants = cva(
         default: 'h-10 px-4 py-2 min-h-[44px]',
         sm: 'h-9 px-3 text-xs min-h-[44px]',
         lg: 'h-12 px-8 text-base min-h-[48px]',
-        icon: 'h-10 w-10 min-h-[44px] min-w-[44px]',
+        icon: 'size-10 min-h-[44px] min-w-[44px]',
       },
     },
     defaultVariants: {

--- a/packages/frontend/src/components/ui/dialog.tsx
+++ b/packages/frontend/src/components/ui/dialog.tsx
@@ -50,9 +50,9 @@ function DialogContent({
         {children}
         <DialogPrimitive.Close
           aria-label="Fermer"
-          className="absolute right-2 top-2 inline-flex items-center justify-center h-11 w-11 min-h-[44px] min-w-[44px] rounded-md opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus-visible:ring-[3px] focus-visible:ring-ring disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground"
+          className="absolute right-2 top-2 inline-flex items-center justify-center size-11 min-h-[44px] min-w-[44px] rounded-md opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus-visible:ring-[3px] focus-visible:ring-ring disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground"
         >
-          <X className="h-4 w-4" />
+          <X className="size-4" />
           <span className="sr-only">Close</span>
         </DialogPrimitive.Close>
       </DialogPrimitive.Content>

--- a/packages/frontend/src/components/ui/dropdown-menu.tsx
+++ b/packages/frontend/src/components/ui/dropdown-menu.tsx
@@ -107,9 +107,9 @@ function DropdownMenuCheckboxItem({
       checked={checked}
       {...props}
     >
-      <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <span className="absolute left-2 flex size-3.5 items-center justify-center">
         <DropdownMenuPrimitive.ItemIndicator>
-          <CheckIcon className="h-4 w-4" />
+          <CheckIcon className="size-4" />
         </DropdownMenuPrimitive.ItemIndicator>
       </span>
       {children}
@@ -131,9 +131,9 @@ function DropdownMenuRadioItem({
       )}
       {...props}
     >
-      <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <span className="absolute left-2 flex size-3.5 items-center justify-center">
         <DropdownMenuPrimitive.ItemIndicator>
-          <CircleIcon className="h-2 w-2 fill-current" />
+          <CircleIcon className="size-2 fill-current" />
         </DropdownMenuPrimitive.ItemIndicator>
       </span>
       {children}

--- a/packages/frontend/src/components/vote-setup-dialog.tsx
+++ b/packages/frontend/src/components/vote-setup-dialog.tsx
@@ -196,7 +196,7 @@ export function VoteSetupDialog({ open, onOpenChange, members, groupId, onlineMe
           <>
             <ResponsiveDialogHeader>
               <ResponsiveDialogTitle className="flex items-center gap-2">
-                <Users className="w-5 h-5 text-primary" />
+                <Users className="size-5 text-primary" />
                 {t('voteSetup.title')}
               </ResponsiveDialogTitle>
               <ResponsiveDialogDescription>
@@ -242,12 +242,12 @@ export function VoteSetupDialog({ open, onOpenChange, members, groupId, onlineMe
                         className="size-6 sm:size-5 shrink-0"
                       />
                       <div className="relative shrink-0">
-                        <Avatar className="w-7 h-7">
+                        <Avatar className="size-7">
                           <AvatarImage src={member.avatarUrl} alt={member.displayName} />
                           <AvatarFallback>{member.displayName.charAt(0).toUpperCase()}</AvatarFallback>
                         </Avatar>
                         <span
-                          className={`absolute bottom-0 right-0 w-2 h-2 rounded-full border-2 border-card ${isOnline ? 'bg-online' : 'bg-muted-foreground/40'}`}
+                          className={`absolute bottom-0 right-0 size-2 rounded-full border-2 border-card ${isOnline ? 'bg-online' : 'bg-muted-foreground/40'}`}
                         />
                       </div>
                       <span className={`text-sm font-medium truncate ${!isOnline ? 'text-muted-foreground' : ''}`}>{member.displayName}</span>
@@ -265,12 +265,12 @@ export function VoteSetupDialog({ open, onOpenChange, members, groupId, onlineMe
                 </span>
               ) : loadingLivePreview ? (
                 <span className="flex items-center gap-2 text-muted-foreground">
-                  <Loader2 className="w-4 h-4 animate-spin" />
+                  <Loader2 className="size-4 animate-spin" />
                   {t('voteSetup.calculatingCommonGames')}
                 </span>
               ) : livePreviewCount !== null && livePreviewCount === 0 ? (
                 <span className="flex items-center gap-2 text-warning">
-                  <AlertTriangle className="w-4 h-4" />
+                  <AlertTriangle className="size-4" />
                   {t('voteSetup.noCommonGames')}
                 </span>
               ) : livePreviewCount !== null ? (
@@ -285,7 +285,7 @@ export function VoteSetupDialog({ open, onOpenChange, members, groupId, onlineMe
                 {t('voteSetup.selectedCount', { count: selectedIds.size })}
               </span>
               <Button onClick={handleNext} disabled={!canProceed || loadingPreview} className="w-full sm:w-auto">
-                {loadingPreview && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+                {loadingPreview && <Loader2 className="size-4 mr-2 animate-spin" />}
                 {t('voteSetup.next')}
               </Button>
             </div>
@@ -296,7 +296,7 @@ export function VoteSetupDialog({ open, onOpenChange, members, groupId, onlineMe
           <>
             <ResponsiveDialogHeader>
               <ResponsiveDialogTitle className="flex items-center gap-2">
-                <Vote className="w-5 h-5 text-primary" />
+                <Vote className="size-5 text-primary" />
                 {t('voteSetup.confirmTitle')}
               </ResponsiveDialogTitle>
               <ResponsiveDialogDescription>
@@ -309,7 +309,7 @@ export function VoteSetupDialog({ open, onOpenChange, members, groupId, onlineMe
 
             <div className="flex items-center gap-2 flex-wrap py-2 px-3 sm:px-4">
               {members.filter(m => selectedIds.has(m.id)).map((member) => (
-                <Avatar key={member.id} className="w-8 h-8">
+                <Avatar key={member.id} className="size-8">
                   <AvatarImage src={member.avatarUrl} alt={member.displayName} />
                   <AvatarFallback>{member.displayName.charAt(0).toUpperCase()}</AvatarFallback>
                 </Avatar>
@@ -332,7 +332,7 @@ export function VoteSetupDialog({ open, onOpenChange, members, groupId, onlineMe
                   onClick={() => setGameFilters(prev => ({ ...prev, multiplayer: !prev.multiplayer }))}
                   className="gap-1.5"
                 >
-                  <Users className="w-3.5 h-3.5" />
+                  <Users className="size-3.5" />
                   {t('voteSetup.filterMultiplayer')}
                 </Button>
                 <Button
@@ -342,7 +342,7 @@ export function VoteSetupDialog({ open, onOpenChange, members, groupId, onlineMe
                   onClick={() => setGameFilters(prev => ({ ...prev, coop: !prev.coop }))}
                   className="gap-1.5"
                 >
-                  <Handshake className="w-3.5 h-3.5" />
+                  <Handshake className="size-3.5" />
                   {t('voteSetup.filterCoop')}
                 </Button>
                 <Button
@@ -352,7 +352,7 @@ export function VoteSetupDialog({ open, onOpenChange, members, groupId, onlineMe
                   onClick={() => setGameFilters(prev => ({ ...prev, free: !prev.free }))}
                   className="gap-1.5"
                 >
-                  <CircleDollarSign className="w-3.5 h-3.5" />
+                  <CircleDollarSign className="size-3.5" />
                   {t('voteSetup.filterFree')}
                 </Button>
               </div>
@@ -367,9 +367,9 @@ export function VoteSetupDialog({ open, onOpenChange, members, groupId, onlineMe
                   disabled={!isPremium}
                   className="size-5"
                 />
-                <Calendar className="w-4 h-4 text-muted-foreground" />
+                <Calendar className="size-4 text-muted-foreground" />
                 <span className="text-sm font-medium">{t('voteSetup.scheduleLater')}</span>
-                {!isPremium && <Lock className="w-3.5 h-3.5 text-muted-foreground" />}
+                {!isPremium && <Lock className="size-3.5 text-muted-foreground" />}
               </label>
 
               {isScheduled && (
@@ -394,7 +394,7 @@ export function VoteSetupDialog({ open, onOpenChange, members, groupId, onlineMe
 
             <ResponsiveDialogFooter className="mt-4 flex flex-col sm:flex-row gap-2 sm:justify-between">
               <Button variant="ghost" onClick={handleBack} className="w-full sm:w-auto">
-                <ArrowLeft className="w-4 h-4 mr-2" />
+                <ArrowLeft className="size-4 mr-2" />
                 {t('voteSetup.back')}
               </Button>
               <Button onClick={handleConfirm} disabled={isScheduled && !scheduledDate} className="w-full sm:w-auto">

--- a/packages/frontend/src/pages/AdminPage.tsx
+++ b/packages/frontend/src/pages/AdminPage.tsx
@@ -519,7 +519,7 @@ export function AdminPage() {
     <div className="min-h-dvh flex flex-col bg-background">
       <AppHeader maxWidth="wide">
         <Button variant="ghost" size="icon" onClick={() => navigate('/')}>
-          <ArrowLeft className="h-5 w-5" />
+          <ArrowLeft className="size-5" />
         </Button>
       </AppHeader>
 
@@ -548,7 +548,7 @@ export function AdminPage() {
               </Badge>
             </div>
             <p className="text-sm text-muted-foreground font-mono">
-              <Terminal className="inline h-3.5 w-3.5 mr-1.5 -mt-0.5" />
+              <Terminal className="inline size-3.5 mr-1.5 -mt-0.5" />
               Tableau de bord administrateur
             </p>
           </div>
@@ -559,7 +559,7 @@ export function AdminPage() {
             disabled={loading}
             className="gap-2 shrink-0"
           >
-            <RefreshCw className={cn('h-3.5 w-3.5', loading && 'animate-spin')} />
+            <RefreshCw className={cn('size-3.5', loading && 'animate-spin')} />
             Actualiser
           </Button>
         </motion.div>
@@ -594,7 +594,7 @@ export function AdminPage() {
                       transition={{ type: 'spring', bounce: 0.15, duration: 0.5 }}
                     />
                   )}
-                  <Icon className="relative z-10 h-4 w-4" />
+                  <Icon className="relative z-10 size-4" />
                   <span className="relative z-10 hidden sm:inline">{tab.label}</span>
                   {tab.id === 'personas' && personas.length > 0 && (
                     <span className="relative z-10 hidden sm:inline text-[10px] font-mono text-muted-foreground">
@@ -770,7 +770,7 @@ export function AdminPage() {
                   id="persona-color"
                   value={formData.embedColor}
                   onChange={(e) => setFormData({ ...formData, embedColor: e.target.value })}
-                  className="w-10 h-10 rounded border border-input cursor-pointer"
+                  className="size-10 rounded border border-input cursor-pointer"
                 />
                 <Input
                   value={formData.embedColor}
@@ -977,7 +977,7 @@ function NotificationsTab() {
       <Card>
         <CardHeader className="pb-3">
           <CardTitle className="flex items-center gap-2 text-base">
-            <Megaphone className="w-4 h-4" />
+            <Megaphone className="size-4" />
             {t('notifications.broadcastTitle')}
           </CardTitle>
         </CardHeader>
@@ -1011,7 +1011,7 @@ function NotificationsTab() {
             disabled={!title.trim() || sending}
             className="w-full"
           >
-            <Send className="w-4 h-4 mr-2" />
+            <Send className="size-4 mr-2" />
             {sending ? '...' : t('notifications.broadcastSend')}
           </Button>
         </CardContent>
@@ -1092,7 +1092,7 @@ function EmailTab() {
       <Card>
         <CardHeader className="pb-3">
           <CardTitle className="flex items-center gap-2 text-base">
-            <Mail className="w-4 h-4" />
+            <Mail className="size-4" />
             État de l'intégration email
           </CardTitle>
         </CardHeader>
@@ -1104,7 +1104,7 @@ function EmailTab() {
               <div className="flex items-center gap-2 text-sm">
                 {status.configured ? (
                   <>
-                    <CheckCircle2 className="w-4 h-4 text-success" />
+                    <CheckCircle2 className="size-4 text-success" />
                     <span className="text-foreground">Resend configuré</span>
                     <Badge variant="outline" className="ml-1 text-[10px] font-mono">
                       RESEND_API_KEY
@@ -1112,7 +1112,7 @@ function EmailTab() {
                   </>
                 ) : (
                   <>
-                    <AlertTriangle className="w-4 h-4 text-ember" />
+                    <AlertTriangle className="size-4 text-ember" />
                     <span className="text-foreground">Resend non configuré</span>
                     <Badge variant="outline" className="ml-1 text-[10px] font-mono text-muted-foreground">
                       RESEND_API_KEY manquante
@@ -1138,7 +1138,7 @@ function EmailTab() {
       <Card>
         <CardHeader className="pb-3">
           <CardTitle className="flex items-center gap-2 text-base">
-            <Send className="w-4 h-4" />
+            <Send className="size-4" />
             Envoyer un email de test
           </CardTitle>
         </CardHeader>
@@ -1190,7 +1190,7 @@ function EmailTab() {
             disabled={!emailLooksValid || sending || (status !== null && !status.configured)}
             className="w-full"
           >
-            <Send className="w-4 h-4 mr-2" />
+            <Send className="size-4 mr-2" />
             {sending ? 'Envoi…' : 'Envoyer'}
           </Button>
         </CardContent>
@@ -1202,9 +1202,9 @@ function EmailTab() {
           <CardHeader className="pb-3">
             <CardTitle className="flex items-center gap-2 text-base">
               {lastResult.ok ? (
-                <CheckCircle2 className="w-4 h-4 text-success" />
+                <CheckCircle2 className="size-4 text-success" />
               ) : (
-                <AlertTriangle className="w-4 h-4 text-destructive" />
+                <AlertTriangle className="size-4 text-destructive" />
               )}
               Dernière tentative
             </CardTitle>
@@ -1344,7 +1344,7 @@ function OverviewTab({
                 >
                   {/* Background glow orb */}
                   <div
-                    className="absolute -top-8 -right-8 w-24 h-24 rounded-full opacity-[0.04] blur-2xl transition-opacity duration-500 group-hover:opacity-[0.08]"
+                    className="absolute -top-8 -right-8 size-24 rounded-full opacity-[0.04] blur-2xl transition-opacity duration-500 group-hover:opacity-[0.08]"
                     style={{
                       background: card.accent === 'neon'
                         ? 'oklch(0.82 0.19 190)'
@@ -1356,8 +1356,8 @@ function OverviewTab({
                     }}
                   />
 
-                  <div className={cn('w-9 h-9 rounded-lg flex items-center justify-center mb-3', c.iconBg)}>
-                    <Icon className={cn('h-4.5 w-4.5', c.iconColor)} />
+                  <div className={cn('size-9 rounded-lg flex items-center justify-center mb-3', c.iconBg)}>
+                    <Icon className={cn('size-4.5', c.iconColor)} />
                   </div>
                   <div className={cn('text-3xl font-heading font-bold tracking-tight', c.valueColor)}>
                     <AnimatedNumber value={card.value} />
@@ -1391,7 +1391,7 @@ function OverviewTab({
           <Card className="bg-card/60 backdrop-blur-sm border-white/[0.04]">
             <CardHeader className="pb-3">
               <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-2">
-                <Theater className="h-4 w-4" />
+                <Theater className="size-4" />
                 Personas en rotation
               </CardTitle>
             </CardHeader>
@@ -1413,7 +1413,7 @@ function OverviewTab({
                       )}
                     >
                       <div
-                        className="w-2.5 h-2.5 rounded-full shrink-0 ring-2 ring-offset-1 ring-offset-background"
+                        className="size-2.5 rounded-full shrink-0 ring-2 ring-offset-1 ring-offset-background"
                         style={{
                           backgroundColor: colorIntToHex(p.embedColor),
                           '--tw-ring-color': colorIntToHex(p.embedColor) + '40',
@@ -1421,7 +1421,7 @@ function OverviewTab({
                       />
                       <span className="text-sm truncate flex-1">{p.name}</span>
                       {p.isDefault && (
-                        <Lock className="h-3 w-3 text-muted-foreground/50" />
+                        <Lock className="size-3 text-muted-foreground/50" />
                       )}
                       <span className={cn(
                         'text-[10px] font-mono uppercase tracking-wider',
@@ -1447,7 +1447,7 @@ function OverviewTab({
           <Card className="bg-card/60 backdrop-blur-sm border-white/[0.04]">
             <CardHeader className="pb-3">
               <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-2">
-                <Users className="h-4 w-4" />
+                <Users className="size-4" />
                 Derniers inscrits
               </CardTitle>
             </CardHeader>
@@ -1463,7 +1463,7 @@ function OverviewTab({
                         key={u.id}
                         className="flex items-center gap-2.5 px-3 py-2 rounded-lg bg-white/[0.02]"
                       >
-                        <Avatar className="h-7 w-7">
+                        <Avatar className="size-7">
                           <AvatarImage src={u.avatarUrl} alt={u.displayName} />
                           <AvatarFallback className="text-[10px]">{u.displayName.charAt(0).toUpperCase()}</AvatarFallback>
                         </Avatar>
@@ -1521,8 +1521,8 @@ function BotSettingsTab({
           <div className="h-[2px] bg-gradient-to-r from-primary/40 via-neon/30 to-transparent" />
           <CardHeader>
             <CardTitle className="flex items-center gap-2.5 text-base">
-              <div className="w-8 h-8 rounded-lg bg-primary/10 flex items-center justify-center">
-                <Bot className="h-4 w-4 text-primary" />
+              <div className="size-8 rounded-lg bg-primary/10 flex items-center justify-center">
+                <Bot className="size-4 text-primary" />
               </div>
               Rotation des personas
             </CardTitle>
@@ -1546,7 +1546,7 @@ function BotSettingsTab({
                     Rotation des personas activée
                   </label>
                   <div className={cn(
-                    'w-2 h-2 rounded-full transition-colors',
+                    'size-2 rounded-full transition-colors',
                     settings.persona_rotation_enabled ? 'bg-success' : 'bg-muted-foreground/30',
                   )} />
                 </div>
@@ -1587,7 +1587,7 @@ function BotSettingsTab({
                 {/* Persona override */}
                 <div className="space-y-2 pt-2">
                   <label htmlFor="persona-override" className="text-sm font-medium flex items-center gap-1.5">
-                    <Theater className="h-3.5 w-3.5 text-muted-foreground" />
+                    <Theater className="size-3.5 text-muted-foreground" />
                     Forcer le persona du jour
                   </label>
                   <select
@@ -1623,8 +1623,8 @@ function BotSettingsTab({
           <div className="h-[2px] bg-gradient-to-r from-ember/40 via-reward/30 to-transparent" />
           <CardHeader>
             <CardTitle className="flex items-center gap-2.5 text-base">
-              <div className="w-8 h-8 rounded-lg bg-ember/10 flex items-center justify-center">
-                <Clock className="h-4 w-4 text-ember" />
+              <div className="size-8 rounded-lg bg-ember/10 flex items-center justify-center">
+                <Clock className="size-4 text-ember" />
               </div>
               Planification
             </CardTitle>
@@ -1668,7 +1668,7 @@ function BotSettingsTab({
 
                 <div className="space-y-1.5">
                   <label htmlFor="timezone" className="text-sm font-medium flex items-center gap-1.5">
-                    <Globe className="h-3.5 w-3.5 text-muted-foreground" />
+                    <Globe className="size-3.5 text-muted-foreground" />
                     Fuseau horaire
                   </label>
                   <Input
@@ -1688,7 +1688,7 @@ function BotSettingsTab({
       {/* Save bar */}
       <motion.div variants={fadeUp} className="flex gap-3 pt-2">
         <Button onClick={onSave} disabled={saving || loading} className="gap-2">
-          <Save className="h-4 w-4" />
+          <Save className="size-4" />
           {saving ? 'Sauvegarde...' : 'Sauvegarder les paramètres'}
         </Button>
       </motion.div>
@@ -1722,7 +1722,7 @@ function PersonasTab({
           {personas.filter(p => p.isActive).length} actif{personas.filter(p => p.isActive).length > 1 ? 's' : ''} sur {personas.length}
         </div>
         <Button size="sm" className="gap-1.5" onClick={onCreate}>
-          <Plus className="h-4 w-4" />
+          <Plus className="size-4" />
           Ajouter un persona
         </Button>
       </div>
@@ -1762,7 +1762,7 @@ function PersonasTab({
                   <div className="flex items-start justify-between">
                     <div className="flex items-center gap-2.5 min-w-0">
                       <div
-                        className="w-4 h-4 rounded-full shrink-0 ring-2 ring-offset-2 ring-offset-card"
+                        className="size-4 rounded-full shrink-0 ring-2 ring-offset-2 ring-offset-card"
                         style={{
                           backgroundColor: colorIntToHex(persona.embedColor),
                           boxShadow: persona.isActive
@@ -1777,7 +1777,7 @@ function PersonasTab({
                     </div>
                     {persona.isDefault && (
                       <span title="Persona par défaut">
-                        <Lock className="h-3.5 w-3.5 text-muted-foreground/40 shrink-0 mt-0.5" />
+                        <Lock className="size-3.5 text-muted-foreground/40 shrink-0 mt-0.5" />
                       </span>
                     )}
                   </div>
@@ -1810,21 +1810,21 @@ function PersonasTab({
                     <Button
                       variant="ghost"
                       size="icon"
-                      className="h-7 w-7 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity"
+                      className="size-7 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity"
                       onClick={() => onEdit(persona)}
                       title="Modifier"
                     >
-                      <Pencil className="h-3 w-3" />
+                      <Pencil className="size-3" />
                     </Button>
                     {!persona.isDefault && (
                       <Button
                         variant="ghost"
                         size="icon"
-                        className="h-7 w-7 shrink-0 text-destructive hover:text-destructive opacity-0 group-hover:opacity-100 transition-opacity"
+                        className="size-7 shrink-0 text-destructive hover:text-destructive opacity-0 group-hover:opacity-100 transition-opacity"
                         onClick={() => onDelete(persona.id)}
                         title="Supprimer"
                       >
-                        <Trash2 className="h-3 w-3" />
+                        <Trash2 className="size-3" />
                       </Button>
                     )}
                   </div>
@@ -1884,7 +1884,7 @@ function UsersTab({
       {/* Search bar */}
       <div className="flex items-center gap-3">
         <div className="relative flex-1 max-w-sm">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground/50" />
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground/50" />
           <Input
             value={searchQuery}
             onChange={(e) => onSearchChange(e.target.value)}
@@ -1896,7 +1896,7 @@ function UsersTab({
               onClick={() => onSearchChange('')}
               className="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground/50 hover:text-foreground transition-colors"
             >
-              <X className="h-3.5 w-3.5" />
+              <X className="size-3.5" />
             </button>
           )}
         </div>
@@ -1930,13 +1930,13 @@ function UsersTab({
                   : 'border-white/[0.04] hover:border-white/[0.08]',
               )}>
                 <div className="relative">
-                  <Avatar className="h-10 w-10">
+                  <Avatar className="size-10">
                     <AvatarImage src={u.avatarUrl} alt={u.displayName} />
                     <AvatarFallback>{u.displayName.charAt(0).toUpperCase()}</AvatarFallback>
                   </Avatar>
                   {u.isAdmin && (
-                    <div className="absolute -bottom-0.5 -right-0.5 w-4 h-4 rounded-full bg-primary/20 border border-card flex items-center justify-center">
-                      <ShieldCheck className="h-2.5 w-2.5 text-primary" />
+                    <div className="absolute -bottom-0.5 -right-0.5 size-4 rounded-full bg-primary/20 border border-card flex items-center justify-center">
+                      <ShieldCheck className="size-2.5 text-primary" />
                     </div>
                   )}
                 </div>
@@ -1989,7 +1989,7 @@ function UsersTab({
                       onClick={() => onTogglePremium(u)}
                       title="Retirer l'accès premium offert"
                     >
-                      <Crown className="h-3.5 w-3.5" />
+                      <Crown className="size-3.5" />
                       <span className="hidden sm:inline">Retirer premium</span>
                     </Button>
                   ) : (
@@ -2000,7 +2000,7 @@ function UsersTab({
                       onClick={() => onTogglePremium(u)}
                       title="Offrir l'accès premium à cet utilisateur"
                     >
-                      <Crown className="h-3.5 w-3.5 text-reward" />
+                      <Crown className="size-3.5 text-reward" />
                       <span className="hidden sm:inline">Offrir premium</span>
                     </Button>
                   )}
@@ -2014,7 +2014,7 @@ function UsersTab({
                       disabled={u.id === currentUserId}
                       title={u.id === currentUserId ? 'Vous ne pouvez pas révoquer votre propre accès' : undefined}
                     >
-                      <ShieldOff className="h-3.5 w-3.5" />
+                      <ShieldOff className="size-3.5" />
                       <span className="hidden sm:inline">Révoquer</span>
                     </Button>
                   ) : (
@@ -2024,7 +2024,7 @@ function UsersTab({
                       className="gap-1.5"
                       onClick={() => onToggleAdmin(u)}
                     >
-                      <ShieldCheck className="h-3.5 w-3.5" />
+                      <ShieldCheck className="size-3.5" />
                       <span className="hidden sm:inline">Promouvoir</span>
                     </Button>
                   )}
@@ -2060,7 +2060,7 @@ function UsersTab({
               disabled={!canPrev}
               className="gap-1.5"
             >
-              <ChevronLeft className="h-3.5 w-3.5" />
+              <ChevronLeft className="size-3.5" />
               <span className="hidden sm:inline">Précédent</span>
             </Button>
             <Button
@@ -2071,7 +2071,7 @@ function UsersTab({
               className="gap-1.5"
             >
               <span className="hidden sm:inline">Suivant</span>
-              <ChevronRight className="h-3.5 w-3.5" />
+              <ChevronRight className="size-3.5" />
             </Button>
           </div>
         </div>

--- a/packages/frontend/src/pages/ComparePage.tsx
+++ b/packages/frontend/src/pages/ComparePage.tsx
@@ -69,7 +69,7 @@ export function ComparePage() {
       <div className="min-h-dvh flex flex-col">
         <AppHeader>
           <Button variant="ghost" size="icon" onClick={() => navigate(-1)}>
-            <ArrowLeft className="h-5 w-5" />
+            <ArrowLeft className="size-5" />
           </Button>
         </AppHeader>
         <main id="main-content" className="max-w-2xl mx-auto w-full p-4 flex-1 flex items-center justify-center text-center">
@@ -90,7 +90,7 @@ export function ComparePage() {
       <div className="min-h-dvh flex flex-col">
         <AppHeader>
           <Button variant="ghost" size="icon" onClick={() => navigate(-1)}>
-            <ArrowLeft className="h-5 w-5" />
+            <ArrowLeft className="size-5" />
           </Button>
         </AppHeader>
         <main
@@ -115,7 +115,7 @@ export function ComparePage() {
       <div className="min-h-dvh flex flex-col">
         <AppHeader>
           <Button variant="ghost" size="icon" onClick={() => navigate(-1)}>
-            <ArrowLeft className="h-5 w-5" />
+            <ArrowLeft className="size-5" />
           </Button>
         </AppHeader>
         <main id="main-content" className="max-w-2xl mx-auto w-full p-4 flex-1 flex items-center justify-center text-center">
@@ -143,7 +143,7 @@ export function ComparePage() {
     <div className="min-h-dvh flex flex-col">
       <AppHeader>
         <Button variant="ghost" size="icon" onClick={() => navigate(-1)}>
-          <ArrowLeft className="h-5 w-5" />
+          <ArrowLeft className="size-5" />
         </Button>
       </AppHeader>
 
@@ -186,7 +186,7 @@ export function ComparePage() {
         {/* ── Common games with playtime bars ── */}
         <section>
           <h2 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-3 flex items-center gap-2">
-            <Trophy className="w-4 h-4" />
+            <Trophy className="size-4" />
             {t('compare.topPlayedHeading')}
           </h2>
           {commonCount === 0 ? (
@@ -239,7 +239,7 @@ export function ComparePage() {
         {(result.onlyAGames.length > 0 || result.onlyBGames.length > 0) && (
           <section>
             <h2 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-3 flex items-center gap-2">
-              <Gamepad2 className="w-4 h-4" />
+              <Gamepad2 className="size-4" />
               {t('compare.personalLibrariesHeading')}
             </h2>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
@@ -265,7 +265,7 @@ function UserBadge({ name, avatarUrl, gameCount, align }: UserBadgeProps) {
   const { t } = useTranslation()
   return (
     <div className={`flex-1 flex flex-col items-center min-w-0 ${align === 'left' ? 'order-1' : ''}`}>
-      <Avatar className="w-20 h-20 ring-2 ring-background mb-2">
+      <Avatar className="size-20 ring-2 ring-background mb-2">
         <AvatarImage src={avatarUrl ?? undefined} alt={name} />
         <AvatarFallback className="text-2xl font-heading font-bold">
           {name.charAt(0).toUpperCase()}

--- a/packages/frontend/src/pages/DialogTestPage.tsx
+++ b/packages/frontend/src/pages/DialogTestPage.tsx
@@ -86,7 +86,7 @@ export function DialogTestPage() {
           <div className="space-y-3">
             {Array.from({ length: 20 }, (_, i) => (
               <div key={i} className="flex items-center gap-3 py-2.5 px-2 rounded-md hover:bg-accent/50">
-                <div className="w-8 h-8 rounded-full bg-muted" />
+                <div className="size-8 rounded-full bg-muted" />
                 <span className="text-sm">Member {i + 1}</span>
               </div>
             ))}

--- a/packages/frontend/src/pages/DiscordLinkPage.tsx
+++ b/packages/frontend/src/pages/DiscordLinkPage.tsx
@@ -42,7 +42,7 @@ export function DiscordLinkPage() {
   if (!code) {
     return (
       <main id="main-content" className="min-h-dvh flex flex-col items-center justify-center px-4">
-        <X className="w-12 h-12 text-destructive mb-4" aria-hidden="true" />
+        <X className="size-12 text-destructive mb-4" aria-hidden="true" />
         <h1 className="text-2xl font-bold mb-2">{t('discordLink.invalidCode')}</h1>
         <p className="text-muted-foreground mb-6">{t('discordLink.noCode')}</p>
         <Button onClick={() => navigate('/')}>{t('discordLink.goHome')}</Button>
@@ -54,7 +54,7 @@ export function DiscordLinkPage() {
   if (!user) {
     return (
       <main id="main-content" className="min-h-dvh flex flex-col items-center justify-center px-4">
-        <Gamepad2 className="w-12 h-12 text-primary mb-4" aria-hidden="true" />
+        <Gamepad2 className="size-12 text-primary mb-4" aria-hidden="true" />
         <h1 className="text-2xl font-bold mb-2">{t('discordLink.title')}</h1>
         <p className="text-muted-foreground mb-6">{t('discordLink.loginPrompt')}</p>
         <Button variant="steam" size="lg" asChild>
@@ -74,7 +74,7 @@ export function DiscordLinkPage() {
         aria-busy="true"
         aria-live="polite"
       >
-        <Loader2 className="w-8 h-8 animate-spin text-primary mb-4" aria-hidden="true" />
+        <Loader2 className="size-8 animate-spin text-primary mb-4" aria-hidden="true" />
         <p className="text-muted-foreground">{t('discordLink.linking')}</p>
       </main>
     )
@@ -84,7 +84,7 @@ export function DiscordLinkPage() {
   if (discordUsername) {
     return (
       <main id="main-content" className="min-h-dvh flex flex-col items-center justify-center px-4">
-        <Check className="w-12 h-12 text-success mb-4" aria-hidden="true" />
+        <Check className="size-12 text-success mb-4" aria-hidden="true" />
         <h1 className="text-2xl font-bold mb-2">{t('discordLink.linked')}</h1>
         <p className="text-muted-foreground mb-6">
           {t('discordLink.linkedDescription', { username: discordUsername })}
@@ -97,7 +97,7 @@ export function DiscordLinkPage() {
   // Error
   return (
     <main id="main-content" className="min-h-dvh flex flex-col items-center justify-center px-4" role="alert">
-      <X className="w-12 h-12 text-destructive mb-4" aria-hidden="true" />
+      <X className="size-12 text-destructive mb-4" aria-hidden="true" />
       <h1 className="text-2xl font-bold mb-2">{t('discordLink.failed')}</h1>
       <p className="text-muted-foreground mb-6">{error}</p>
       <Button onClick={() => navigate('/')}>{t('discordLink.goHome')}</Button>

--- a/packages/frontend/src/pages/GroupPage.tsx
+++ b/packages/frontend/src/pages/GroupPage.tsx
@@ -388,7 +388,7 @@ export function GroupPage() {
     return (
       <div className="min-h-dvh flex flex-col">
         <AppHeader maxWidth="wide">
-          <Skeleton className="h-5 w-5 rounded" />
+          <Skeleton className="size-5 rounded" />
         </AppHeader>
         <main
           id="main-content"
@@ -413,12 +413,12 @@ export function GroupPage() {
       <AppHeader maxWidth="wide">
         <div className="flex items-center gap-2 min-w-0 flex-1">
           <Button variant="ghost" size="icon" onClick={() => navigate('/')} aria-label={t('group.back')} className="shrink-0">
-            <ArrowLeft className="w-5 h-5" />
+            <ArrowLeft className="size-5" />
           </Button>
           <h1 className="text-base sm:text-lg font-heading font-bold truncate min-w-0 flex-1">{currentGroup.name}</h1>
           {onlineUserIds.length > 0 && (
             <Badge variant="secondary" className="text-[10px] px-1.5 py-0 gap-1 font-normal shrink-0 hidden sm:inline-flex">
-              <span className="w-1.5 h-1.5 rounded-full bg-online animate-pulse" />
+              <span className="size-1.5 rounded-full bg-online animate-pulse" />
               {t('group.onlineCount', { count: onlineUserIds.length })}
             </Badge>
           )}
@@ -438,13 +438,13 @@ export function GroupPage() {
           <div className="flex items-center gap-2 min-w-0">
             <div className="flex -space-x-1.5 shrink-0">
               {currentGroup.members.slice(0, 4).map((member) => (
-                <Avatar key={member.id} className="w-6 h-6 ring-2 ring-background">
+                <Avatar key={member.id} className="size-6 ring-2 ring-background">
                   <AvatarImage src={member.avatarUrl} alt={member.displayName} />
                   <AvatarFallback className="text-[9px]">{member.displayName.charAt(0).toUpperCase()}</AvatarFallback>
                 </Avatar>
               ))}
               {currentGroup.members.length > 4 && (
-                <div className="w-6 h-6 rounded-full bg-muted ring-2 ring-background flex items-center justify-center text-[9px] text-muted-foreground font-medium">
+                <div className="size-6 rounded-full bg-muted ring-2 ring-background flex items-center justify-center text-[9px] text-muted-foreground font-medium">
                   +{currentGroup.members.length - 4}
                 </div>
               )}
@@ -455,12 +455,12 @@ export function GroupPage() {
               </span>
               {onlineUserIds.length > 0 && (
                 <span className="flex items-center gap-1 text-[11px] text-emerald-500 whitespace-nowrap">
-                  <span className="w-1.5 h-1.5 rounded-full bg-online animate-pulse" />
+                  <span className="size-1.5 rounded-full bg-online animate-pulse" />
                   {t('group.onlineCount', { count: onlineUserIds.length })}
                 </span>
               )}
             </div>
-            <UsersIcon className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
+            <UsersIcon className="size-3.5 text-muted-foreground shrink-0" />
           </div>
         </button>
 
@@ -509,7 +509,7 @@ export function GroupPage() {
                 transition={{ duration: 0.35, ease: [0.22, 1, 0.36, 1] }}
               >
                 <div className="rounded-lg border border-primary/20 bg-primary/5 p-3 sm:p-4 flex items-start gap-3">
-                  <Link2 className="w-5 h-5 mt-0.5 shrink-0 text-primary" />
+                  <Link2 className="size-5 mt-0.5 shrink-0 text-primary" />
                   <div className="flex-1 min-w-0">
                     <p className="text-sm font-medium">{t('group.discordBannerTitle')}</p>
                     <p className="text-xs text-muted-foreground mt-0.5">{t('group.discordBannerHint')}</p>
@@ -527,7 +527,7 @@ export function GroupPage() {
                 groups bound before the name-snapshot migration. */}
             {currentGroup.discordChannelId && (
               <div className="inline-flex items-center gap-1.5 text-xs text-muted-foreground border border-border/60 bg-muted/20 rounded-full px-2.5 py-1">
-                <Link2 className="w-3 h-3 text-primary shrink-0" />
+                <Link2 className="size-3 text-primary shrink-0" />
                 {currentGroup.discordChannelName || currentGroup.discordGuildName ? (
                   <span className="truncate">
                     {currentGroup.discordChannelName && (

--- a/packages/frontend/src/pages/GroupsPage.tsx
+++ b/packages/frontend/src/pages/GroupsPage.tsx
@@ -237,7 +237,7 @@ export function GroupsPage() {
               'flex items-center gap-2 text-xs text-muted-foreground',
               refreshing && 'animate-pulse',
             )}>
-              <RefreshCw className={cn('w-4 h-4', refreshing && 'animate-spin')} />
+              <RefreshCw className={cn('size-4', refreshing && 'animate-spin')} />
               {refreshing ? t('groups.refreshing', 'Actualisation...') : pullDistance > 60 ? t('groups.releaseToRefresh', 'Relâcher pour actualiser') : t('groups.pullToRefresh', 'Tirer pour actualiser')}
             </div>
           </div>
@@ -252,11 +252,11 @@ export function GroupsPage() {
               aren't stranded in the top-right unreachable zone. */}
           <div className="hidden sm:flex gap-2">
             <Button variant="secondary" size="sm" onClick={() => setShowJoin(true)}>
-              <LogIn className="w-4 h-4" />
+              <LogIn className="size-4" />
               {t('groups.join')}
             </Button>
             <Button size="sm" onClick={() => setShowCreate(true)}>
-              <Plus className="w-4 h-4" />
+              <Plus className="size-4" />
               {t('groups.create')}
             </Button>
           </div>
@@ -268,7 +268,7 @@ export function GroupsPage() {
         {/* Search Groups */}
         {groups.length > 3 && (
           <div className="relative mb-4" role="search">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground pointer-events-none" />
             <Input
               type="search"
               inputMode="search"
@@ -290,7 +290,7 @@ export function GroupsPage() {
                 className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
                 aria-label={t('groups.clearSearch')}
               >
-                <X className="w-4 h-4" />
+                <X className="size-4" />
               </button>
             )}
           </div>
@@ -399,7 +399,7 @@ export function GroupsPage() {
                   aria-label={t('joinGroup.paste')}
                   title={t('joinGroup.paste')}
                 >
-                  <ClipboardPaste className="w-4 h-4" />
+                  <ClipboardPaste className="size-4" />
                 </Button>
                 <Button onClick={handleJoin}>{t('joinGroup.submit')}</Button>
               </div>
@@ -452,8 +452,8 @@ export function GroupsPage() {
 
               <ol className="text-left space-y-4 mb-8">
                 <li className="flex items-start gap-3">
-                  <div className="flex items-center justify-center w-8 h-8 rounded-full bg-primary/10 border border-primary/20 text-primary shrink-0">
-                    <Users className="w-4 h-4" />
+                  <div className="flex items-center justify-center size-8 rounded-full bg-primary/10 border border-primary/20 text-primary shrink-0">
+                    <Users className="size-4" />
                   </div>
                   <div className="flex-1 min-w-0">
                     <p className="font-semibold text-sm">{t('groups.welcomeStep1')}</p>
@@ -461,8 +461,8 @@ export function GroupsPage() {
                   </div>
                 </li>
                 <li className="flex items-start gap-3">
-                  <div className="flex items-center justify-center w-8 h-8 rounded-full bg-neon/10 border border-neon/20 text-neon shrink-0">
-                    <Vote className="w-4 h-4" />
+                  <div className="flex items-center justify-center size-8 rounded-full bg-neon/10 border border-neon/20 text-neon shrink-0">
+                    <Vote className="size-4" />
                   </div>
                   <div className="flex-1 min-w-0">
                     <p className="font-semibold text-sm">{t('groups.welcomeStep2')}</p>
@@ -470,8 +470,8 @@ export function GroupsPage() {
                   </div>
                 </li>
                 <li className="flex items-start gap-3">
-                  <div className="flex items-center justify-center w-8 h-8 rounded-full bg-reward/10 border border-reward/20 text-reward shrink-0">
-                    <Sparkles className="w-4 h-4" />
+                  <div className="flex items-center justify-center size-8 rounded-full bg-reward/10 border border-reward/20 text-reward shrink-0">
+                    <Sparkles className="size-4" />
                   </div>
                   <div className="flex-1 min-w-0">
                     <p className="font-semibold text-sm">{t('groups.welcomeStep3')}</p>
@@ -482,11 +482,11 @@ export function GroupsPage() {
 
               <div className="flex flex-col sm:flex-row justify-center gap-3">
                 <Button size="lg" onClick={() => setShowCreate(true)}>
-                  <Plus className="w-4 h-4" />
+                  <Plus className="size-4" />
                   {t('groups.welcomeCta')}
                 </Button>
                 <Button size="lg" variant="secondary" onClick={() => setShowJoin(true)}>
-                  <LogIn className="w-4 h-4" />
+                  <LogIn className="size-4" />
                   {t('groups.join')}
                 </Button>
               </div>
@@ -529,7 +529,7 @@ export function GroupsPage() {
                         <h3 className="font-semibold flex items-center gap-1.5">
                           {group.name}
                           {group.role === 'owner' && (
-                            <Crown className="w-4 h-4 text-reward shrink-0" />
+                            <Crown className="size-4 text-reward shrink-0" />
                           )}
                           {group.todayPersona && (
                             <PersonaBadge
@@ -541,26 +541,26 @@ export function GroupsPage() {
                         </h3>
                         <div className="flex items-center gap-2 text-sm text-muted-foreground mt-0.5">
                           <span className="flex items-center gap-1">
-                            <Users className="w-3 h-3" />
+                            <Users className="size-3" />
                             {group.memberCount}
                           </span>
                           <span className="text-muted-foreground/30">·</span>
                           <span className="flex items-center gap-1">
-                            <Gamepad2 className="w-3 h-3" />
+                            <Gamepad2 className="size-3" />
                             {t('groups.commonGames', { count: group.commonGameCount })}
                           </span>
                           {group.lastSession && (
                             <>
                               <span className="text-muted-foreground/30">·</span>
                               <span className="flex items-center gap-1 truncate">
-                                <Trophy className="w-3 h-3 shrink-0" />
+                                <Trophy className="size-3 shrink-0" />
                                 <span className="truncate">{group.lastSession.gameName}</span>
                               </span>
                             </>
                           )}
                         </div>
                       </div>
-                      <ChevronRight className="w-4 h-4 text-muted-foreground/20 shrink-0 transition-all duration-300 group-hover/card:translate-x-0.5 group-hover/card:text-muted-foreground/50" />
+                      <ChevronRight className="size-4 text-muted-foreground/20 shrink-0 transition-all duration-300 group-hover/card:translate-x-0.5 group-hover/card:text-muted-foreground/50" />
                     </div>
                   </Card>
                 </Link>
@@ -579,14 +579,14 @@ export function GroupsPage() {
               onClick={() => setShowJoin(true)}
               className="flex-1 h-12 gap-2"
             >
-              <LogIn className="w-4 h-4" />
+              <LogIn className="size-4" />
               {t('groups.join')}
             </Button>
             <Button
               onClick={() => setShowCreate(true)}
               className="flex-1 h-12 gap-2"
             >
-              <Plus className="w-4 h-4" />
+              <Plus className="size-4" />
               {t('groups.create')}
             </Button>
           </div>

--- a/packages/frontend/src/pages/JoinPage.tsx
+++ b/packages/frontend/src/pages/JoinPage.tsx
@@ -100,7 +100,7 @@ export function JoinPage() {
           animate="visible"
         >
           <motion.div variants={fadeUp}>
-            <Gamepad2 className="w-12 h-12 text-primary mb-4" />
+            <Gamepad2 className="size-12 text-primary mb-4" />
           </motion.div>
 
           <motion.h1 variants={fadeUp} className="text-2xl font-bold mb-2">
@@ -121,13 +121,13 @@ export function JoinPage() {
                         key={i}
                         src={url}
                         alt=""
-                        className="w-8 h-8 rounded-full border-2 border-background"
+                        className="size-8 rounded-full border-2 border-background"
                       />
                     ))}
                   </div>
                 )}
                 <span className="text-sm text-muted-foreground flex items-center gap-1">
-                  <Users className="w-4 h-4" />
+                  <Users className="size-4" />
                   {t('join.memberCount', { count: preview.memberCount })}
                 </span>
               </div>
@@ -136,7 +136,7 @@ export function JoinPage() {
               {preview.recentWinner && (
                 <Card className="w-full p-3 mb-4">
                   <div className="flex items-center gap-3">
-                    <Trophy className="w-5 h-5 text-reward shrink-0" />
+                    <Trophy className="size-5 text-reward shrink-0" />
                     <div className="flex items-center gap-3 min-w-0">
                       {preview.recentWinner.headerImageUrl && (
                         <img
@@ -169,7 +169,7 @@ export function JoinPage() {
                           />
                         ) : (
                           <div className="w-full aspect-[460/215] rounded bg-muted flex items-center justify-center">
-                            <Gamepad2 className="w-6 h-6 text-muted-foreground" />
+                            <Gamepad2 className="size-6 text-muted-foreground" />
                           </div>
                         )}
                         <p className="text-xs text-center font-medium leading-tight line-clamp-2">{game.gameName}</p>
@@ -206,7 +206,7 @@ export function JoinPage() {
             <motion.div variants={fadeUp} className="w-full">
               <Card className="p-4 mb-4 border-warning/40 bg-warning/5">
                 <div className="flex items-start gap-3">
-                  <AlertTriangle className="w-5 h-5 text-warning shrink-0 mt-0.5" aria-hidden="true" />
+                  <AlertTriangle className="size-5 text-warning shrink-0 mt-0.5" aria-hidden="true" />
                   <div className="min-w-0">
                     <p className="font-semibold mb-1">{t('join.inAppBrowserTitle')}</p>
                     <p className="text-sm text-muted-foreground mb-2">{t('join.inAppBrowserBody')}</p>
@@ -235,7 +235,7 @@ export function JoinPage() {
                       .catch(() => toast.info(url))
                   }}
                 >
-                  <Copy className="w-4 h-4 mr-2" aria-hidden="true" />
+                  <Copy className="size-4 mr-2" aria-hidden="true" />
                   {t('join.copyLink')}
                 </Button>
                 <Button
@@ -262,7 +262,7 @@ export function JoinPage() {
   if (joining) {
     return (
       <div className="min-h-dvh flex flex-col items-center justify-center">
-        <Loader2 className="w-8 h-8 animate-spin text-primary mb-4" />
+        <Loader2 className="size-8 animate-spin text-primary mb-4" />
         <p className="text-muted-foreground">{t('join.connecting')}</p>
       </div>
     )

--- a/packages/frontend/src/pages/LandingPage.tsx
+++ b/packages/frontend/src/pages/LandingPage.tsx
@@ -132,7 +132,7 @@ export function LandingPage() {
           {/* Decorative horizontal rule */}
           <motion.div variants={fadeUp} className="flex items-center justify-center gap-4 mt-8 sm:mt-10 mb-6 sm:mb-8">
             <div className="h-px w-16 bg-gradient-to-r from-transparent to-primary/30" />
-            <div className="w-1.5 h-1.5 rounded-full bg-primary/40" />
+            <div className="size-1.5 rounded-full bg-primary/40" />
             <div className="h-px w-16 bg-gradient-to-l from-transparent to-primary/30" />
           </motion.div>
 
@@ -155,14 +155,14 @@ export function LandingPage() {
                 className="gap-3 text-base sm:text-lg px-10 py-7 group"
               >
                 <svg
-                  className="w-6 h-6 transition-transform duration-300 group-hover:scale-110"
+                  className="size-6 transition-transform duration-300 group-hover:scale-110"
                   viewBox="0 0 256 259"
                   fill="currentColor"
                 >
                   <path d="M127.779 0C60.21 0 5.2 52.063.553 117.735l68.39 28.273c5.801-3.964 12.8-6.288 20.358-6.288.672 0 1.34.023 2.004.06l30.469-44.148v-.62c0-26.392 21.476-47.868 47.868-47.868 26.393 0 47.869 21.476 47.869 47.869 0 26.392-21.476 47.868-47.869 47.868h-1.108l-43.44 31.026c0 .524.032 1.049.032 1.578 0 19.803-16.096 35.898-35.898 35.898-17.463 0-32.058-12.535-35.263-29.116L3.27 155.962C20.038 213.357 69.68 258.557 127.779 258.557c71.472 0 129.377-57.905 129.377-129.278C257.156 57.905 199.251 0 127.779 0" />
                 </svg>
                 {t('landing.cta')}
-                <ChevronRight className="w-5 h-5 transition-transform duration-300 group-hover:translate-x-1.5" />
+                <ChevronRight className="size-5 transition-transform duration-300 group-hover:translate-x-1.5" />
               </a>
             </Button>
             <p className="text-xs text-muted-foreground">
@@ -185,7 +185,7 @@ export function LandingPage() {
             transition={{ duration: 3.5, repeat: Infinity }}
           >
             <motion.div
-              className="w-0.5 h-0.5 rounded-full bg-primary/60"
+              className="size-0.5 rounded-full bg-primary/60"
               animate={{ y: [0, 18, 0] }}
               transition={{
                 duration: 2.8,
@@ -236,7 +236,7 @@ export function LandingPage() {
                       <div className="flex justify-center mb-7">
                         <div className="relative">
                           <div
-                            className={`w-14 h-14 rounded-2xl border flex items-center justify-center bg-card/70 backdrop-blur-sm ${colors.badge}`}
+                            className={`size-14 rounded-2xl border flex items-center justify-center bg-card/70 backdrop-blur-sm ${colors.badge}`}
                           >
                             <span className="font-heading text-xl font-bold">
                               {String(i + 1).padStart(2, '0')}
@@ -250,8 +250,8 @@ export function LandingPage() {
 
                       {/* Card body */}
                       <div className="landing-glass-card p-7 sm:p-9 rounded-2xl text-center group">
-                        <div className="relative inline-flex items-center justify-center w-14 h-14 rounded-xl bg-white/[0.03] border border-white/[0.05] mb-6 transition-transform duration-500 group-hover:scale-110">
-                          <step.icon className={`w-7 h-7 ${colors.icon}`} />
+                        <div className="relative inline-flex items-center justify-center size-14 rounded-xl bg-white/[0.03] border border-white/[0.05] mb-6 transition-transform duration-500 group-hover:scale-110">
+                          <step.icon className={`size-7 ${colors.icon}`} />
                         </div>
                         <h3 className="font-heading text-lg sm:text-xl font-semibold mb-3 tracking-tight">
                           {t(step.titleKey)}
@@ -301,8 +301,8 @@ export function LandingPage() {
             <motion.div variants={scaleIn}>
               <div className="h-full landing-glass-card rounded-2xl p-7 sm:p-9">
                 <div className="flex items-center gap-3 mb-7">
-                  <div className="w-11 h-11 rounded-xl bg-white/[0.03] border border-white/[0.06] flex items-center justify-center">
-                    <Zap className="w-5 h-5 text-muted-foreground" />
+                  <div className="size-11 rounded-xl bg-white/[0.03] border border-white/[0.06] flex items-center justify-center">
+                    <Zap className="size-5 text-muted-foreground" />
                   </div>
                   <div>
                     <h3 className="font-heading text-lg font-semibold">
@@ -325,7 +325,7 @@ export function LandingPage() {
                     ] as const
                   ).map((key) => (
                     <li key={key} className="flex items-start gap-3">
-                      <Check className="w-4 h-4 text-muted-foreground/35 mt-0.5 shrink-0" />
+                      <Check className="size-4 text-muted-foreground/35 mt-0.5 shrink-0" />
                       <span className="text-sm text-muted-foreground/60">
                         {t(`landing.${key}`)}
                       </span>
@@ -354,8 +354,8 @@ export function LandingPage() {
                 </Badge>
 
                 <div className="flex items-center gap-3 mb-7">
-                  <div className="w-11 h-11 rounded-xl bg-reward/10 border border-reward/20 flex items-center justify-center">
-                    <Crown className="w-5 h-5 text-reward" />
+                  <div className="size-11 rounded-xl bg-reward/10 border border-reward/20 flex items-center justify-center">
+                    <Crown className="size-5 text-reward" />
                   </div>
                   <div>
                     <h3 className="font-heading text-lg font-semibold">
@@ -382,7 +382,7 @@ export function LandingPage() {
                     ] as const
                   ).map((key) => (
                     <li key={key} className="flex items-start gap-3">
-                      <Check className="w-4 h-4 text-reward mt-0.5 shrink-0" />
+                      <Check className="size-4 text-reward mt-0.5 shrink-0" />
                       <span className="text-sm">{t(`landing.${key}`)}</span>
                     </li>
                   ))}

--- a/packages/frontend/src/pages/NotFoundPage.tsx
+++ b/packages/frontend/src/pages/NotFoundPage.tsx
@@ -11,7 +11,7 @@ export function NotFoundPage() {
 
   return (
     <main id="main-content" className="min-h-dvh flex flex-col items-center justify-center px-4">
-      <SearchX className="w-12 h-12 text-muted-foreground mb-4" aria-hidden="true" />
+      <SearchX className="size-12 text-muted-foreground mb-4" aria-hidden="true" />
       <h1 className="text-2xl font-bold mb-2">{t('notFound.title')}</h1>
       <p className="text-muted-foreground mb-6">{t('notFound.description')}</p>
       <Button onClick={() => navigate('/')}>{t('notFound.backHome')}</Button>

--- a/packages/frontend/src/pages/ProfilePage.tsx
+++ b/packages/frontend/src/pages/ProfilePage.tsx
@@ -334,7 +334,7 @@ export function ProfilePage() {
       <div className="min-h-dvh flex flex-col">
         <AppHeader>
           <Button variant="ghost" size="icon" onClick={() => navigate('/')}>
-            <ArrowLeft className="h-5 w-5" />
+            <ArrowLeft className="size-5" />
           </Button>
         </AppHeader>
         <main
@@ -365,7 +365,7 @@ export function ProfilePage() {
     <div className="min-h-dvh flex flex-col">
       <AppHeader>
         <Button variant="ghost" size="icon" onClick={() => navigate('/')}>
-          <ArrowLeft className="h-5 w-5" />
+          <ArrowLeft className="size-5" />
         </Button>
       </AppHeader>
 
@@ -384,13 +384,13 @@ export function ProfilePage() {
         >
           {/* Decorative holographic seal */}
           <div className="profile-holo-seal" aria-hidden="true">
-            <Gamepad2 className="w-4 h-4 relative z-10 text-foreground/25" />
+            <Gamepad2 className="size-4 relative z-10 text-foreground/25" />
           </div>
 
           <div className="relative z-10 flex flex-col items-center text-center">
             {/* Avatar with prismatic ring */}
             <motion.div variants={avatarReveal} className="profile-avatar-ring mb-5">
-              <Avatar className="w-24 h-24 sm:w-28 sm:h-28 ring-2 ring-background">
+              <Avatar className="size-24 sm:w-28 sm:h-28 ring-2 ring-background">
                 <AvatarImage src={profile.avatarUrl} alt={profile.displayName} />
                 <AvatarFallback className="text-3xl font-heading font-bold">
                   {profile.displayName.charAt(0).toUpperCase()}
@@ -428,7 +428,7 @@ export function ProfilePage() {
                 className="text-sm text-primary hover:text-primary/80 inline-flex items-center gap-1.5 transition-colors mt-1.5"
               >
                 {t('profile.steamProfile')}
-                <ExternalLink className="w-3.5 h-3.5" />
+                <ExternalLink className="size-3.5" />
               </motion.a>
             )}
 
@@ -447,7 +447,7 @@ export function ProfilePage() {
                   variants={statItem}
                   className="flex flex-col items-center"
                 >
-                  <stat.icon className="w-4 h-4 mb-2 text-muted-foreground/50" />
+                  <stat.icon className="size-4 mb-2 text-muted-foreground/50" />
                   <span className="text-2xl sm:text-3xl font-heading font-bold tracking-tight">
                     {formatStatValue(stat.raw)}
                   </span>
@@ -465,7 +465,7 @@ export function ProfilePage() {
         {/* ── Platforms ── */}
         <motion.section variants={fadeUp}>
           <h3 className="profile-section-line text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-4">
-            <Gamepad2 className="w-4 h-4 shrink-0" />
+            <Gamepad2 className="size-4 shrink-0" />
             {t('profile.platforms')}
           </h3>
           <motion.div variants={stagger} className="space-y-2.5">
@@ -478,7 +478,7 @@ export function ProfilePage() {
               >
                 <PlatformIcon
                   platformId={platform.id}
-                  className="w-5 h-5 shrink-0 text-muted-foreground"
+                  className="size-5 shrink-0 text-muted-foreground"
                   aria-label={platform.name}
                 />
                 <div className="flex-1 min-w-0">
@@ -486,12 +486,12 @@ export function ProfilePage() {
                     <span className="font-medium text-sm">{platform.name}</span>
                     {platform.connected && platform.needsRelink ? (
                       <Badge variant="destructive" className="text-[10px] gap-1 py-0 h-5">
-                        <AlertTriangle className="w-3 h-3" />
+                        <AlertTriangle className="size-3" />
                         {t('profile.needsRelink')}
                       </Badge>
                     ) : platform.connected ? (
                       <span className="flex items-center gap-1 text-[10px] text-success font-medium">
-                        <Check className="w-3 h-3" />
+                        <Check className="size-3" />
                         {t('profile.connected')}
                       </span>
                     ) : platform.comingSoon ? (
@@ -515,13 +515,13 @@ export function ProfilePage() {
                           )}
                           {platform.totalPlaytimeMinutes != null && platform.totalPlaytimeMinutes > 0 && (
                             <span className="flex items-center gap-0.5">
-                              <Timer className="w-3 h-3" />
+                              <Timer className="size-3" />
                               {formatPlaytime(platform.totalPlaytimeMinutes)}
                             </span>
                           )}
                           {platform.lastSyncedAt ? (
                             <span className="flex items-center gap-0.5">
-                              <Clock className="w-3 h-3" />
+                              <Clock className="size-3" />
                               {t('profile.lastSync', {
                                 date: new Date(platform.lastSyncedAt).toLocaleDateString('fr-FR', {
                                   day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit',
@@ -543,7 +543,7 @@ export function ProfilePage() {
                     onClick={() => handleConnect(platform.id)}
                     className="shrink-0 h-8 text-xs"
                   >
-                    <Link className="w-3.5 h-3.5 mr-1" />
+                    <Link className="size-3.5 mr-1" />
                     {t('profile.reconnect')}
                   </Button>
                 )}
@@ -555,7 +555,7 @@ export function ProfilePage() {
                     disabled={syncingPlatform === platform.id}
                     className="shrink-0 h-8 text-xs"
                   >
-                    <RefreshCw className={`w-3.5 h-3.5 mr-1 ${syncingPlatform === platform.id ? 'animate-spin' : ''}`} />
+                    <RefreshCw className={`size-3.5 mr-1 ${syncingPlatform === platform.id ? 'animate-spin' : ''}`} />
                     {syncingPlatform === platform.id ? t('profile.syncing') : t('profile.syncNow')}
                   </Button>
                 )}
@@ -567,7 +567,7 @@ export function ProfilePage() {
                     disabled={unlinking === platform.id}
                     className="shrink-0 h-8 text-xs text-destructive hover:text-destructive"
                   >
-                    <Unlink className="w-3.5 h-3.5 mr-1" />
+                    <Unlink className="size-3.5 mr-1" />
                     {t('profile.disconnect')}
                   </Button>
                 )}
@@ -578,7 +578,7 @@ export function ProfilePage() {
                     onClick={() => handleConnect(platform.id)}
                     className="shrink-0 h-8 text-xs"
                   >
-                    <Link className="w-3.5 h-3.5 mr-1" />
+                    <Link className="size-3.5 mr-1" />
                     {t('profile.connect')}
                   </Button>
                 )}
@@ -590,20 +590,20 @@ export function ProfilePage() {
         {/* ── Discord Link ── */}
         <motion.section variants={fadeUp}>
           <h3 className="profile-section-line text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-4">
-            <MessageCircle className="w-4 h-4 shrink-0" />
+            <MessageCircle className="size-4 shrink-0" />
             Discord
           </h3>
           <div
             className="flex items-start gap-3 p-3.5 rounded-xl border border-border/50 bg-card/50 backdrop-blur-sm border-l-[3px] transition-all duration-300 hover:bg-card/80"
             style={{ borderLeftColor: 'oklch(0.55 0.18 270)' }}
           >
-            <MessageCircle className="w-5 h-5 shrink-0 text-muted-foreground mt-0.5" />
+            <MessageCircle className="size-5 shrink-0 text-muted-foreground mt-0.5" />
             <div className="flex-1 min-w-0">
               <div className="flex items-center gap-2 flex-wrap">
                 <span className="font-medium text-sm">Discord</span>
                 {profile.discord?.linked ? (
                   <span className="flex items-center gap-1 text-[10px] text-success font-medium">
-                    <Check className="w-3 h-3" />
+                    <Check className="size-3" />
                     {t('profile.connected')}
                   </span>
                 ) : (
@@ -630,7 +630,7 @@ export function ProfilePage() {
                 disabled={unlinking === 'discord'}
                 className="shrink-0 h-8 text-xs text-destructive hover:text-destructive"
               >
-                <Unlink className="w-3.5 h-3.5 mr-1" />
+                <Unlink className="size-3.5 mr-1" />
                 {t('profile.disconnect')}
               </Button>
             )}
@@ -641,7 +641,7 @@ export function ProfilePage() {
         {visibility && (
           <motion.section variants={fadeUp}>
             <h3 className="profile-section-line text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-4">
-              <Eye className="w-4 h-4 shrink-0" />
+              <Eye className="size-4 shrink-0" />
               Confidentialité
             </h3>
             <p className="text-xs text-muted-foreground leading-relaxed mb-3">
@@ -685,7 +685,7 @@ export function ProfilePage() {
         {profile.topGames && profile.topGames.length > 0 && (
           <motion.section variants={fadeUp}>
             <h3 className="profile-section-line text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-4">
-              <Trophy className="w-4 h-4 shrink-0" />
+              <Trophy className="size-4 shrink-0" />
               {t('profile.topGames')}
             </h3>
             <motion.div variants={stagger} className="space-y-3">
@@ -705,7 +705,7 @@ export function ProfilePage() {
                     )}
                     <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent" />
                     <div className="absolute top-2.5 left-2.5 flex items-center gap-1.5 bg-reward/90 text-reward-foreground rounded-lg px-2.5 py-1 text-xs font-bold backdrop-blur-sm shadow-lg">
-                      <Trophy className="w-3.5 h-3.5" />
+                      <Trophy className="size-3.5" />
                       #1
                     </div>
                     <div className="absolute bottom-0 left-0 right-0 px-4 py-3 flex items-center justify-between">
@@ -738,7 +738,7 @@ export function ProfilePage() {
                             loading="lazy"
                           />
                           <div className={`
-                            absolute top-1.5 left-1.5 w-6 h-6 rounded-md flex items-center justify-center
+                            absolute top-1.5 left-1.5 size-6 rounded-md flex items-center justify-center
                             text-[11px] font-bold backdrop-blur-sm
                             ${i === 0 ? 'bg-foreground/15 text-foreground/70' : i === 1 ? 'bg-ember/20 text-ember' : 'bg-muted/50 text-muted-foreground'}
                           `}>
@@ -765,7 +765,7 @@ export function ProfilePage() {
           <motion.section variants={fadeUp}>
             <div className="flex items-center justify-between mb-4">
               <h3 className="profile-section-line text-xs font-semibold uppercase tracking-widest text-muted-foreground">
-                <Target className="w-4 h-4 shrink-0" />
+                <Target className="size-4 shrink-0" />
                 {t('challenges.title')}
               </h3>
               <Badge variant="secondary" className="text-[10px] py-0 h-5 font-mono">

--- a/packages/frontend/src/pages/SubscriptionPage.tsx
+++ b/packages/frontend/src/pages/SubscriptionPage.tsx
@@ -73,7 +73,7 @@ export function SubscriptionPage() {
       <AppHeader />
       <main id="main-content" className="max-w-2xl mx-auto px-4 py-8">
         <Button variant="ghost" size="sm" onClick={() => navigate(-1)} className="mb-4">
-          <ArrowLeft className="w-4 h-4 mr-2" />
+          <ArrowLeft className="size-4 mr-2" />
           {t('group.back')}
         </Button>
         <h1 className="text-2xl font-heading font-bold mb-6">{t('subscription.title')}</h1>
@@ -93,9 +93,9 @@ export function SubscriptionPage() {
             <div className="flex items-center justify-between">
               <CardTitle className="flex items-center gap-2">
                 {isPremium ? (
-                  <Crown className="w-5 h-5 text-reward" />
+                  <Crown className="size-5 text-reward" />
                 ) : (
-                  <CreditCard className="w-5 h-5 text-muted-foreground" />
+                  <CreditCard className="size-5 text-muted-foreground" />
                 )}
                 {t('subscription.currentPlan')}
               </CardTitle>
@@ -127,7 +127,7 @@ export function SubscriptionPage() {
                   </p>
                 )}
                 <Button variant="secondary" onClick={handlePortal} disabled={actionLoading}>
-                  <ExternalLink className="w-4 h-4 mr-2" />
+                  <ExternalLink className="size-4 mr-2" />
                   {t('subscription.manageButton')}
                 </Button>
               </>
@@ -139,13 +139,13 @@ export function SubscriptionPage() {
                 <ul className="space-y-2 text-sm">
                   {[1, 2, 3, 4, 5, 6].map((n) => (
                     <li key={n} className="flex items-center gap-2">
-                      <Crown className="w-4 h-4 text-reward shrink-0" />
+                      <Crown className="size-4 text-reward shrink-0" />
                       {t(`landing.premiumFeature${n}`)}
                     </li>
                   ))}
                 </ul>
                 <Button onClick={handleCheckout} disabled={actionLoading} className="mt-2">
-                  <Crown className="w-4 h-4 mr-2" />
+                  <Crown className="size-4 mr-2" />
                   {t('subscription.upgradeButton')}
                 </Button>
               </>

--- a/packages/frontend/src/pages/UserProfilePage.tsx
+++ b/packages/frontend/src/pages/UserProfilePage.tsx
@@ -66,7 +66,7 @@ export function UserProfilePage() {
       <div className="min-h-dvh flex flex-col">
         <AppHeader>
           <Button variant="ghost" size="icon" onClick={() => navigate(-1)}>
-            <ArrowLeft className="h-5 w-5" />
+            <ArrowLeft className="size-5" />
           </Button>
         </AppHeader>
         <main id="main-content" className="max-w-2xl mx-auto w-full p-4 space-y-4">
@@ -85,12 +85,12 @@ export function UserProfilePage() {
       <div className="min-h-dvh flex flex-col">
         <AppHeader>
           <Button variant="ghost" size="icon" onClick={() => navigate(-1)}>
-            <ArrowLeft className="h-5 w-5" />
+            <ArrowLeft className="size-5" />
           </Button>
         </AppHeader>
         <main id="main-content" className="max-w-2xl mx-auto w-full p-4 flex-1 flex items-center justify-center">
           <div className="text-center space-y-3">
-            <Lock className="w-8 h-8 mx-auto text-muted-foreground" />
+            <Lock className="size-8 mx-auto text-muted-foreground" />
             <h1 className="text-lg font-semibold">{t('userProfile.unavailableTitle')}</h1>
             <p className="text-sm text-muted-foreground max-w-sm">
               {t('userProfile.unavailableBody')}
@@ -112,14 +112,14 @@ export function UserProfilePage() {
     <div className="min-h-dvh flex flex-col">
       <AppHeader>
         <Button variant="ghost" size="icon" onClick={() => navigate(-1)}>
-          <ArrowLeft className="h-5 w-5" />
+          <ArrowLeft className="size-5" />
         </Button>
       </AppHeader>
 
       <main id="main-content" className="max-w-2xl mx-auto w-full p-4 space-y-6 pb-12">
         {/* ── Header card ── */}
         <div className="rounded-2xl border border-border/50 bg-card/50 backdrop-blur-sm p-6 flex flex-col items-center text-center">
-          <Avatar className="w-24 h-24 ring-2 ring-background mb-4">
+          <Avatar className="size-24 ring-2 ring-background mb-4">
             <AvatarImage src={profile.avatarUrl ?? undefined} alt={profile.displayName} />
             <AvatarFallback className="text-3xl font-heading font-bold">
               {profile.displayName.charAt(0).toUpperCase()}
@@ -127,7 +127,7 @@ export function UserProfilePage() {
           </Avatar>
           <h1 className="text-2xl font-heading font-bold">{profile.displayName}</h1>
           <p className="text-xs text-muted-foreground mt-1 flex items-center gap-1">
-            <Clock className="w-3 h-3" />
+            <Clock className="size-3" />
             {t('userProfile.lastSyncedAt', { date: formatSyncedAt(profile.lastSyncedAt) })}
           </p>
 
@@ -163,7 +163,7 @@ export function UserProfilePage() {
               onClick={() => me && navigate(`/compare?a=${me.id}&b=${profile.id}`)}
               disabled={!me}
             >
-              <GitCompare className="w-4 h-4 mr-2" />
+              <GitCompare className="size-4 mr-2" />
               {t('userProfile.compareCta')}
             </Button>
             <Button
@@ -173,7 +173,7 @@ export function UserProfilePage() {
               disabled={isLoading}
               aria-label={t('userProfile.refreshLabel')}
             >
-              <RefreshCw className={`w-4 h-4 ${isLoading ? 'animate-spin' : ''}`} />
+              <RefreshCw className={`size-4 ${isLoading ? 'animate-spin' : ''}`} />
             </Button>
           </div>
         </div>
@@ -181,7 +181,7 @@ export function UserProfilePage() {
         {/* ── Common games with me ── */}
         <section>
           <h2 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-3 flex items-center gap-2">
-            <Trophy className="w-4 h-4" />
+            <Trophy className="size-4" />
             {t('userProfile.commonHeading')}
           </h2>
           {commonCount === 0 ? (
@@ -235,7 +235,7 @@ export function UserProfilePage() {
         {profile.visibilityFullLibrary && profile.topGames && profile.topGames.length > 0 && (
           <section>
             <h2 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-3 flex items-center gap-2">
-              <Trophy className="w-4 h-4" />
+              <Trophy className="size-4" />
               {t('userProfile.topGamesHeading')}
             </h2>
             <ul className="space-y-2">
@@ -260,7 +260,7 @@ export function UserProfilePage() {
         {/* ── Empty state when the user has opted out of full library ── */}
         {!profile.visibilityFullLibrary && (
           <div className="flex items-start gap-3 p-4 rounded-xl border border-dashed border-border/50 bg-muted/10">
-            <Lock className="w-4 h-4 text-muted-foreground shrink-0 mt-0.5" />
+            <Lock className="size-4 text-muted-foreground shrink-0 mt-0.5" />
             <div className="text-xs text-muted-foreground leading-relaxed">
               <Trans
                 i18nKey="userProfile.fullLibraryHidden"

--- a/packages/frontend/src/pages/VotePage.tsx
+++ b/packages/frontend/src/pages/VotePage.tsx
@@ -268,7 +268,7 @@ export function VotePage() {
       <div className="min-h-dvh flex flex-col">
         <AppHeader>
           <Button variant="ghost" size="icon" onClick={() => navigate(`/groups/${id}`)} aria-label={t('group.back')}>
-            <ArrowLeft className="w-5 h-5" />
+            <ArrowLeft className="size-5" />
           </Button>
         </AppHeader>
         <main id="main-content" className="flex-1 flex items-center justify-center p-4">
@@ -315,7 +315,7 @@ export function VotePage() {
 
     return (
       <main id="main-content" className="min-h-dvh flex flex-col items-center justify-center px-3 sm:px-4 py-4">
-        <Check className="w-16 h-16 text-success mb-4" aria-hidden="true" />
+        <Check className="size-16 text-success mb-4" aria-hidden="true" />
         <h1 className="text-2xl font-heading font-bold mb-2">{t('vote.submitted')}</h1>
 
         {isScheduledSession && (
@@ -361,7 +361,7 @@ export function VotePage() {
                   key={pid}
                   role="listitem"
                   aria-label={voted ? t('vote.participantVoted') : t('vote.participantWaiting')}
-                  className={`h-2.5 w-2.5 rounded-full transition-colors duration-300 ${
+                  className={`size-2.5 rounded-full transition-colors duration-300 ${
                     voted
                       ? 'bg-primary shadow-[0_0_8px_oklch(0.55_0.27_270_/_0.45)]'
                       : 'bg-muted-foreground/30'
@@ -374,7 +374,7 @@ export function VotePage() {
 
         {canClose && (
           <Button onClick={handleClose} disabled={closing}>
-            {closing && <Loader2 className="w-4 h-4 animate-spin" />}
+            {closing && <Loader2 className="size-4 animate-spin" />}
             {t('vote.closeVote')}
           </Button>
         )}
@@ -394,7 +394,7 @@ export function VotePage() {
   if (!isParticipant) {
     return (
       <main id="main-content" className="min-h-dvh flex flex-col items-center justify-center p-4">
-        <Vote className="w-16 h-16 text-muted-foreground mb-4" aria-hidden="true" />
+        <Vote className="size-16 text-muted-foreground mb-4" aria-hidden="true" />
         <h1 className="text-2xl font-heading font-bold mb-2">{t('vote.sessionInProgress')}</h1>
         <p className="text-muted-foreground mb-6">
           {t('vote.notParticipant')}
@@ -414,7 +414,7 @@ export function VotePage() {
     <div className="min-h-dvh flex flex-col">
       <AppHeader>
         <Button variant="ghost" size="icon" onClick={() => navigate(`/groups/${id}`)} aria-label={t('group.back')}>
-          <ArrowLeft className="w-5 h-5" />
+          <ArrowLeft className="size-5" />
         </Button>
       </AppHeader>
 
@@ -428,7 +428,7 @@ export function VotePage() {
 
         {/* Search bar */}
         <div className="relative mb-4" role="search">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" aria-hidden="true" />
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" aria-hidden="true" />
           <input
             type="search"
             inputMode="search"
@@ -506,8 +506,8 @@ export function VotePage() {
                   />
                 </button>
                 {isSelected && (
-                  <div className="absolute top-1.5 right-1.5 w-6 h-6 bg-primary rounded-full flex items-center justify-center pointer-events-none">
-                    <Check className="w-4 h-4 text-primary-foreground" />
+                  <div className="absolute top-1.5 right-1.5 size-6 bg-primary rounded-full flex items-center justify-center pointer-events-none">
+                    <Check className="size-4 text-primary-foreground" />
                   </div>
                 )}
                 {game.metacriticScore != null && (
@@ -531,7 +531,7 @@ export function VotePage() {
                         className="ml-1 shrink-0 min-w-[44px] min-h-[44px] flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-secondary active:bg-accent/10 active:scale-95 transition-all"
                         aria-label={t('vote.gameDetails')}
                       >
-                        <Info className="w-3.5 h-3.5" />
+                        <Info className="size-3.5" />
                       </button>
                     </TooltipTrigger>
                     <TooltipContent side="top" className="text-xs">
@@ -562,9 +562,9 @@ export function VotePage() {
             </span>
             <Button onClick={submitVotes} disabled={submitting || selectedGames.size === 0} aria-label={t('vote.submitSelection')} className="relative">
               {submitting ? (
-                <Loader2 className="w-4 h-4 animate-spin mr-2" />
+                <Loader2 className="size-4 animate-spin mr-2" />
               ) : (
-                <Send className="w-4 h-4 mr-2" />
+                <Send className="size-4 mr-2" />
               )}
               {t('vote.submitSelection')}
               {selectedGames.size > 0 && (
@@ -670,7 +670,7 @@ function ResultScreen({
           aria-live="polite"
         >
           <CircleOff
-            className="w-16 h-16 mx-auto mb-4 text-muted-foreground"
+            className="size-16 mx-auto mb-4 text-muted-foreground"
             aria-hidden="true"
           />
           <h1
@@ -686,9 +686,9 @@ function ResultScreen({
           <div className="flex flex-col items-center gap-3">
             <Button onClick={onRematch} disabled={rematching}>
               {rematching ? (
-                <Loader2 className="w-4 h-4 animate-spin" />
+                <Loader2 className="size-4 animate-spin" />
               ) : (
-                <RefreshCw className="w-4 h-4" />
+                <RefreshCw className="size-4" />
               )}
               {t('vote.rematch')}
             </Button>
@@ -898,7 +898,7 @@ function ResultScreen({
                   className="gap-2"
                   onClick={() => onSteamLaunch(result.steamAppId)}
                 >
-                  <ExternalLink className="w-5 h-5" />
+                  <ExternalLink className="size-5" />
                   {t('vote.launchSteam')}
                 </a>
               </Button>
@@ -931,9 +931,9 @@ function ResultScreen({
               className="mt-1 inline-flex items-center gap-1.5 px-2 py-2 min-h-[44px] text-xs text-muted-foreground hover:text-foreground underline underline-offset-4 decoration-dotted rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {rematching ? (
-                <Loader2 className="w-3 h-3 animate-spin" />
+                <Loader2 className="size-3 animate-spin" />
               ) : (
-                <RefreshCw className="w-3 h-3" />
+                <RefreshCw className="size-3" />
               )}
               {t('vote.rematch')}
             </button>
@@ -994,7 +994,7 @@ function GameDetailDialog({ game, isSelected, onOpenChange, onToggle, t }: GameD
                 'border-score-bad text-score-bad'
               }`}
             >
-              <Star className="w-3 h-3" />
+              <Star className="size-3" />
               Metacritic {game.metacriticScore}
             </Badge>
           )}
@@ -1009,7 +1009,7 @@ function GameDetailDialog({ game, isSelected, onOpenChange, onToggle, t }: GameD
           {/* Controller support */}
           {game.controllerSupport && (
             <Badge variant="secondary" className="gap-1">
-              <Gamepad2 className="w-3 h-3" />
+              <Gamepad2 className="size-3" />
               {t('vote.controllerSupport', { level: game.controllerSupport })}
             </Badge>
           )}
@@ -1029,19 +1029,19 @@ function GameDetailDialog({ game, isSelected, onOpenChange, onToggle, t }: GameD
             <div className="flex gap-2">
               {game.platforms.windows && (
                 <span className="flex items-center gap-1 text-xs text-foreground">
-                  <Monitor className="w-3.5 h-3.5" />
+                  <Monitor className="size-3.5" />
                   Windows
                 </span>
               )}
               {game.platforms.mac && (
                 <span className="flex items-center gap-1 text-xs text-foreground">
-                  <Apple className="w-3.5 h-3.5" />
+                  <Apple className="size-3.5" />
                   Mac
                 </span>
               )}
               {game.platforms.linux && (
                 <span className="flex items-center gap-1 text-xs text-foreground">
-                  <Monitor className="w-3.5 h-3.5" />
+                  <Monitor className="size-3.5" />
                   Linux
                 </span>
               )}
@@ -1076,7 +1076,7 @@ function GameDetailDialog({ game, isSelected, onOpenChange, onToggle, t }: GameD
             className="gap-1.5"
           >
             <a href={steamStoreUrl} target="_blank" rel="noopener noreferrer">
-              <ExternalLink className="w-4 h-4" />
+              <ExternalLink className="size-4" />
               {t('vote.viewOnSteam')}
             </a>
           </Button>
@@ -1087,7 +1087,7 @@ function GameDetailDialog({ game, isSelected, onOpenChange, onToggle, t }: GameD
             onClick={() => onToggle(game.steamAppId)}
             className="gap-1.5"
           >
-            <Check className={`w-4 h-4 ${isSelected ? '' : 'opacity-0'}`} />
+            <Check className={`size-4 ${isSelected ? '' : 'opacity-0'}`} />
             {isSelected ? t('vote.deselect') : t('vote.select')}
           </Button>
         </ResponsiveDialogFooter>


### PR DESCRIPTION
## Summary

Mechanical equivalence transformation of every paired `w-N h-N` (and reverse-order `h-N w-N`) where both numbers are equal → Tailwind's `size-N` shorthand.

- **336 substitutions across 36 files** (components, pages, ui).
- Sizes touched: `1.5, 2, 2.5, 3, 3.5, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 16, 24`.
- Non-square pairs (Steam capsule thumbs `w-16 h-8`, drawer handle `h-1.5 w-12`) are intentionally left alone.
- Net effect: zero visual change, kills the reverse-order vs forward-order inconsistency the visual-design review flagged as a tell that the team had no documented icon size scale.

## Test plan

- [x] Frontend `tsc --noEmit -p .` clean
- [x] Backend `vitest run` 42/42 passing
- [x] `npm run lint` shows only the 5 pre-existing warnings (no new ones)
- [x] `grep -E '\bw-\d+\s+h-\d+\b'` returns only legit non-square pairs (3 sites: Steam thumbs, drawer handle)

https://claude.ai/code/session_01QHwe8pbmm5PDobWHYSWoSa

---
_Generated by [Claude Code](https://claude.ai/code/session_01QHwe8pbmm5PDobWHYSWoSa)_