### PR TITLE
Refactor dialog positioning to use Tailwind shorthand classes

### DIFF
--- a/packages/frontend/src/components/ui/dialog.tsx
+++ b/packages/frontend/src/components/ui/dialog.tsx
@@ -42,7 +42,7 @@ function DialogContent({
           // max-h prevents content from overflowing the viewport on tablet
           // portrait (640-768px), where ResponsiveDialog still uses Dialog
           // rather than Drawer.
-          'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg max-h-[calc(100dvh-2rem)] overflow-y-auto translate-x-[-50%] translate-y-[-50%] gap-4 border border-border bg-card p-6 shadow-3 duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg',
+          'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg max-h-[calc(100dvh-2rem)] overflow-y-auto -translate-x-1/2 -translate-y-1/2 gap-4 border border-border bg-card p-6 shadow-3 duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg',
           className
         )}
         {...props}


### PR DESCRIPTION
## Summary
Updated the DialogContent component to use Tailwind CSS shorthand positioning classes instead of arbitrary values, improving code readability and maintainability.

## Key Changes
- Replaced `left-[50%]` with `left-1/2` for horizontal centering
- Replaced `top-[50%]` with `top-1/2` for vertical centering
- Replaced `translate-x-[-50%]` with `-translate-x-1/2` for horizontal translation
- Replaced `translate-y-[-50%]` with `-translate-y-1/2` for vertical translation

## Implementation Details
These changes maintain the exact same visual behavior and positioning logic while using Tailwind's built-in utility classes instead of arbitrary bracket notation. This makes the code more consistent with Tailwind best practices and easier to read at a glance.

https://claude.ai/code/session_01Gmo6NwNiPxVyFrie9uJd2k