### PR TITLE
chore(frontend): clean up 3 fast-refresh lint warnings

### DIFF
--- a/packages/frontend/src/components/KoeSupport.tsx
+++ b/packages/frontend/src/components/KoeSupport.tsx
@@ -7,13 +7,8 @@ import { useAuthStore } from '@/stores/auth.store'
 const PROJECT_KEY = (import.meta.env.VITE_KOE_PROJECT_KEY as string | undefined) ?? 'wawptn'
 const API_URL = (import.meta.env.VITE_KOE_API_URL as string | undefined) ?? 'https://koe.battistella.ovh'
 
-// The Koe library ships a floating launcher button we don't want to show —
-// we trigger the widget from the user menu instead. Keep the launcher
-// reachable via DOM so `openKoeSupport` can click it, but hide it visually.
-export function openKoeSupport() {
-  const launcher = document.querySelector<HTMLButtonElement>('.koe-root > button[aria-expanded]')
-  launcher?.click()
-}
+// `openKoeSupport` lives in `lib/koe-support.ts` so this module exports
+// only React components — keeps Vite's fast-refresh happy.
 
 const FR_LOCALE = {
   launcherLabel: 'Support',

--- a/packages/frontend/src/components/app-header.tsx
+++ b/packages/frontend/src/components/app-header.tsx
@@ -25,7 +25,7 @@ import {
 } from '@/components/ui/responsive-dialog'
 import { WawptnLogo } from '@/components/icons/wawptn-logo'
 import { NotificationBell } from '@/components/notification-bell'
-import { openKoeSupport } from '@/components/KoeSupport'
+import { openKoeSupport } from '@/lib/koe-support'
 
 interface AppHeaderProps {
   children?: React.ReactNode

--- a/packages/frontend/src/components/ui/badge.tsx
+++ b/packages/frontend/src/components/ui/badge.tsx
@@ -44,4 +44,6 @@ function Badge({
   )
 }
 
-export { Badge, badgeVariants }
+// See note on Button: `badgeVariants` is intentionally module-private
+// to keep this file a clean components-only export.
+export { Badge }

--- a/packages/frontend/src/components/ui/button.tsx
+++ b/packages/frontend/src/components/ui/button.tsx
@@ -49,4 +49,8 @@ function Button({
   )
 }
 
-export { Button, buttonVariants }
+// `buttonVariants` is intentionally not re-exported — no consumer needs it,
+// and re-exporting non-component values from a component module trips the
+// react-refresh/only-export-components lint rule. If a call site ever
+// genuinely needs the cva variants, hoist them into a sibling file.
+export { Button }

--- a/packages/frontend/src/lib/koe-support.ts
+++ b/packages/frontend/src/lib/koe-support.ts
@@ -1,0 +1,15 @@
+/**
+ * Trigger the Koe support widget from outside the React tree (e.g. a
+ * dropdown menu item in the app header). The widget itself ships a
+ * floating launcher button that we hide visually via CSS in the
+ * `KoeSupport` component — calling this clicks that hidden launcher
+ * to open the panel.
+ *
+ * Pulled into its own file so `components/KoeSupport.tsx` stays a
+ * components-only export module (Vite's react-refresh fast-refresh
+ * needs that to hot-reload reliably).
+ */
+export function openKoeSupport() {
+  const launcher = document.querySelector<HTMLButtonElement>('.koe-root > button[aria-expanded]')
+  launcher?.click()
+}


### PR DESCRIPTION
## Summary

Three of the four remaining frontend lint warnings (`react-refresh/only-export-components`) come from component modules that also export non-component values. Vite's fast-refresh skips hot-reload for the whole module in that case.

- **`ui/button.tsx`, `ui/badge.tsx`** — dropped unused `buttonVariants` / `badgeVariants` re-exports (zero external hits across the codebase).
- **`lib/koe-support.ts`** *(new)* — moved `openKoeSupport` here so `KoeSupport.tsx` stays a components-only module.
- **`app-header.tsx`** — updated single import site.

Net result: lint warnings down from 4 → **1**. The remaining warning is the React-Compiler-vs-TanStack-Virtual incompatibility on `game-grid.tsx`, which can't be fixed without dropping either dependency.

## Test plan

- [x] Frontend `tsc --noEmit -p .` clean
- [x] Backend `vitest run` 46/46 passing
- [x] `npm run lint` shows 1 warning (down from 4)

https://claude.ai/code/session_01QHwe8pbmm5PDobWHYSWoSa

---
_Generated by [Claude Code](https://claude.ai/code/session_01QHwe8pbmm5PDobWHYSWoSa)_