### PR TITLE
Distinguish admin-granted premium from Stripe subscriptions

### DIFF
--- a/packages/backend/src/presentation/routes/subscription.routes.ts
+++ b/packages/backend/src/presentation/routes/subscription.routes.ts
@@ -22,6 +22,8 @@ const subLogger = logger.child({ module: 'subscription' })
 // GET /api/subscription/me — current subscription state
 // Admins and admin-granted premium users are reported as active premium so
 // the client-side PremiumGate unlocks features regardless of Stripe state.
+// `source` distinguishes a real Stripe-backed sub (manageable via the Customer
+// Portal) from an admin grant (no Stripe customer — Manage button is hidden).
 subscriptionRoutes.get('/me', async (req: Request, res: Response) => {
   try {
     const [user, subscription] = await Promise.all([
@@ -31,9 +33,11 @@ subscriptionRoutes.get('/me', async (req: Request, res: Response) => {
         .first(),
       db('subscriptions')
         .where({ user_id: req.userId })
-        .select('tier', 'status', 'current_period_end', 'cancel_at_period_end')
+        .select('tier', 'status', 'current_period_end', 'cancel_at_period_end', 'stripe_customer_id')
         .first(),
     ])
+
+    const hasStripeCustomer = !!subscription?.stripe_customer_id
 
     if (user?.is_admin || user?.admin_granted_premium) {
       res.json({
@@ -41,6 +45,7 @@ subscriptionRoutes.get('/me', async (req: Request, res: Response) => {
         status: 'active',
         currentPeriodEnd: subscription?.current_period_end || null,
         cancelAtPeriodEnd: false,
+        source: hasStripeCustomer ? 'stripe' : 'admin_grant',
       })
       return
     }
@@ -50,6 +55,7 @@ subscriptionRoutes.get('/me', async (req: Request, res: Response) => {
       status: subscription?.status || 'inactive',
       currentPeriodEnd: subscription?.current_period_end || null,
       cancelAtPeriodEnd: !!subscription?.cancel_at_period_end,
+      source: hasStripeCustomer ? 'stripe' : 'none',
     })
   } catch (error) {
     subLogger.error({ error: String(error) }, 'failed to get status')

--- a/packages/frontend/src/i18n/locales/fr.json
+++ b/packages/frontend/src/i18n/locales/fr.json
@@ -507,6 +507,7 @@
       "feature": "Cette fonctionnalité fait partie de Premium."
     },
     "manageButton": "Gérer mon abonnement",
+    "adminGrantedDescription": "Premium t'a été accordé par un administrateur. Aucun paiement n'est associé à ton compte — il n'y a donc pas de portail de gestion.",
     "activated": "Abonnement Premium activé !",
     "activating": "Activation de ton abonnement...",
     "activationDelayed": "L'activation prend plus longtemps que prévu — recharge la page dans un instant.",
@@ -521,7 +522,9 @@
       "prorationNotice": "En passant à l'annuel, vous êtes facturé immédiatement au prorata. Pas de remboursement sur le mois en cours."
     },
     "upgradeMonthly": "Passer en Premium — {{price}}/mois",
-    "upgradeYearly": "Passer en Premium — {{price}}/an"
+    "upgradeYearly": "Passer en Premium — {{price}}/an",
+    "portalErrorNoSubscription": "Aucun abonnement Stripe à gérer pour ce compte",
+    "portalErrorStripe": "Le portail de gestion Stripe n'est pas disponible pour le moment"
   },
   "premium": {
     "featureLocked": "Fonctionnalité Premium",

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -320,7 +320,7 @@ export const api = {
     }),
 
   // Subscription
-  getSubscription: () => request<{ tier: 'free' | 'premium'; status: 'active' | 'past_due' | 'canceled' | 'inactive'; currentPeriodEnd: string | null; cancelAtPeriodEnd: boolean }>('/subscription/me'),
+  getSubscription: () => request<{ tier: 'free' | 'premium'; status: 'active' | 'past_due' | 'canceled' | 'inactive'; currentPeriodEnd: string | null; cancelAtPeriodEnd: boolean; source: 'stripe' | 'admin_grant' | 'none' }>('/subscription/me'),
   getCatalog: () => request<{ entries: Array<{ cadence: 'monthly' | 'yearly'; priceId: string; unitAmount: number | null; currency: string | null; default: boolean }>; annualAvailable: boolean }>('/subscription/catalog'),
   createCheckout: (cadence: 'monthly' | 'yearly' = 'monthly') =>
     request<{ url: string }>('/subscription/checkout', { method: 'POST', body: JSON.stringify({ cadence }) }),

--- a/packages/frontend/src/pages/SubscriptionPage.tsx
+++ b/packages/frontend/src/pages/SubscriptionPage.tsx
@@ -9,7 +9,7 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { useSubscriptionStore, selectIsPremium } from '@/stores/subscription.store'
-import { api } from '@/lib/api'
+import { api, ApiError } from '@/lib/api'
 import { useDocumentTitle } from '@/hooks/useDocumentTitle'
 import { track } from '@/lib/analytics'
 
@@ -21,7 +21,7 @@ export function SubscriptionPage() {
   const { t } = useTranslation()
   useDocumentTitle(t('subscription.title'))
   const navigate = useNavigate()
-  const { tier, currentPeriodEnd, cancelAtPeriodEnd, loading, fetchSubscription } = useSubscriptionStore()
+  const { tier, currentPeriodEnd, cancelAtPeriodEnd, source, loading, fetchSubscription } = useSubscriptionStore()
   const isPremium = useSubscriptionStore(selectIsPremium)
   const [searchParams] = useSearchParams()
   const [actionLoading, setActionLoading] = useState(false)
@@ -154,8 +154,15 @@ export function SubscriptionPage() {
     try {
       const { url } = await api.createPortal()
       window.location.href = url
-    } catch {
-      toast.error(t('subscription.portalError'))
+    } catch (err) {
+      const code = err instanceof ApiError ? err.code : 'unknown'
+      const messageKey =
+        code === 'no_subscription'
+          ? 'subscription.portalErrorNoSubscription'
+          : code === 'stripe_error'
+            ? 'subscription.portalErrorStripe'
+            : 'subscription.portalError'
+      toast.error(t(messageKey))
       setActionLoading(false)
     }
   }
@@ -164,6 +171,8 @@ export function SubscriptionPage() {
   // who would see the upgrade gate elsewhere never sees the "Premium"
   // badge on this page (they used to diverge: the page treated
   // status='canceled' as premium, the gate did not).
+  const isAdminGranted = isPremium && source === 'admin_grant'
+  const canManageSubscription = isPremium && source === 'stripe'
 
   return (
     <div className="min-h-dvh flex flex-col bg-background">
@@ -211,9 +220,11 @@ export function SubscriptionPage() {
             ) : isPremium ? (
               <>
                 <p className="text-muted-foreground">
-                  {t('subscription.premiumDescription')}
+                  {isAdminGranted
+                    ? t('subscription.adminGrantedDescription')
+                    : t('subscription.premiumDescription')}
                 </p>
-                {currentPeriodEnd && (
+                {currentPeriodEnd && !isAdminGranted && (
                   <p className="text-sm text-muted-foreground">
                     {t('subscription.renewsAt', {
                       date: new Date(currentPeriodEnd).toLocaleDateString('fr-FR', {
@@ -227,10 +238,12 @@ export function SubscriptionPage() {
                     {t('subscription.canceledNotice')}
                   </p>
                 )}
-                <Button variant="secondary" onClick={handlePortal} disabled={actionLoading}>
-                  <ExternalLink className="size-4 mr-2" />
-                  {t('subscription.manageButton')}
-                </Button>
+                {canManageSubscription && (
+                  <Button variant="secondary" onClick={handlePortal} disabled={actionLoading}>
+                    <ExternalLink className="size-4 mr-2" />
+                    {t('subscription.manageButton')}
+                  </Button>
+                )}
               </>
             ) : (
               <>

--- a/packages/frontend/src/stores/subscription.store.ts
+++ b/packages/frontend/src/stores/subscription.store.ts
@@ -14,6 +14,7 @@ interface SubscriptionState {
   status: SubscriptionStatus
   currentPeriodEnd: string | null
   cancelAtPeriodEnd: boolean
+  source: 'stripe' | 'admin_grant' | 'none'
   loading: boolean
   /** True after the first successful fetch — lets the UI distinguish
    *  "we don't know yet" (loading + !hydrated) from "user really is free"
@@ -31,6 +32,7 @@ interface SubscriptionSnapshot {
   status: SubscriptionStatus
   currentPeriodEnd: string | null
   cancelAtPeriodEnd: boolean
+  source: 'stripe' | 'admin_grant' | 'none'
 }
 
 function readSnapshot(): SubscriptionSnapshot | null {
@@ -63,6 +65,7 @@ export const useSubscriptionStore = create<SubscriptionState>((set, get) => ({
   status: initialSnapshot?.status ?? 'inactive',
   currentPeriodEnd: initialSnapshot?.currentPeriodEnd ?? null,
   cancelAtPeriodEnd: initialSnapshot?.cancelAtPeriodEnd ?? false,
+  source: initialSnapshot?.source ?? 'none',
   loading: true,
   hydrated: !!initialSnapshot,
   fetchSubscription: async () => {
@@ -73,6 +76,7 @@ export const useSubscriptionStore = create<SubscriptionState>((set, get) => ({
         status: data.status,
         currentPeriodEnd: data.currentPeriodEnd,
         cancelAtPeriodEnd: data.cancelAtPeriodEnd,
+        source: data.source,
       }
       writeSnapshot(snapshot)
       set({ ...snapshot, loading: false, hydrated: true })
@@ -88,6 +92,7 @@ export const useSubscriptionStore = create<SubscriptionState>((set, get) => ({
           status: 'inactive',
           currentPeriodEnd: null,
           cancelAtPeriodEnd: false,
+          source: 'none',
           loading: false,
         })
       } else {


### PR DESCRIPTION
## Summary
This PR adds support for distinguishing between Stripe-backed premium subscriptions and admin-granted premium access. This allows the UI to hide the Stripe Customer Portal management button for admin-granted users while showing appropriate messaging about their subscription source.

## Key Changes
- **Backend**: Modified `/subscription/me` endpoint to return a `source` field indicating whether premium access comes from `'stripe'`, `'admin_grant'`, or `'none'`. The source is determined by checking if a `stripe_customer_id` exists on the subscription record.
- **Frontend Store**: Updated `useSubscriptionStore` to track and persist the subscription `source` field.
- **Frontend UI**: 
  - Added conditional rendering to show different descriptions based on subscription source
  - Hide the "Manage Subscription" button for admin-granted users (only show for Stripe subscriptions)
  - Hide renewal date information for admin-granted subscriptions
- **Error Handling**: Enhanced portal creation error handling to distinguish between different error types (`no_subscription`, `stripe_error`) and show appropriate localized messages.
- **Localization**: Added French translations for admin-granted subscription description and specific portal error messages.
- **Type Safety**: Updated API response type to include the new `source` field.

## Implementation Details
- The `source` field is derived server-side from the presence of `stripe_customer_id` rather than being stored separately, keeping the data model simple
- Admin users and users with `admin_granted_premium` flag are reported as active premium regardless of Stripe state, but the `source` field correctly reflects whether they have a Stripe customer
- The `ApiError` class is now imported and used to provide more granular error handling for portal operations

https://claude.ai/code/session_01PMnFzS4FMmMN3oFi5iZNEZ