### PR TITLE
Support Stripe restricted keys in mode detection

### DIFF
--- a/packages/backend/src/config/env.ts
+++ b/packages/backend/src/config/env.ts
@@ -117,7 +117,7 @@ export function validateEnv(): void {
     }
     // Mode parity: live secret with test webhook (or vice versa) silently
     // fails signature verification with no startup error.
-    const liveKey = env.STRIPE_SECRET_KEY.startsWith('sk_live_')
+    const liveKey = /^(sk|rk)_live_/.test(env.STRIPE_SECRET_KEY)
     const liveWebhook = !env.STRIPE_WEBHOOK_SECRET.startsWith('whsec_test_')
       && !env.STRIPE_WEBHOOK_SECRET.includes('test')
     // The webhook secret naming convention isn't strictly enforced by Stripe

--- a/packages/backend/src/infrastructure/stripe/stripe-client.ts
+++ b/packages/backend/src/infrastructure/stripe/stripe-client.ts
@@ -12,7 +12,7 @@ export function getStripe(): Stripe {
       throw new Error('STRIPE_SECRET_KEY is not configured')
     }
 
-    const mode = env.STRIPE_SECRET_KEY.startsWith('sk_live_') ? 'live' : 'test'
+    const mode = /^(sk|rk)_live_/.test(env.STRIPE_SECRET_KEY) ? 'live' : 'test'
     stripeLogger.info({ mode, apiVersion: '2026-02-25.clover' }, 'initializing stripe client')
 
     stripeInstance = new Stripe(env.STRIPE_SECRET_KEY, {
@@ -34,7 +34,7 @@ export function isStripeEnabled(): boolean {
  *  /admin/subscription-health endpoint so ops can spot a mode mismatch. */
 export function getStripeMode(): 'live' | 'test' | 'unconfigured' {
   if (!env.STRIPE_SECRET_KEY) return 'unconfigured'
-  return env.STRIPE_SECRET_KEY.startsWith('sk_live_') ? 'live' : 'test'
+  return /^(sk|rk)_live_/.test(env.STRIPE_SECRET_KEY) ? 'live' : 'test'
 }
 
 /** Type guard around the Stripe SDK error hierarchy. Lets call sites map


### PR DESCRIPTION
## Summary
Updated Stripe mode detection logic to recognize both standard secret keys (`sk_live_`) and restricted keys (`rk_live_`) when determining whether the Stripe client is in live or test mode.

## Changes
- Updated regex pattern in `getStripe()` to match both `sk_live_` and `rk_live_` prefixes
- Updated regex pattern in `getStripeMode()` to match both `sk_live_` and `rk_live_` prefixes
- Updated regex pattern in `validateEnv()` to match both `sk_live_` and `rk_live_` prefixes for webhook secret validation

## Details
Stripe supports restricted keys (prefixed with `rk_`) in addition to standard secret keys (prefixed with `sk_`). The previous implementation only checked for the `sk_live_` prefix, which would incorrectly classify restricted live keys as test mode. The new regex pattern `/^(sk|rk)_live_/` properly handles both key types across all mode detection functions.

https://claude.ai/code/session_013uB3gCxQbQvcCmzjzqdpPV