### PR TITLE
perf(frontend): final mobile-perf cleanup (C2/C4/C6/C7/C10)

### DIFF
--- a/packages/frontend/src/components/game-grid.tsx
+++ b/packages/frontend/src/components/game-grid.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { Search, X, Users, Handshake, Star, ChevronDown, Gamepad2, Monitor, TrendingUp, SearchX, RefreshCw, ShieldAlert, EyeOff, SlidersHorizontal, Sparkles, Sofa, Trophy, Zap } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
@@ -460,7 +460,12 @@ export function GameGrid({ games, loading, filters, onToggleMultiplayer, onToggl
             <ResponsiveDialogTitle>{t('group.moreFilters')}</ResponsiveDialogTitle>
             <ResponsiveDialogDescription>{t('group.moreFiltersDescription')}</ResponsiveDialogDescription>
           </ResponsiveDialogHeader>
-          <div className="px-4 pb-4 space-y-5 max-h-[70dvh] overflow-y-auto">
+          {/* No nested scroll container — `ResponsiveDialogContent`
+              already caps at 96dvh and scrolls. Adding our own
+              overflow-y here created a swipe-trap on iOS where the
+              outer drawer-handle pull-down gesture got captured by
+              the inner scroller (mobile review §C4 follow-up). */}
+          <div className="px-4 pb-4 space-y-5">
             {/* Metacritic */}
             <section>
               <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider flex items-center gap-1 mb-2">
@@ -720,7 +725,13 @@ export function GameGrid({ games, loading, filters, onToggleMultiplayer, onToggl
   )
 }
 
-function GameCard({ game, t }: { game: Game; t: (key: string, options?: Record<string, unknown>) => string }) {
+// React.memo so virtualizer slice changes (e.g. on viewport resize)
+// don't force every visible card to re-render. `game` is stable per
+// appId from the parent's useMemo'd filtered list; `t` is stable for
+// the locale. The wishlist Zustand subscription inside the body uses
+// a steamAppId selector so an unrelated star toggle doesn't kick a
+// sibling card either. See mobile review §C2.
+const GameCard = memo(function GameCard({ game, t }: { game: Game; t: (key: string, options?: Record<string, unknown>) => string }) {
   // Subscribe only to our own steamAppId's wishlist state so siblings
   // don't re-render when unrelated cards are starred. Zustand bails out
   // when the selected boolean hasn't actually changed, which keeps the
@@ -829,4 +840,4 @@ function GameCard({ game, t }: { game: Game; t: (key: string, options?: Record<s
       </div>
     </div>
   )
-}
+})

--- a/packages/frontend/src/components/notification-bell.tsx
+++ b/packages/frontend/src/components/notification-bell.tsx
@@ -213,7 +213,10 @@ export function NotificationBell() {
                         key={notification.id}
                         initial={{ opacity: 0, y: -8 }}
                         animate={{ opacity: 1, y: 0 }}
-                        transition={{ delay: i * 0.03, duration: 0.15 }}
+                        // Cap the stagger cascade at 8 rows. Beyond that
+                        // it's barely perceptible and starts dropping
+                        // frames on low-end Android (mobile review §C6).
+                        transition={{ delay: Math.min(i, 8) * 0.03, duration: 0.15 }}
                         onClick={() => handleNotificationClick(notification)}
                         className={`w-full text-left px-3 py-2.5 hover:bg-accent/50 transition-colors flex gap-2.5 ${
                           !notification.read ? 'bg-accent/20' : ''

--- a/packages/frontend/src/components/share-button.tsx
+++ b/packages/frontend/src/components/share-button.tsx
@@ -166,8 +166,14 @@ export function ShareButton({
             animate={{ opacity: 1, y: 0, scale: 1 }}
             exit={{ opacity: 0, y: -6, scale: 0.96 }}
             transition={{ duration: 0.16, ease: [0.22, 1, 0.36, 1] }}
+            // Anchor right-aligned so the popover stays inside the
+            // viewport on phones <360px wide, where the centred variant
+            // would overflow off-screen with no clipping ancestor to
+            // catch it (mobile review §C4). The `right-0` placement is
+            // safe even when the trigger is the rightmost element of a
+            // CTA row — popover width (w-56 = 14rem) ≤ all phones.
             className={cn(
-              'absolute left-1/2 top-full z-50 mt-2 w-56 -translate-x-1/2 origin-top',
+              'absolute right-0 sm:left-1/2 sm:right-auto top-full z-50 mt-2 w-56 sm:-translate-x-1/2 origin-top',
               'overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-2'
             )}
           >

--- a/packages/frontend/src/components/tonight-pick-hero.tsx
+++ b/packages/frontend/src/components/tonight-pick-hero.tsx
@@ -174,7 +174,13 @@ export function TonightPickHero({
           alt=""
           aria-hidden="true"
           className="w-full h-full object-cover opacity-40 group-hover:opacity-50 transition-opacity duration-500 group-hover:scale-[1.02] motion-safe:transition-transform"
-          loading="eager"
+          // The visible foreground thumb (below) is the sharp asset we
+          // care about; this is a decorative 40%-opacity backdrop. Tell
+          // the browser so it can deprioritise the network slot when
+          // both fetches race over flaky 4G. Same URL → cache dedupes.
+          // Mobile review §C7.
+          loading="lazy"
+          fetchPriority="low"
         />
         <div className="absolute inset-0 bg-gradient-to-r from-background via-background/85 to-background/30" />
         <div className="absolute inset-0 bg-gradient-to-t from-background/95 via-background/40 to-transparent" />

--- a/packages/frontend/src/pages/VotePage.tsx
+++ b/packages/frontend/src/pages/VotePage.tsx
@@ -447,7 +447,7 @@ export function VotePage() {
 
         {/* Scrollable grid area: holds the sticky selection badge so users
             don't lose track of their pick count while scrolling on mobile. */}
-        <div className="flex-1 overflow-y-auto pb-24">
+        <div className="flex-1 overflow-y-auto pb-24 touch-scroll overscroll-contain">
           {/* Sticky selection counter — appears at the top of the scroll
               container as soon as the user picks at least one game. The
               floating bottom bar still shows the same count and the submit


### PR DESCRIPTION
## Summary

Six small mobile-perf items the original Mobile UX persona flagged that were still open after sprints 1-8:

- **C2** GameCard memoization — `React.memo` so virtualizer slice changes don't cascade.
- **C6** Notification stagger cap — `Math.min(i, 8) * 0.03` so long unread lists don't drop frames on low-end Android.
- **C7** Tonight-pick double image — background blur demoted to `loading="lazy"` + `fetchPriority="low"`.
- **C4** Share popover overflow — `right-0 sm:left-1/2` so it stays in the viewport on phones <360px.
- **C10** VotePage scroll surface — added `touch-scroll overscroll-contain` to the flex-1 wrapper.
- Filter drawer swipe-trap — dropped a nested `max-h-[70dvh] overflow-y-auto` inside `ResponsiveDialogContent` that was capturing the outer drawer's pull-down gesture on iOS.

## Test plan

- [x] Frontend `tsc --noEmit -p .` clean
- [x] Backend `vitest run` 46/46 passing
- [x] `npm run lint` stable at 1 framework warning

https://claude.ai/code/session_01QHwe8pbmm5PDobWHYSWoSa

---
_Generated by [Claude Code](https://claude.ai/code/session_01QHwe8pbmm5PDobWHYSWoSa)_