### PR TITLE
feat: D8 persona color clamp + streaks summary tests

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -324,9 +324,10 @@ product input first:
   `color` variant's gradient now uses OKLCH values that mirror
   `--primary` and `--reward`. Update the stops in
   `components/icons/wawptn-logo.tsx` if the brand tokens evolve.
-- **Persona color clamp (D8)** — Discord-style hex per persona is
-  rendered raw in `persona-badge.tsx`. Should be wrapped through a
-  saturation/contrast clamp helper or constrained to a palette.
+- **Persona color clamp (D8)** — DONE in sprint 8. Embed colors now
+  flow through `lib/persona-color.ts:clampPersonaColor()` which snaps
+  HSL lightness to [0.55, 0.78] and saturation to [0.45, 0.85] before
+  rendering. Hue is preserved so each persona keeps its identity.
 - **Type scale shrink** — drop `text-xl` (only 8 hits).
 - **Annual subscription plan + first-month-free coupon** — backend
   Stripe SKU work needed.

--- a/packages/backend/src/domain/__tests__/streaks.test.ts
+++ b/packages/backend/src/domain/__tests__/streaks.test.ts
@@ -58,7 +58,7 @@ vi.mock('@/infrastructure/logger/logger.js', () => {
 // Import module under test
 // ---------------------------------------------------------------------------
 
-import { updateStreak } from '../streaks.js'
+import { updateStreak, getUserStreakSummary } from '../streaks.js'
 
 // Replace the raw stub with a real vi.fn so we can assert against it
 const rawFn = vi.fn().mockResolvedValue(undefined)
@@ -186,5 +186,64 @@ describe('updateStreak', () => {
     const params = rawFn.mock.calls[0]![1] as unknown[]
     expect(params[2]).toBe(1)  // reset
     expect(params[3]).toBe(10) // best preserved
+  })
+})
+
+describe('getUserStreakSummary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    rawFn.mockResolvedValue(undefined)
+    dbResultQueue.clear()
+    dbCallCounts.clear()
+  })
+
+  it('returns zeros when the user has no streak rows', async () => {
+    // Empty array — user has never closed a session
+    setResult('streaks', [])
+
+    const summary = await getUserStreakSummary('user-1')
+
+    expect(summary).toEqual({ bestCurrent: 0, bestEver: 0, activeStreakGroups: 0 })
+  })
+
+  it('rolls up the best current and ever across multiple groups', async () => {
+    setResult('streaks', [
+      { current_streak: 3, best_streak: 5 },
+      { current_streak: 7, best_streak: 7 },  // best current
+      { current_streak: 1, best_streak: 12 }, // best ever
+    ])
+
+    const summary = await getUserStreakSummary('user-1')
+
+    expect(summary.bestCurrent).toBe(7)
+    expect(summary.bestEver).toBe(12)
+  })
+
+  it('counts only groups with a current streak >= 2 as active', async () => {
+    // The badge tooltip says "active in N groups"; a single-session
+    // streak is not considered active per the helper's contract.
+    setResult('streaks', [
+      { current_streak: 1, best_streak: 4 },  // not active
+      { current_streak: 2, best_streak: 2 },  // active
+      { current_streak: 5, best_streak: 5 },  // active
+      { current_streak: 1, best_streak: 8 },  // not active
+    ])
+
+    const summary = await getUserStreakSummary('user-1')
+
+    expect(summary.activeStreakGroups).toBe(2)
+  })
+
+  it('coerces string-like number columns from pg', async () => {
+    // node-postgres can return numeric() / bigint columns as strings;
+    // the function should still produce numeric output.
+    setResult('streaks', [
+      { current_streak: '4', best_streak: '9' },
+    ])
+
+    const summary = await getUserStreakSummary('user-1')
+
+    expect(summary.bestCurrent).toBe(4)
+    expect(summary.bestEver).toBe(9)
   })
 })

--- a/packages/frontend/src/components/persona-badge.tsx
+++ b/packages/frontend/src/components/persona-badge.tsx
@@ -3,16 +3,13 @@ import { useTranslation } from 'react-i18next'
 import { motion } from 'framer-motion'
 import { Sparkles } from 'lucide-react'
 import { api } from '@/lib/api'
+import { clampPersonaColor } from '@/lib/persona-color'
 
 interface PersonaData {
   id?: string
   name: string
   embedColor: number
   introMessage: string
-}
-
-function colorIntToHex(color: number): string {
-  return `#${color.toString(16).padStart(6, '0')}`
 }
 
 interface PersonaBadgeProps {
@@ -76,7 +73,10 @@ export function PersonaBadge({ groupId, persona: initialPersona, variant = 'hero
   const persona = initialPersona ?? fetched
   if (!persona) return null
 
-  const color = colorIntToHex(persona.embedColor)
+  // Clamp the persona's embed color into a contrast-safe range so an
+  // arbitrary admin-picked hex doesn't crash the visual hierarchy.
+  // See lib/persona-color.ts and design-review §D8.
+  const color = clampPersonaColor(persona.embedColor)
 
   if (variant === 'compact') {
     return (

--- a/packages/frontend/src/lib/persona-color.ts
+++ b/packages/frontend/src/lib/persona-color.ts
@@ -1,0 +1,111 @@
+/**
+ * Persona color clamp — addresses D8 from the design review.
+ *
+ * Discord embed colors are 24-bit integers a server admin (or the
+ * persona pool seed) freely picks. Without clamping, a low-lightness
+ * blue or a near-white yellow lands on a card that's already on a
+ * dark background and either disappears or burns the eye out.
+ *
+ * The clamp parses the embed integer through HSL and snaps the
+ * lightness and saturation into a "designer-friendly" range:
+ *
+ *   - Lightness clamp: [0.55, 0.78] keeps the color above the
+ *     contrast floor on `--background` (oklch 0.115) without going
+ *     so light it loses saturation.
+ *   - Saturation clamp: [0.45, 0.85] avoids muddy near-greys at the
+ *     low end and oversaturated retina-burners at the high end.
+ *
+ * Pure functions — no DOM, no side effects — so they work in any
+ * environment. Hue is preserved so each persona keeps its identity.
+ */
+
+const MIN_LIGHTNESS = 0.55
+const MAX_LIGHTNESS = 0.78
+const MIN_SATURATION = 0.45
+const MAX_SATURATION = 0.85
+
+interface RGB { r: number; g: number; b: number }
+interface HSL { h: number; s: number; l: number }
+
+function clamp(n: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, n))
+}
+
+function intToRgb(color: number): RGB {
+  return {
+    r: (color >> 16) & 0xff,
+    g: (color >> 8) & 0xff,
+    b: color & 0xff,
+  }
+}
+
+function rgbToHex({ r, g, b }: RGB): string {
+  const hex = (n: number) => clamp(Math.round(n), 0, 255).toString(16).padStart(2, '0')
+  return `#${hex(r)}${hex(g)}${hex(b)}`
+}
+
+function rgbToHsl({ r, g, b }: RGB): HSL {
+  const r1 = r / 255
+  const g1 = g / 255
+  const b1 = b / 255
+  const max = Math.max(r1, g1, b1)
+  const min = Math.min(r1, g1, b1)
+  const l = (max + min) / 2
+  if (max === min) return { h: 0, s: 0, l }
+  const d = max - min
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min)
+  let h = 0
+  switch (max) {
+    case r1:
+      h = (g1 - b1) / d + (g1 < b1 ? 6 : 0)
+      break
+    case g1:
+      h = (b1 - r1) / d + 2
+      break
+    case b1:
+      h = (r1 - g1) / d + 4
+      break
+  }
+  return { h: h / 6, s, l }
+}
+
+function hslToRgb({ h, s, l }: HSL): RGB {
+  if (s === 0) {
+    const v = Math.round(l * 255)
+    return { r: v, g: v, b: v }
+  }
+  const hue2rgb = (p: number, q: number, t: number): number => {
+    let tt = t
+    if (tt < 0) tt += 1
+    if (tt > 1) tt -= 1
+    if (tt < 1 / 6) return p + (q - p) * 6 * tt
+    if (tt < 1 / 2) return q
+    if (tt < 2 / 3) return p + (q - p) * (2 / 3 - tt) * 6
+    return p
+  }
+  const q = l < 0.5 ? l * (1 + s) : l + s - l * s
+  const p = 2 * l - q
+  return {
+    r: Math.round(hue2rgb(p, q, h + 1 / 3) * 255),
+    g: Math.round(hue2rgb(p, q, h) * 255),
+    b: Math.round(hue2rgb(p, q, h - 1 / 3) * 255),
+  }
+}
+
+/**
+ * Clamp a Discord embed color (24-bit integer) into the
+ * designer-approved lightness/saturation range and return a hex
+ * string. Hue is preserved.
+ *
+ * Exported separately for unit testing.
+ */
+export function clampPersonaColor(embedColor: number): string {
+  const rgb = intToRgb(embedColor)
+  const hsl = rgbToHsl(rgb)
+  const clamped: HSL = {
+    h: hsl.h,
+    s: clamp(hsl.s, MIN_SATURATION, MAX_SATURATION),
+    l: clamp(hsl.l, MIN_LIGHTNESS, MAX_LIGHTNESS),
+  }
+  return rgbToHex(hslToRgb(clamped))
+}


### PR DESCRIPTION
## Summary

- **D8 — Persona color clamp** (the last spec'd item from the design review). Discord embed integers now flow through `clampPersonaColor()` (`packages/frontend/src/lib/persona-color.ts`) which parses the 24-bit int through HSL and snaps lightness to `[0.55, 0.78]` and saturation to `[0.45, 0.85]` — keeps colors above the contrast floor on `--background` without going so light they lose identity. Hue is preserved.
- **Streaks summary tests**: 4 new cases for `getUserStreakSummary` covering empty rows, multi-group best-current/ever rollup, the `>=2` active-group rule, and pg string-column coercion. Backend test suite is now 46/46 (up from 42).
- Stats endpoint test deliberately skipped — would mostly exercise the `vi.hoisted` mock framework rather than business logic; the underlying COUNT queries are straightforward Postgres.

## Test plan

- [x] Frontend `tsc --noEmit -p .` clean
- [x] Backend `tsc --noEmit` clean
- [x] Backend `vitest run` 46/46 passing (up from 42)
- [x] Lint stable at 4 framework-level warnings (no new ones)

https://claude.ai/code/session_01QHwe8pbmm5PDobWHYSWoSa

---
_Generated by [Claude Code](https://claude.ai/code/session_01QHwe8pbmm5PDobWHYSWoSa)_