### PR TITLE
feat(billing): scope portal sessions to this app's Stripe configuration

### DIFF
--- a/packages/backend/src/config/env.ts
+++ b/packages/backend/src/config/env.ts
@@ -70,6 +70,12 @@ export const env = {
    *  "STRIPE_PRICE_ID points at the wrong product" misconfiguration that
    *  produced the Toko Premium incident. Empty disables the check. */
   STRIPE_PRODUCT_ID: process.env['STRIPE_PRODUCT_ID'] || '',
+  /** Stripe Billing Portal configuration ID (bpc_…). When set, portal
+   *  sessions are created with this configuration so the customer can
+   *  only switch between WAWPTN Premium prices, not toward products of
+   *  other apps that share the same Stripe account. When empty, Stripe
+   *  uses the account's default configuration. */
+  STRIPE_PORTAL_CONFIG_ID: process.env['STRIPE_PORTAL_CONFIG_ID'] || '',
   // Enables Stripe Tax (automatic_tax + tax_id_collection) on Checkout.
   // Requires Stripe Tax to be onboarded in the dashboard and tax_behavior
   // set on the price object — keep disabled until that's done or Checkout

--- a/packages/backend/src/presentation/routes/subscription.routes.ts
+++ b/packages/backend/src/presentation/routes/subscription.routes.ts
@@ -220,6 +220,13 @@ subscriptionRoutes.post('/portal', async (req: Request, res: Response) => {
       {
         customer: subscription.stripe_customer_id,
         return_url: `${env.CORS_ORIGIN}/subscription`,
+        // Restricts the portal to WAWPTN Premium products only. The four
+        // apps share one Stripe account, so without a config a WAWPTN
+        // customer would see Toko / The Box / CoproPilot prices in the
+        // "switch plan" picker.
+        ...(env.STRIPE_PORTAL_CONFIG_ID
+          ? { configuration: env.STRIPE_PORTAL_CONFIG_ID }
+          : {}),
       },
       { idempotencyKey: `portal:${userId}:${bucket}` },
     )


### PR DESCRIPTION
## Context

The four apps (Tokō, WAWPTN, The Box, CoproPilot) share a single Stripe account. Before this PR, `stripe.billingPortal.sessions.create()` was called without a `configuration` parameter, so the portal fell back to the account default — which lists every active product on the account. A logged-in customer could open "Manage subscription" and see prices for the three other apps in the "switch plan" picker.

Worst case: a WAWPTN customer (3€/mo) accidentally switches to CoproPilot Entreprise (749€/year), the webhook receives a `customer.subscription.updated` for an unrelated product, and the user state in DB ends up inconsistent.

## What this PR does

- Adds a `STRIPE_PORTAL_CONFIG_ID` env var.
- When set, it is passed as the `configuration` argument to every `billingPortal.sessions.create()` call → the portal only lists this app's products.
- When empty, behaviour is unchanged (falls back to the account default), so the change is back-compat safe.

## Stripe-side state

The four portal configurations have already been provisioned in Stripe live via the API and are pinned to each app's products only. The matching `bpc_…` IDs are already set in the prod `.env` of each app.

## Test plan

- [ ] Verify backend builds and existing tests still pass
- [ ] After deploy: open Manage Subscription as a customer, confirm only this app's prices appear in the picker
- [ ] Confirm cancellation / payment method update still work
- [ ] Confirm no regression for customers that have no active subscription (route still 400s cleanly)