### PR TITLE
feat(pwa): notify user with a panel when an app update is ready

### DIFF
--- a/packages/frontend/src/components/pwa-update-panel.tsx
+++ b/packages/frontend/src/components/pwa-update-panel.tsx
@@ -1,0 +1,92 @@
+import { useTranslation } from 'react-i18next'
+import { useRegisterSW } from 'virtual:pwa-register/react'
+import { AnimatePresence, motion } from 'framer-motion'
+import { RefreshCw, X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+/**
+ * Surfaces a fixed bottom panel when vite-plugin-pwa detects that a fresh
+ * service worker is waiting. The user can refresh on demand (calls
+ * `updateServiceWorker(true)`, which `skipWaiting`s the new SW and reloads
+ * the page) or dismiss the panel and keep working — the new SW stays in
+ * waiting state and the panel re-surfaces if a subsequent deploy fires
+ * `onNeedRefresh` again.
+ *
+ * Wrapped in AnimatePresence/motion so it slides in without jolting the
+ * layout (the panel sits in a fixed overlay above the routes).
+ */
+export function PwaUpdatePanel() {
+  const { t } = useTranslation()
+
+  const {
+    needRefresh: [needRefresh, setNeedRefresh],
+    updateServiceWorker,
+  } = useRegisterSW({
+    onRegisteredSW(_url, registration) {
+      // Belt-and-braces hourly check: vite-plugin-pwa calls `update()` on
+      // load, but a long-lived PWA tab (mobile, screen never locked) would
+      // otherwise miss deploys until a manual reload. 1h is gentle enough
+      // not to hammer the SW cache.
+      if (!registration) return
+      setInterval(() => {
+        void registration.update()
+      }, 60 * 60 * 1000)
+    },
+  })
+
+  const dismiss = () => {
+    setNeedRefresh(false)
+  }
+
+  const refresh = () => {
+    void updateServiceWorker(true)
+  }
+
+  return (
+    <AnimatePresence>
+      {needRefresh && (
+        <motion.div
+          role="status"
+          aria-live="polite"
+          initial={{ y: 80, opacity: 0 }}
+          animate={{ y: 0, opacity: 1 }}
+          exit={{ y: 80, opacity: 0 }}
+          transition={{ type: 'spring', stiffness: 320, damping: 32 }}
+          className="fixed inset-x-0 bottom-0 z-50 flex justify-center px-4 pb-[max(env(safe-area-inset-bottom),1rem)] sm:px-6 pointer-events-none"
+        >
+          <div className="pointer-events-auto w-full max-w-md rounded-2xl border border-border bg-card/95 p-4 shadow-[0_10px_40px_oklch(0_0_0_/_0.5)] backdrop-blur-md">
+            <div className="flex items-start gap-3">
+              <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-primary/15 text-primary">
+                <RefreshCw className="size-5" aria-hidden="true" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <h2 className="text-sm font-semibold text-card-foreground">
+                  {t('pwa.updateAvailableTitle')}
+                </h2>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {t('pwa.updateAvailableDescription')}
+                </p>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <Button size="sm" onClick={refresh}>
+                    {t('pwa.updateAction')}
+                  </Button>
+                  <Button size="sm" variant="ghost" onClick={dismiss}>
+                    {t('pwa.updateLater')}
+                  </Button>
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={dismiss}
+                aria-label={t('pwa.updateDismissLabel')}
+                className="-m-1 inline-flex size-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+              >
+                <X className="size-4" aria-hidden="true" />
+              </button>
+            </div>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/packages/frontend/src/i18n/locales/en.json
+++ b/packages/frontend/src/i18n/locales/en.json
@@ -488,7 +488,12 @@
     "enableNotifications": "Enable notifications",
     "notificationsEnabled": "Notifications enabled",
     "notificationsDenied": "Permission denied (check your browser settings)",
-    "notificationsUnsupported": "Not supported in this browser"
+    "notificationsUnsupported": "Not supported in this browser",
+    "updateAvailableTitle": "Update available",
+    "updateAvailableDescription": "A new version of WAWPTN is ready. Refresh to apply it.",
+    "updateAction": "Refresh",
+    "updateLater": "Later",
+    "updateDismissLabel": "Dismiss update notification"
   },
   "notifications": {
     "title": "Notifications",

--- a/packages/frontend/src/i18n/locales/fr.json
+++ b/packages/frontend/src/i18n/locales/fr.json
@@ -574,7 +574,12 @@
     "enableNotifications": "Activer les notifications",
     "notificationsEnabled": "Notifications activées",
     "notificationsDenied": "Permission refusée (vérifiez vos paramètres navigateur)",
-    "notificationsUnsupported": "Non supporté sur ce navigateur"
+    "notificationsUnsupported": "Non supporté sur ce navigateur",
+    "updateAvailableTitle": "Mise à jour disponible",
+    "updateAvailableDescription": "Une nouvelle version de WAWPTN est prête. Rafraîchissez pour l'appliquer.",
+    "updateAction": "Rafraîchir",
+    "updateLater": "Plus tard",
+    "updateDismissLabel": "Ignorer la notification de mise à jour"
   },
   "notifications": {
     "title": "Notifications",

--- a/packages/frontend/src/lib/pwa.ts
+++ b/packages/frontend/src/lib/pwa.ts
@@ -3,9 +3,10 @@
  * notification delivery via the registered service worker, and the
  * `beforeinstallprompt` capture for "install to home screen" UX.
  *
- * The service worker itself is registered automatically by vite-plugin-pwa
- * (`registerType: 'autoUpdate'` in vite.config.ts). This module is a thin
- * wrapper over the browser APIs — it never installs its own SW.
+ * The service worker itself is registered by vite-plugin-pwa in `prompt`
+ * mode — `<PwaUpdatePanel>` calls `useRegisterSW` and surfaces the refresh
+ * UI. This module is a thin wrapper over the browser APIs — it never
+ * installs its own SW.
  */
 
 /** Whether the current browser supports the Notification API at all. */

--- a/packages/frontend/src/main.tsx
+++ b/packages/frontend/src/main.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { Toaster } from 'sonner'
 import { ErrorBoundary } from '@/components/error-boundary'
+import { PwaUpdatePanel } from '@/components/pwa-update-panel'
 import App from './App'
 import './i18n'
 import './index.css'
@@ -15,6 +16,7 @@ createRoot(document.getElementById('root')!).render(
         <ErrorBoundary>
           <App />
         </ErrorBoundary>
+        <PwaUpdatePanel />
         <Toaster
           theme="dark"
           position="bottom-center"

--- a/packages/frontend/src/vite-env.d.ts
+++ b/packages/frontend/src/vite-env.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="vite/client" />
+/// <reference types="vite-plugin-pwa/react" />
 
 declare const __APP_VERSION__: string
 declare const __BUILD_TIME__: string

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -22,7 +22,11 @@ export default defineConfig({
     react(),
     tailwindcss(),
     VitePWA({
-      registerType: 'autoUpdate',
+      // Prompt-based: a new SW waits in the background until the user
+      // confirms via <PwaUpdatePanel>. Switching from `autoUpdate` avoids
+      // dropping a vote / unsaved input on the floor when a deploy lands
+      // mid-session.
+      registerType: 'prompt',
       includeAssets: ['favicon.ico', 'apple-touch-icon.png', 'logo.svg'],
       manifest: {
         name: 'WAWPTN - On joue à quoi ce soir ?',


### PR DESCRIPTION
Switch vite-plugin-pwa from autoUpdate to prompt mode so a deploy mid-
session no longer steals an in-flight vote or unsaved input. A new
PwaUpdatePanel surfaces a fixed bottom panel via useRegisterSW with
Refresh / Later actions, hourly background SW update checks, and FR/EN
copy.