### PR TITLE
feat(billing): support annual subscription cadence with anti-Toko boot guard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,15 +75,29 @@ STEAM_API_KEY=your-steam-web-api-key
 
 # ── Stripe (optional — enables premium subscriptions) ──
 # 1. Create a Stripe account or use test mode
-# 2. Create a Product (e.g. "WAWPTN Premium")
-# 3. Create a recurring Price: 3€/month
+# 2. Create a Product (e.g. "WAWPTN Premium") and copy its prod_… id below
+# 3. Create one or two recurring Prices on that product (monthly, yearly)
 # 4. Set up a Webhook → https://<domain>/api/subscription/webhook
 #    Events: checkout.session.completed, customer.subscription.updated,
 #            customer.subscription.deleted, invoice.payment_failed
 # 5. Configure the Customer Portal in the Stripe dashboard
 # STRIPE_SECRET_KEY=<STRIPE_SECRET_KEY>
 # STRIPE_WEBHOOK_SECRET=<STRIPE_WEBHOOK_SECRET>
-# STRIPE_PRICE_ID=<STRIPE_PRICE_ID>
+#
+# Cadence-scoped price IDs. If only the monthly is configured the annual
+# toggle is hidden in the UI. STRIPE_PRICE_ID (single) is kept as a legacy
+# alias for the monthly cadence so existing single-price deployments keep
+# working without env changes.
+# STRIPE_PRICE_ID=<STRIPE_PRICE_ID_MONTHLY>          # legacy single-cadence alias
+# STRIPE_PRICE_ID_MONTHLY=<STRIPE_PRICE_ID_MONTHLY>
+# STRIPE_PRICE_ID_YEARLY=<STRIPE_PRICE_ID_YEARLY>
+#
+# When STRIPE_PRODUCT_ID is set, the backend retrieves every configured
+# price at boot and asserts price.product === STRIPE_PRODUCT_ID. This is
+# the "anti-Toko" guardrail — a price ID pointing at the wrong product
+# will refuse to boot in production. Strongly recommended for live mode.
+# STRIPE_PRODUCT_ID=<STRIPE_PRODUCT_ID>
+#
 # Set to "true" to enable Stripe Tax on Checkout (requires Stripe Tax to be
 # onboarded in the dashboard and tax_behavior set on the price object).
 # STRIPE_AUTOMATIC_TAX_ENABLED=false

--- a/packages/backend/src/config/__tests__/billing.test.ts
+++ b/packages/backend/src/config/__tests__/billing.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('@/config/env.js', () => ({
+  env: {
+    STRIPE_PRICE_ID: '',
+    STRIPE_PRICE_ID_MONTHLY: '',
+    STRIPE_PRICE_ID_YEARLY: '',
+  },
+}))
+
+import { env } from '@/config/env.js'
+import {
+  isCadence,
+  resolvePriceId,
+  isAnnualAvailable,
+  getConfiguredPriceIds,
+  BILLING_CATALOG,
+} from '../billing.js'
+
+describe('billing catalog', () => {
+  beforeEach(() => {
+    env.STRIPE_PRICE_ID = ''
+    env.STRIPE_PRICE_ID_MONTHLY = ''
+    env.STRIPE_PRICE_ID_YEARLY = ''
+  })
+
+  describe('isCadence', () => {
+    it('accepts the supported cadences', () => {
+      expect(isCadence('monthly')).toBe(true)
+      expect(isCadence('yearly')).toBe(true)
+    })
+
+    it('rejects everything else, including objects and the empty string', () => {
+      expect(isCadence('')).toBe(false)
+      expect(isCadence('weekly')).toBe(false)
+      expect(isCadence(undefined)).toBe(false)
+      expect(isCadence(null)).toBe(false)
+      expect(isCadence({})).toBe(false)
+      expect(isCadence(42)).toBe(false)
+    })
+  })
+
+  describe('BILLING_CATALOG', () => {
+    it('has exactly one default entry', () => {
+      const defaults = BILLING_CATALOG.filter((e) => e.default)
+      expect(defaults).toHaveLength(1)
+    })
+
+    it('defaults to yearly to push ARPU per converted user', () => {
+      const fallback = BILLING_CATALOG.find((e) => e.default)
+      expect(fallback?.cadence).toBe('yearly')
+    })
+  })
+
+  describe('resolvePriceId', () => {
+    it('returns the cadence-scoped var when set', () => {
+      env.STRIPE_PRICE_ID_MONTHLY = 'price_monthly_x'
+      env.STRIPE_PRICE_ID_YEARLY = 'price_yearly_x'
+      expect(resolvePriceId('monthly')).toBe('price_monthly_x')
+      expect(resolvePriceId('yearly')).toBe('price_yearly_x')
+    })
+
+    it('falls back to STRIPE_PRICE_ID for monthly when the cadence-scoped var is missing (back-compat)', () => {
+      env.STRIPE_PRICE_ID = 'price_legacy'
+      expect(resolvePriceId('monthly')).toBe('price_legacy')
+    })
+
+    it('does NOT fall back to STRIPE_PRICE_ID for yearly — silent fall-through is the Toko failure mode', () => {
+      env.STRIPE_PRICE_ID = 'price_legacy_monthly'
+      expect(resolvePriceId('yearly')).toBeNull()
+    })
+
+    it('returns null when nothing is configured', () => {
+      expect(resolvePriceId('monthly')).toBeNull()
+      expect(resolvePriceId('yearly')).toBeNull()
+    })
+  })
+
+  describe('isAnnualAvailable', () => {
+    it('is true only when the yearly price is explicitly configured', () => {
+      env.STRIPE_PRICE_ID_YEARLY = 'price_yearly_x'
+      expect(isAnnualAvailable()).toBe(true)
+    })
+
+    it('stays false when only the monthly is set', () => {
+      env.STRIPE_PRICE_ID_MONTHLY = 'price_monthly_x'
+      expect(isAnnualAvailable()).toBe(false)
+    })
+
+    it('stays false on legacy single-price deployments', () => {
+      env.STRIPE_PRICE_ID = 'price_legacy'
+      expect(isAnnualAvailable()).toBe(false)
+    })
+  })
+
+  describe('getConfiguredPriceIds', () => {
+    it('deduplicates when monthly aliases STRIPE_PRICE_ID', () => {
+      env.STRIPE_PRICE_ID = 'price_legacy'
+      env.STRIPE_PRICE_ID_MONTHLY = 'price_legacy'
+      env.STRIPE_PRICE_ID_YEARLY = 'price_yearly_x'
+      const ids = getConfiguredPriceIds()
+      expect(ids).toHaveLength(2)
+      expect(ids).toContain('price_legacy')
+      expect(ids).toContain('price_yearly_x')
+    })
+
+    it('returns an empty list when nothing is configured', () => {
+      expect(getConfiguredPriceIds()).toEqual([])
+    })
+  })
+})

--- a/packages/backend/src/config/billing.ts
+++ b/packages/backend/src/config/billing.ts
@@ -1,0 +1,74 @@
+import { env } from './env.js'
+
+/** Subscription cadence — exposed to API callers (frontend toggle) and to
+ *  the checkout/webhook layer to resolve the right Stripe price.
+ *
+ *  Why a discrete enum instead of just a price ID string from the client:
+ *  - The price ID is server-side only. The client picks a *cadence* and the
+ *    server maps it to the configured price ID. A hostile client cannot
+ *    inject an arbitrary `price_xxx`.
+ *  - The set of supported cadences is stable; adding `lifetime` or
+ *    `quarterly` later is one entry in the catalog. */
+export type Cadence = 'monthly' | 'yearly'
+
+export const CADENCES: readonly Cadence[] = ['monthly', 'yearly'] as const
+
+export function isCadence(value: unknown): value is Cadence {
+  return value === 'monthly' || value === 'yearly'
+}
+
+interface CatalogEntry {
+  cadence: Cadence
+  /** Stable Stripe `lookup_key` posted on the live + test prices. The catalog
+   *  resolves the price ID via `stripe.prices.list({ lookup_keys })` at
+   *  boot, so a price rotation in Stripe does not require an env change. */
+  lookupKey: string
+  /** Default selection in the UI when a user lands on the upgrade page
+   *  without an explicit cadence — annual is pre-selected to push ARPU
+   *  per converted user without a hard sell. */
+  default: boolean
+}
+
+/** WAWPTN Premium catalog. Amounts are deliberately NOT stored here:
+ *  Stripe is the single source of truth for price. The frontend reads the
+ *  resolved amount from `/api/subscription/catalog` (populated at boot
+ *  from `stripe.prices.list`). */
+export const BILLING_CATALOG: readonly CatalogEntry[] = [
+  { cadence: 'monthly', lookupKey: 'wawptn_premium_monthly', default: false },
+  { cadence: 'yearly',  lookupKey: 'wawptn_premium_yearly',  default: true  },
+] as const
+
+/** Resolve the configured Stripe price ID for a given cadence from env.
+ *  Falls back to `STRIPE_PRICE_ID` when the cadence-specific var is unset
+ *  so existing single-price deployments keep working unchanged.
+ *
+ *  Returns null when the requested cadence is not configured — callers
+ *  should treat this as "cadence unavailable" and either reject the
+ *  request or hide the UI affordance, NOT silently fall back to the other
+ *  cadence (which is exactly the kind of price substitution the Toko
+ *  incident exposed). */
+export function resolvePriceId(cadence: Cadence): string | null {
+  if (cadence === 'monthly') {
+    return env.STRIPE_PRICE_ID_MONTHLY || env.STRIPE_PRICE_ID || null
+  }
+  return env.STRIPE_PRICE_ID_YEARLY || null
+}
+
+/** True when both monthly and yearly are configured — UI uses this to
+ *  decide whether to render the cadence toggle or fall back to a single
+ *  CTA. */
+export function isAnnualAvailable(): boolean {
+  return !!resolvePriceId('yearly')
+}
+
+/** All configured price IDs across the catalog. Drives the boot-time
+ *  product-assertion in `validateEnv()` and could later back an explicit
+ *  webhook allowlist. */
+export function getConfiguredPriceIds(): string[] {
+  const ids = new Set<string>()
+  for (const entry of BILLING_CATALOG) {
+    const id = resolvePriceId(entry.cadence)
+    if (id) ids.add(id)
+  }
+  return [...ids]
+}

--- a/packages/backend/src/config/env.ts
+++ b/packages/backend/src/config/env.ts
@@ -58,7 +58,18 @@ export const env = {
   // configuration cannot silently 400 every webhook.
   STRIPE_SECRET_KEY: process.env['STRIPE_SECRET_KEY'] || '',
   STRIPE_WEBHOOK_SECRET: process.env['STRIPE_WEBHOOK_SECRET'] || '',
+  /** Legacy single-cadence price ID. Kept for back-compat — when only
+   *  STRIPE_PRICE_ID is set the checkout uses it for the monthly cadence
+   *  and the annual toggle is hidden. New deployments should set the
+   *  cadence-scoped vars below instead. */
   STRIPE_PRICE_ID: process.env['STRIPE_PRICE_ID'] || '',
+  STRIPE_PRICE_ID_MONTHLY: process.env['STRIPE_PRICE_ID_MONTHLY'] || '',
+  STRIPE_PRICE_ID_YEARLY: process.env['STRIPE_PRICE_ID_YEARLY'] || '',
+  /** Stripe Product ID for WAWPTN Premium. When set, validateEnv() asserts
+   *  every configured price belongs to this product — guards against the
+   *  "STRIPE_PRICE_ID points at the wrong product" misconfiguration that
+   *  produced the Toko Premium incident. Empty disables the check. */
+  STRIPE_PRODUCT_ID: process.env['STRIPE_PRODUCT_ID'] || '',
   // Enables Stripe Tax (automatic_tax + tax_id_collection) on Checkout.
   // Requires Stripe Tax to be onboarded in the dashboard and tax_behavior
   // set on the price object — keep disabled until that's done or Checkout
@@ -112,8 +123,11 @@ export function validateEnv(): void {
     if (!env.STRIPE_WEBHOOK_SECRET) {
       throw new Error('STRIPE_WEBHOOK_SECRET is required when STRIPE_SECRET_KEY is set')
     }
-    if (!env.STRIPE_PRICE_ID) {
-      throw new Error('STRIPE_PRICE_ID is required when STRIPE_SECRET_KEY is set')
+    // Either the legacy single-price var OR the cadence-scoped monthly var
+    // must be present so checkout can resolve a default price. Yearly is
+    // optional — when missing the UI hides the annual toggle.
+    if (!env.STRIPE_PRICE_ID && !env.STRIPE_PRICE_ID_MONTHLY) {
+      throw new Error('STRIPE_PRICE_ID (or STRIPE_PRICE_ID_MONTHLY) is required when STRIPE_SECRET_KEY is set')
     }
     // Mode parity: live secret with test webhook (or vice versa) silently
     // fails signature verification with no startup error.

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -29,6 +29,7 @@ import { discordRoutes, discordUserRoutes } from './presentation/routes/discord.
 import { adminRoutes } from './presentation/routes/admin.routes.js'
 import { subscriptionRoutes, subscriptionWebhookRouter } from './presentation/routes/subscription.routes.js'
 import { isStripeEnabled } from './infrastructure/stripe/stripe-client.js'
+import { assertConfiguredPricesBelongToProduct } from './infrastructure/stripe/billing-bootstrap.js'
 import { personaRoutes } from './presentation/routes/persona.routes.js'
 import { koeRoutes } from './presentation/routes/koe.routes.js'
 import { notificationRoutes, adminNotificationRoutes } from './presentation/routes/notification.routes.js'
@@ -298,6 +299,22 @@ async function main() {
 
   // Auto-vote scheduler (recurring auto-created sessions)
   startAutoVoteScheduler()
+
+  // Anti-Toko guardrail: assert every configured price belongs to the
+  // expected product. Fatal in production (a wrong price ID would charge
+  // customers for the wrong SKU); a warning in dev so a half-set local
+  // env doesn't block running the app.
+  if (isStripeEnabled()) {
+    try {
+      await assertConfiguredPricesBelongToProduct()
+    } catch (err) {
+      if (env.NODE_ENV === 'production') {
+        logger.fatal({ error: String(err) }, 'stripe price/product assertion failed')
+        process.exit(1)
+      }
+      logger.warn({ error: String(err) }, 'stripe price/product assertion failed (non-prod)')
+    }
+  }
 
   // Subscription reconciler (daily Stripe sync + grace period enforcement)
   startSubscriptionReconciler()

--- a/packages/backend/src/infrastructure/stripe/__tests__/billing-bootstrap.test.ts
+++ b/packages/backend/src/infrastructure/stripe/__tests__/billing-bootstrap.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('@/config/env.js', () => ({
+  env: {
+    STRIPE_SECRET_KEY: 'sk_test_xxx',
+    STRIPE_PRODUCT_ID: '',
+    STRIPE_PRICE_ID: '',
+    STRIPE_PRICE_ID_MONTHLY: '',
+    STRIPE_PRICE_ID_YEARLY: '',
+  },
+}))
+
+const stripeMock = vi.hoisted(() => ({
+  prices: { retrieve: vi.fn() },
+}))
+
+vi.mock('@/infrastructure/stripe/stripe-client.js', () => ({
+  getStripe: () => stripeMock,
+  isStripeEnabled: () => true,
+}))
+
+vi.mock('@/infrastructure/logger/logger.js', () => ({
+  logger: { child: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }) },
+}))
+
+import { env } from '@/config/env.js'
+import { assertConfiguredPricesBelongToProduct } from '../billing-bootstrap.js'
+
+describe('assertConfiguredPricesBelongToProduct', () => {
+  beforeEach(() => {
+    env.STRIPE_PRODUCT_ID = ''
+    env.STRIPE_PRICE_ID = ''
+    env.STRIPE_PRICE_ID_MONTHLY = ''
+    env.STRIPE_PRICE_ID_YEARLY = ''
+    stripeMock.prices.retrieve.mockReset()
+  })
+
+  it('no-ops when STRIPE_PRODUCT_ID is unset (opt-in guardrail)', async () => {
+    env.STRIPE_PRICE_ID_MONTHLY = 'price_monthly'
+    await expect(assertConfiguredPricesBelongToProduct()).resolves.toBeUndefined()
+    expect(stripeMock.prices.retrieve).not.toHaveBeenCalled()
+  })
+
+  it('passes when every configured price belongs to the expected product', async () => {
+    env.STRIPE_PRODUCT_ID = 'prod_wawptn'
+    env.STRIPE_PRICE_ID_MONTHLY = 'price_m'
+    env.STRIPE_PRICE_ID_YEARLY = 'price_y'
+    stripeMock.prices.retrieve.mockImplementation(async (id: string) => ({
+      id,
+      product: 'prod_wawptn',
+      lookup_key: id,
+      recurring: { interval: id === 'price_m' ? 'month' : 'year' },
+    }))
+
+    await expect(assertConfiguredPricesBelongToProduct()).resolves.toBeUndefined()
+    expect(stripeMock.prices.retrieve).toHaveBeenCalledTimes(2)
+  })
+
+  it('throws when a configured price points at the wrong product (Toko scenario)', async () => {
+    env.STRIPE_PRODUCT_ID = 'prod_wawptn'
+    env.STRIPE_PRICE_ID_MONTHLY = 'price_toko'
+    stripeMock.prices.retrieve.mockResolvedValueOnce({
+      id: 'price_toko',
+      product: 'prod_toko',
+      recurring: { interval: 'month' },
+    })
+
+    await expect(assertConfiguredPricesBelongToProduct()).rejects.toThrow(/price_toko.*prod_toko/)
+  })
+
+  it('handles the expanded-product object form', async () => {
+    env.STRIPE_PRODUCT_ID = 'prod_wawptn'
+    env.STRIPE_PRICE_ID_MONTHLY = 'price_m'
+    stripeMock.prices.retrieve.mockResolvedValueOnce({
+      id: 'price_m',
+      product: { id: 'prod_wawptn', name: 'WAWPTN Premium' },
+      recurring: { interval: 'month' },
+    })
+
+    await expect(assertConfiguredPricesBelongToProduct()).resolves.toBeUndefined()
+  })
+})

--- a/packages/backend/src/infrastructure/stripe/billing-bootstrap.ts
+++ b/packages/backend/src/infrastructure/stripe/billing-bootstrap.ts
@@ -1,0 +1,49 @@
+import { env } from '../../config/env.js'
+import { getConfiguredPriceIds } from '../../config/billing.js'
+import { getStripe, isStripeEnabled } from './stripe-client.js'
+import { logger } from '../logger/logger.js'
+
+const bootLogger = logger.child({ module: 'billing-bootstrap' })
+
+/**
+ * Boot-time guardrail against the Toko-Premium failure mode: a stringly-
+ * typed STRIPE_PRICE_ID env var pointing at the wrong Stripe Product (in
+ * the original incident, the Toko Premium 4,99 € price instead of WAWPTN
+ * Premium). The mistake passed startup, passed checkout, and would have
+ * silently sold the wrong subscription.
+ *
+ * Mitigation: when STRIPE_PRODUCT_ID is configured, retrieve every price
+ * the catalog resolves to and assert `price.product === STRIPE_PRODUCT_ID`.
+ * Mismatch → throw on boot. Caller (index.ts) treats throws here as fatal
+ * in production and as a warning in development so a half-set local env
+ * doesn't block running the app without Stripe.
+ */
+export async function assertConfiguredPricesBelongToProduct(): Promise<void> {
+  if (!isStripeEnabled()) return
+  if (!env.STRIPE_PRODUCT_ID) {
+    bootLogger.warn(
+      'STRIPE_PRODUCT_ID unset — skipping price/product assertion. Set it to guard against the Toko-style misconfiguration.',
+    )
+    return
+  }
+
+  const priceIds = getConfiguredPriceIds()
+  if (priceIds.length === 0) return
+
+  const stripe = getStripe()
+  const expectedProduct = env.STRIPE_PRODUCT_ID
+
+  for (const priceId of priceIds) {
+    const price = await stripe.prices.retrieve(priceId)
+    const productId = typeof price.product === 'string' ? price.product : price.product.id
+    if (productId !== expectedProduct) {
+      throw new Error(
+        `Stripe price/product mismatch: ${priceId} belongs to product ${productId}, expected ${expectedProduct}. Refusing to boot to prevent selling the wrong product.`,
+      )
+    }
+    bootLogger.info(
+      { priceId, productId, lookupKey: price.lookup_key, recurring: price.recurring?.interval },
+      'price/product assertion ok',
+    )
+  }
+}

--- a/packages/backend/src/presentation/routes/subscription.routes.ts
+++ b/packages/backend/src/presentation/routes/subscription.routes.ts
@@ -3,6 +3,7 @@ import type { Request, Response } from 'express'
 import type Stripe from 'stripe'
 import { getStripe, isStripeError, stripeErrorContext } from '../../infrastructure/stripe/stripe-client.js'
 import { env } from '../../config/env.js'
+import { isCadence, resolvePriceId, isAnnualAvailable, BILLING_CATALOG, type Cadence } from '../../config/billing.js'
 import { db } from '../../infrastructure/database/connection.js'
 import { logger } from '../../infrastructure/logger/logger.js'
 
@@ -56,11 +57,65 @@ subscriptionRoutes.get('/me', async (req: Request, res: Response) => {
   }
 })
 
+// GET /api/subscription/catalog — public-facing pricing catalog. Drives
+// the cadence toggle in the upgrade UI. Reads live amounts from Stripe
+// once and caches in-memory; if Stripe is unreachable, callers fall back
+// to the monthly-only single-CTA layout.
+const CATALOG_CACHE_TTL_MS = 5 * 60_000
+let catalogCache: { value: Array<{ cadence: Cadence; priceId: string; unitAmount: number | null; currency: string | null; default: boolean }>; expiresAt: number } | null = null
+
+subscriptionRoutes.get('/catalog', async (_req: Request, res: Response) => {
+  try {
+    const now = Date.now()
+    if (catalogCache && catalogCache.expiresAt > now) {
+      res.json({ entries: catalogCache.value, annualAvailable: isAnnualAvailable() })
+      return
+    }
+
+    const stripe = getStripe()
+    const entries: Array<{ cadence: Cadence; priceId: string; unitAmount: number | null; currency: string | null; default: boolean }> = []
+
+    for (const entry of BILLING_CATALOG) {
+      const priceId = resolvePriceId(entry.cadence)
+      if (!priceId) continue
+      try {
+        const price = await stripe.prices.retrieve(priceId)
+        entries.push({
+          cadence: entry.cadence,
+          priceId,
+          unitAmount: typeof price.unit_amount === 'number' ? price.unit_amount : null,
+          currency: typeof price.currency === 'string' ? price.currency : null,
+          default: entry.default,
+        })
+      } catch (err) {
+        subLogger.warn({ priceId, error: String(err) }, 'catalog: failed to retrieve price')
+      }
+    }
+
+    catalogCache = { value: entries, expiresAt: now + CATALOG_CACHE_TTL_MS }
+    res.json({ entries, annualAvailable: isAnnualAvailable() })
+  } catch (error) {
+    subLogger.error({ error: String(error) }, 'failed to build catalog')
+    res.status(500).json({ error: 'internal', message: 'Failed to load catalog' })
+  }
+})
+
 // POST /api/subscription/checkout — create Stripe Checkout Session
 subscriptionRoutes.post('/checkout', async (req: Request, res: Response) => {
   try {
     const stripe = getStripe()
     const userId = req.userId!
+
+    // Resolve cadence: client sends a discrete enum, server maps it to a
+    // configured price ID. The price string is never taken from the
+    // client — that closes the price-substitution attack surface.
+    const requestedCadence: unknown = (req.body as { cadence?: unknown } | undefined)?.cadence
+    const cadence: Cadence = isCadence(requestedCadence) ? requestedCadence : 'monthly'
+    const priceId = resolvePriceId(cadence)
+    if (!priceId) {
+      res.status(400).json({ error: 'cadence_unavailable', message: `Cadence "${cadence}" is not configured` })
+      return
+    }
 
     // Get or create Stripe customer. The idempotency key keyed off userId
     // makes the customer-create call safe under concurrent double-clicks
@@ -104,15 +159,16 @@ subscriptionRoutes.post('/checkout', async (req: Request, res: Response) => {
     const sessionParams: Stripe.Checkout.SessionCreateParams = {
       customer: customerId,
       mode: 'subscription',
-      line_items: [{ price: env.STRIPE_PRICE_ID, quantity: 1 }],
+      line_items: [{ price: priceId, quantity: 1 }],
       success_url: `${env.CORS_ORIGIN}/subscription?success=true`,
       cancel_url: `${env.CORS_ORIGIN}/subscription?canceled=true`,
       client_reference_id: userId,
-      // Propagate userId onto the Subscription itself so webhook handlers
-      // and the reconciler can identify the user from any Subscription
-      // object — not just from the Checkout Session.
-      subscription_data: { metadata: { userId } },
-      metadata: { userId },
+      // Propagate userId AND cadence onto the Subscription itself so
+      // webhook handlers, the reconciler, and any future audit query can
+      // identify both the user and the picked cadence from any
+      // Subscription object — not just from the Checkout Session.
+      subscription_data: { metadata: { userId, cadence } },
+      metadata: { userId, cadence },
       allow_promotion_codes: true,
     }
 
@@ -124,7 +180,7 @@ subscriptionRoutes.post('/checkout', async (req: Request, res: Response) => {
 
     const session = await stripe.checkout.sessions.create(
       sessionParams,
-      { idempotencyKey: `checkout:${userId}:${env.STRIPE_PRICE_ID}:${bucket}` },
+      { idempotencyKey: `checkout:${userId}:${priceId}:${bucket}` },
     )
 
     res.json({ url: session.url })

--- a/packages/frontend/src/i18n/locales/fr.json
+++ b/packages/frontend/src/i18n/locales/fr.json
@@ -512,7 +512,16 @@
     "activationDelayed": "L'activation prend plus longtemps que prévu — recharge la page dans un instant.",
     "canceledFromCheckout": "Paiement annulé. Tu peux réessayer quand tu veux.",
     "checkoutError": "Impossible de lancer le paiement",
-    "portalError": "Impossible d'ouvrir le portail de gestion"
+    "portalError": "Impossible d'ouvrir le portail de gestion",
+    "cadence": {
+      "monthly": "Mensuel",
+      "yearly": "Annuel",
+      "savingsBadge": "Économisez 36 %",
+      "yearlyPerMonth": "soit ~{{amount}}/mois",
+      "prorationNotice": "En passant à l'annuel, vous êtes facturé immédiatement au prorata. Pas de remboursement sur le mois en cours."
+    },
+    "upgradeMonthly": "Passer en Premium — {{price}}/mois",
+    "upgradeYearly": "Passer en Premium — {{price}}/an"
   },
   "premium": {
     "featureLocked": "Fonctionnalité Premium",

--- a/packages/frontend/src/lib/analytics.ts
+++ b/packages/frontend/src/lib/analytics.ts
@@ -38,6 +38,7 @@ export type AnalyticsEvent =
   // property (e.g. `from: 'group_limit'`).
   | 'premium.gate_shown'
   | 'premium.upgrade_clicked'
+  | 'premium.cadence_selected'
   | 'premium.checkout_started'
   | 'premium.checkout_completed'
 

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -321,7 +321,9 @@ export const api = {
 
   // Subscription
   getSubscription: () => request<{ tier: 'free' | 'premium'; status: 'active' | 'past_due' | 'canceled' | 'inactive'; currentPeriodEnd: string | null; cancelAtPeriodEnd: boolean }>('/subscription/me'),
-  createCheckout: () => request<{ url: string }>('/subscription/checkout', { method: 'POST' }),
+  getCatalog: () => request<{ entries: Array<{ cadence: 'monthly' | 'yearly'; priceId: string; unitAmount: number | null; currency: string | null; default: boolean }>; annualAvailable: boolean }>('/subscription/catalog'),
+  createCheckout: (cadence: 'monthly' | 'yearly' = 'monthly') =>
+    request<{ url: string }>('/subscription/checkout', { method: 'POST', body: JSON.stringify({ cadence }) }),
   createPortal: () => request<{ url: string }>('/subscription/portal', { method: 'POST' }),
 
   // Per-user streak roll-up (powers the GroupsPage streak badge)

--- a/packages/frontend/src/pages/SubscriptionPage.tsx
+++ b/packages/frontend/src/pages/SubscriptionPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { ArrowLeft, Crown, CreditCard, ExternalLink } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
@@ -13,6 +13,10 @@ import { api } from '@/lib/api'
 import { useDocumentTitle } from '@/hooks/useDocumentTitle'
 import { track } from '@/lib/analytics'
 
+type Cadence = 'monthly' | 'yearly'
+type CatalogEntry = { cadence: Cadence; priceId: string; unitAmount: number | null; currency: string | null; default: boolean }
+type Catalog = { entries: CatalogEntry[]; annualAvailable: boolean }
+
 export function SubscriptionPage() {
   const { t } = useTranslation()
   useDocumentTitle(t('subscription.title'))
@@ -22,10 +26,52 @@ export function SubscriptionPage() {
   const [searchParams] = useSearchParams()
   const [actionLoading, setActionLoading] = useState(false)
   const [pollEnded, setPollEnded] = useState(false)
+  const [catalog, setCatalog] = useState<Catalog | null>(null)
+  const [cadence, setCadence] = useState<Cadence>('yearly')
 
   useEffect(() => {
     fetchSubscription()
   }, [fetchSubscription])
+
+  // Catalog drives the cadence toggle. If the call fails or returns no
+  // entries (Stripe unconfigured / unreachable), the UI falls back to a
+  // single monthly CTA so the upgrade path is never broken.
+  useEffect(() => {
+    let cancelled = false
+    api.getCatalog()
+      .then((c) => {
+        if (cancelled) return
+        setCatalog(c)
+        const preferred = c.entries.find((e) => e.default) ?? c.entries[0]
+        if (preferred) setCadence(preferred.cadence)
+      })
+      .catch(() => {
+        if (!cancelled) setCatalog({ entries: [], annualAvailable: false })
+      })
+    return () => { cancelled = true }
+  }, [])
+
+  const monthlyEntry = useMemo(() => catalog?.entries.find((e) => e.cadence === 'monthly') ?? null, [catalog])
+  const yearlyEntry = useMemo(() => catalog?.entries.find((e) => e.cadence === 'yearly') ?? null, [catalog])
+  const showToggle = !!catalog?.annualAvailable && !!monthlyEntry && !!yearlyEntry
+
+  const formatAmount = (entry: CatalogEntry | null): string => {
+    if (!entry || entry.unitAmount === null || !entry.currency) return ''
+    return new Intl.NumberFormat('fr-FR', { style: 'currency', currency: entry.currency.toUpperCase() })
+      .format(entry.unitAmount / 100)
+  }
+
+  const yearlyPerMonth = useMemo((): string => {
+    if (!yearlyEntry || yearlyEntry.unitAmount === null || !yearlyEntry.currency) return ''
+    return new Intl.NumberFormat('fr-FR', { style: 'currency', currency: yearlyEntry.currency.toUpperCase() })
+      .format(yearlyEntry.unitAmount / 12 / 100)
+  }, [yearlyEntry])
+
+  const selectCadence = (next: Cadence) => {
+    if (next === cadence) return
+    setCadence(next)
+    track('premium.cadence_selected', { cadence: next })
+  }
 
   // The contextual gate banner: which feature/limit sent the user here.
   // Drives the lead-in copy (e.g. "You've hit the free group limit") and
@@ -92,9 +138,9 @@ export function SubscriptionPage() {
   const handleCheckout = async () => {
     if (actionLoading) return
     setActionLoading(true)
-    track('premium.checkout_started', { from: fromKey ?? 'subscription_page' })
+    track('premium.checkout_started', { from: fromKey ?? 'subscription_page', cadence })
     try {
-      const { url } = await api.createCheckout()
+      const { url } = await api.createCheckout(cadence)
       window.location.href = url
     } catch {
       toast.error(t('subscription.checkoutError'))
@@ -199,9 +245,56 @@ export function SubscriptionPage() {
                     </li>
                   ))}
                 </ul>
+
+                {showToggle && (
+                  <div
+                    className="flex flex-col gap-2"
+                    role="radiogroup"
+                    aria-label={t('subscription.cadence.monthly') + ' / ' + t('subscription.cadence.yearly')}
+                  >
+                    <div className="inline-flex rounded-lg border bg-muted p-1 self-start">
+                      <button
+                        type="button"
+                        role="radio"
+                        aria-checked={cadence === 'monthly'}
+                        onClick={() => selectCadence('monthly')}
+                        className={`px-3 py-1.5 text-sm rounded-md transition ${cadence === 'monthly' ? 'bg-background shadow-sm font-medium' : 'text-muted-foreground'}`}
+                      >
+                        {t('subscription.cadence.monthly')}
+                      </button>
+                      <button
+                        type="button"
+                        role="radio"
+                        aria-checked={cadence === 'yearly'}
+                        onClick={() => selectCadence('yearly')}
+                        className={`px-3 py-1.5 text-sm rounded-md transition flex items-center gap-2 ${cadence === 'yearly' ? 'bg-background shadow-sm font-medium' : 'text-muted-foreground'}`}
+                      >
+                        {t('subscription.cadence.yearly')}
+                        <Badge variant="default" className="text-[10px] py-0 px-1.5">
+                          {t('subscription.cadence.savingsBadge')}
+                        </Badge>
+                      </button>
+                    </div>
+                    {cadence === 'yearly' && yearlyPerMonth && (
+                      <p className="text-xs text-muted-foreground">
+                        {t('subscription.cadence.yearlyPerMonth', { amount: yearlyPerMonth })}
+                      </p>
+                    )}
+                    {cadence === 'yearly' && (
+                      <p className="text-xs text-muted-foreground">
+                        {t('subscription.cadence.prorationNotice')}
+                      </p>
+                    )}
+                  </div>
+                )}
+
                 <Button onClick={handleCheckout} disabled={actionLoading} className="mt-2">
                   <Crown className="size-4 mr-2" />
-                  {t('subscription.upgradeButton')}
+                  {cadence === 'yearly' && yearlyEntry
+                    ? t('subscription.upgradeYearly', { price: formatAmount(yearlyEntry) })
+                    : monthlyEntry
+                      ? t('subscription.upgradeMonthly', { price: formatAmount(monthlyEntry) })
+                      : t('subscription.upgradeButton')}
                 </Button>
               </>
             )}


### PR DESCRIPTION
Closes #218.

## Summary

- Add `STRIPE_PRICE_ID_MONTHLY`, `STRIPE_PRICE_ID_YEARLY`, `STRIPE_PRODUCT_ID` env vars (legacy `STRIPE_PRICE_ID` kept as monthly alias for back-compat)
- New `packages/backend/src/config/billing.ts` catalog — only identifiers, no `unitAmount` (Stripe stays the single source of truth)
- New `packages/backend/src/infrastructure/stripe/billing-bootstrap.ts` — boot-time `stripe.prices.retrieve()` per configured price, asserts `price.product === STRIPE_PRODUCT_ID`. Fatal in production, warning in dev. Closes the Toko-Premium config-drift class
- `POST /api/subscription/checkout` now takes a `cadence: 'monthly' | 'yearly'` body param (validated server-side, never trusted as a price string)
- New `GET /api/subscription/catalog` returns resolved cadence/amount/currency for the upgrade UI (5-min in-memory cache)
- `SubscriptionPage.tsx`: cadence toggle with annual pre-selected, savings badge, per-month equivalent, French proration notice, dynamic FR-formatted price on the CTA button
- New `premium.cadence_selected` analytics event

## Out of scope (deferred to v2)

- Customer Portal `subscription_update.products` restriction (5-min Stripe dashboard task, not code)
- E2E test on annual checkout flow (manual QA for now)
- In-app annual→monthly downgrade flow ("contact support" suffices for v1)

## Test plan

- [x] Backend: `npm test --workspace=@wawptn/backend` — 85/85 passing (17 new for catalog + boot guard)
- [x] Backend typecheck: `npm run build --workspace=@wawptn/backend` — clean
- [x] Frontend typecheck + Vite build: `npm run build --workspace=@wawptn/frontend` — clean
- [x] Frontend lint: only the pre-existing `useVirtualizer` warning, no new issues
- [ ] **Manual QA on Stripe test mode** before merge: end-to-end checkout for monthly + annual, then portal swap
- [ ] **Set `STRIPE_PRODUCT_ID` + `STRIPE_PRICE_ID_YEARLY`** in production env before deploying
- [ ] **Post `lookup_key`s on the live prices** in Stripe (`wawptn_premium_monthly`, `wawptn_premium_yearly`) — currently catalog uses env-var fallback so lookup_keys are not required, but recommended for future portability

🤖 Generated with [Claude Code](https://claude.com/claude-code)