### PR TITLE
Gate notification listener on user authentication

### DIFF
--- a/packages/frontend/src/hooks/useNotificationListener.ts
+++ b/packages/frontend/src/hooks/useNotificationListener.ts
@@ -1,12 +1,16 @@
 import { useEffect } from 'react'
 import { getSocket } from '@/lib/socket'
 import { useNotificationStore } from '@/stores/notification.store'
+import { useAuthStore } from '@/stores/auth.store'
 import { showNativeNotification } from '@/lib/pwa'
 
 /**
  * Global hook that listens for notification:new socket events
  * and pushes them into the notification store.
- * Must be mounted once at the app level after authentication.
+ * Mounted at the app level; the network/socket work is gated on
+ * `user` so the unauthenticated landing page doesn't fire a
+ * `/api/notifications` request (which 401s and surfaces as a
+ * console error).
  *
  * When the user has granted native notification permission, the hook also
  * dispatches a native OS notification via the service worker so the bell
@@ -14,8 +18,11 @@ import { showNativeNotification } from '@/lib/pwa'
  */
 export function useNotificationListener() {
   const { addNotification, fetchNotifications } = useNotificationStore()
+  const userId = useAuthStore((s) => s.user?.id ?? null)
 
   useEffect(() => {
+    if (!userId) return
+
     // Fetch existing unread notifications on mount
     fetchNotifications()
 
@@ -41,5 +48,5 @@ export function useNotificationListener() {
     return () => {
       socket.off('notification:new', handleNewNotification)
     }
-  }, [addNotification, fetchNotifications])
+  }, [addNotification, fetchNotifications, userId])
 }


### PR DESCRIPTION
## Summary
Updated the `useNotificationListener` hook to only initialize socket connections and fetch notifications when a user is authenticated, preventing unnecessary API requests and console errors on the unauthenticated landing page.

## Key Changes
- Added `useAuthStore` dependency to access the current user's authentication state
- Added early return guard in the effect hook that prevents socket setup and notification fetching when `userId` is null
- Updated the effect dependency array to include `userId`, ensuring the hook properly responds to authentication state changes
- Updated JSDoc comments to clarify that the hook is mounted at the app level but gated on user authentication

## Implementation Details
The hook now checks for a valid `userId` before executing any side effects. This prevents the `/api/notifications` request from being triggered on unauthenticated pages, which would result in 401 errors and console warnings. The dependency array inclusion of `userId` ensures the effect re-runs when the user logs in or out, properly connecting/disconnecting the socket listener as needed.

https://claude.ai/code/session_01GZamTBWWgahC5bgDZ8XEJh