### PR TITLE
feat(group): replace hidden sidebar with visible tabbed navigation

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import { useSocketConnectionStatus } from '@/hooks/useSocketConnectionStatus'
 import { useNotificationStore } from '@/stores/notification.store'
 import { useWishlistStore } from '@/stores/wishlist.store'
 import { KoeSupport } from '@/components/KoeSupport'
+import { AppLayout } from '@/components/app-layout'
 
 // Route-level code splitting. Keeps LandingPage (LCP target) and
 // NotFoundPage eager; everything else loads on demand so the first paint
@@ -137,13 +138,18 @@ function App() {
     <>
       <Suspense fallback={<RouteFallback />}>
         <Routes>
-          <Route path="/" element={<GroupsPage />} />
-          <Route path="/profile" element={<ProfilePage />} />
-          <Route path="/u/:userId" element={<UserProfilePage />} />
-          <Route path="/compare" element={<ComparePage />} />
-          <Route path="/admin" element={<RequireAdmin><AdminPage /></RequireAdmin>} />
-          <Route path="/subscription" element={<SubscriptionPage />} />
-          <Route path="/groups/:id" element={<GroupPage />} />
+          {/* Standard pages — wrapped in the shared AppLayout shell
+              (persistent header + footer + header slot). */}
+          <Route element={<AppLayout />}>
+            <Route path="/" element={<GroupsPage />} />
+            <Route path="/profile" element={<ProfilePage />} />
+            <Route path="/u/:userId" element={<UserProfilePage />} />
+            <Route path="/compare" element={<ComparePage />} />
+            <Route path="/admin" element={<RequireAdmin><AdminPage /></RequireAdmin>} />
+            <Route path="/subscription" element={<SubscriptionPage />} />
+            <Route path="/groups/:id" element={<GroupPage />} />
+          </Route>
+          {/* Full-screen / chrome-less routes — own their own layout. */}
           <Route path="/groups/:id/vote" element={<VotePage />} />
           <Route path="/join/:token" element={<JoinPage />} />
           <Route path="/invite/:token" element={<InviteRedirect />} />

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { NotFoundPage } from '@/pages/NotFoundPage'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useNotificationListener } from '@/hooks/useNotificationListener'
 import { useChallengeListener } from '@/hooks/useChallengeListener'
+import { useActiveVoteSync } from '@/hooks/useActiveVoteSync'
 import { usePwaInstallPrompt } from '@/hooks/usePwaInstallPrompt'
 import { useSocketConnectionStatus } from '@/hooks/useSocketConnectionStatus'
 import { useNotificationStore } from '@/stores/notification.store'
@@ -80,6 +81,10 @@ function App() {
 
   // Global challenge unlock listener
   useChallengeListener()
+
+  // Keeps the group list fresh so the app-wide "vote in progress" banner
+  // reacts to votes starting / closing in any of the user's groups.
+  useActiveVoteSync()
 
   // PWA install prompt — captures beforeinstallprompt and surfaces a
   // sonner toast with a native install action.

--- a/packages/frontend/src/components/active-vote-banner.tsx
+++ b/packages/frontend/src/components/active-vote-banner.tsx
@@ -1,0 +1,48 @@
+import { useMatch, useNavigate } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { useGroupStore } from '@/stores/group.store'
+import { Button } from '@/components/ui/button'
+
+/**
+ * App-wide banner surfacing any group with a live vote. Rendered by
+ * AppLayout so the "join the vote" call to action follows the user across
+ * every standard page. The group whose detail page is currently open is
+ * excluded — that page already has its own join CTA.
+ */
+export function ActiveVoteBanner() {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const groups = useGroupStore((s) => s.groups)
+  const groupMatch = useMatch('/groups/:id')
+  const currentGroupId = groupMatch?.params.id ?? null
+
+  const activeGroups = groups.filter(
+    (g) => g.activeVoteSession && g.id !== currentGroupId,
+  )
+  if (activeGroups.length === 0) return null
+
+  const single = activeGroups.length === 1 ? activeGroups[0]! : null
+
+  return (
+    <div className="sticky top-14 z-40 border-b border-neon/30 bg-neon/10 backdrop-blur-sm">
+      <div className="mx-auto flex max-w-6xl items-center gap-3 px-3 sm:px-4 py-2">
+        <span
+          className="size-2 shrink-0 rounded-full bg-neon animate-pulse"
+          aria-hidden="true"
+        />
+        <p className="min-w-0 flex-1 truncate text-sm font-medium">
+          {single
+            ? t('voteBanner.single', { name: single.name })
+            : t('voteBanner.multiple', { count: activeGroups.length })}
+        </p>
+        <Button
+          size="sm"
+          className="h-8 shrink-0"
+          onClick={() => navigate(single ? `/groups/${single.id}/vote` : '/')}
+        >
+          {single ? t('voteBanner.join') : t('voteBanner.view')}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/packages/frontend/src/components/app-header.tsx
+++ b/packages/frontend/src/components/app-header.tsx
@@ -32,14 +32,19 @@ interface AppHeaderProps {
   children?: React.ReactNode
   className?: string
   maxWidth?: 'narrow' | 'wide'
+  /** Set by AppLayout: whether a page has portalled content into the header
+   *  slot. When AppLayout passes an (always-truthy) slot node as `children`,
+   *  this — not `children` — decides the page-content layout. */
+  hasPageContent?: boolean
 }
 
-export function AppHeader({ children, className, maxWidth = 'narrow' }: AppHeaderProps) {
+export function AppHeader({ children, className, maxWidth = 'narrow', hasPageContent }: AppHeaderProps) {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const { user, logout } = useAuthStore()
   const { tier } = useSubscriptionStore()
   const [showLogoutDialog, setShowLogoutDialog] = useState(false)
+  const showPageContent = hasPageContent ?? !!children
 
   const handleLogout = async () => {
     await logout()
@@ -53,7 +58,7 @@ export function AppHeader({ children, className, maxWidth = 'narrow' }: AppHeade
       </a>
       <nav className={cn('mx-auto flex h-14 items-center gap-1 px-[max(0.75rem,env(safe-area-inset-left))]', maxWidth === 'wide' ? 'max-w-6xl' : 'max-w-2xl')} style={{ paddingRight: 'max(0.75rem, env(safe-area-inset-right))' }} aria-label={t('app.name')}>
         {children && (
-          <div className="flex items-center min-w-0 flex-1 sm:flex-initial">
+          <div className={cn('flex items-center min-w-0', showPageContent ? 'flex-1 sm:flex-initial' : 'contents')}>
             {children}
           </div>
         )}
@@ -64,9 +69,9 @@ export function AppHeader({ children, className, maxWidth = 'narrow' }: AppHeade
           aria-label={t('app.name') + ' — ' + t('app.tagline')}
         >
           <WawptnLogo size={28} className="text-primary" aria-hidden="true" />
-          <span className={cn('font-heading font-bold text-lg tracking-[-0.03em]', children ? 'hidden sm:inline' : 'inline')}>WAWPTN</span>
+          <span className={cn('font-heading font-bold text-lg tracking-[-0.03em]', showPageContent ? 'hidden sm:inline' : 'inline')}>WAWPTN</span>
         </button>
-        <div className={cn('flex-1', children && 'hidden sm:block')} />
+        <div className={cn('flex-1', showPageContent && 'hidden sm:block')} />
 
         {/* Notifications */}
         {user && <NotificationBell />}

--- a/packages/frontend/src/components/app-layout.tsx
+++ b/packages/frontend/src/components/app-layout.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom'
 import { Outlet } from 'react-router-dom'
 import { AppHeader } from '@/components/app-header'
 import { AppFooter } from '@/components/app-footer'
+import { ActiveVoteBanner } from '@/components/active-vote-banner'
 import { Skeleton } from '@/components/ui/skeleton'
 
 interface HeaderSlot {
@@ -61,6 +62,7 @@ export function AppLayout() {
       <AppHeader maxWidth="wide" hasPageContent={hasContent}>
         <span ref={setElement} className="contents" />
       </AppHeader>
+      <ActiveVoteBanner />
       <HeaderSlotContext.Provider value={slot}>
         <Suspense fallback={<RouteFallback />}>
           <Outlet />

--- a/packages/frontend/src/components/app-layout.tsx
+++ b/packages/frontend/src/components/app-layout.tsx
@@ -1,0 +1,72 @@
+import { Suspense, createContext, useContext, useEffect, useMemo, useState, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
+import { Outlet } from 'react-router-dom'
+import { AppHeader } from '@/components/app-header'
+import { AppFooter } from '@/components/app-footer'
+import { Skeleton } from '@/components/ui/skeleton'
+
+interface HeaderSlot {
+  element: HTMLElement | null
+  setHasContent: (value: boolean) => void
+}
+
+const HeaderSlotContext = createContext<HeaderSlot | null>(null)
+
+/**
+ * Portals page-specific header content (back buttons, page titles) into the
+ * single shared AppHeader rendered by AppLayout. A page renders
+ * `<PageHeader>...</PageHeader>` anywhere in its tree and the content lands in
+ * the global header. Renders nothing in place; renders nothing at all until
+ * the layout's slot element has mounted.
+ */
+export function PageHeader({ children }: { children: ReactNode }) {
+  const slot = useContext(HeaderSlotContext)
+  const setHasContent = slot?.setHasContent
+
+  useEffect(() => {
+    setHasContent?.(true)
+    return () => setHasContent?.(false)
+  }, [setHasContent])
+
+  return slot?.element ? createPortal(children, slot.element) : null
+}
+
+function RouteFallback() {
+  return (
+    <div
+      className="flex-1 flex flex-col items-center justify-center gap-4 py-20"
+      role="status"
+      aria-busy="true"
+      aria-live="polite"
+    >
+      <Skeleton className="size-12 rounded-full" />
+      <Skeleton className="h-4 w-32" />
+    </div>
+  )
+}
+
+/**
+ * Shared chrome for every standard authenticated page: one persistent
+ * AppHeader + AppFooter wrapping a router `<Outlet>`. Pages no longer
+ * hand-roll the `min-h-dvh` wrapper or mount their own header/footer — they
+ * render only their `<main>` and (optionally) a `<PageHeader>`.
+ */
+export function AppLayout() {
+  const [element, setElement] = useState<HTMLElement | null>(null)
+  const [hasContent, setHasContent] = useState(false)
+  const slot = useMemo<HeaderSlot>(() => ({ element, setHasContent }), [element])
+
+  return (
+    <div className="min-h-dvh flex flex-col bg-background">
+      <AppHeader maxWidth="wide" hasPageContent={hasContent}>
+        <span ref={setElement} className="contents" />
+      </AppHeader>
+      <HeaderSlotContext.Provider value={slot}>
+        <Suspense fallback={<RouteFallback />}>
+          <Outlet />
+        </Suspense>
+      </HeaderSlotContext.Provider>
+      <AppFooter />
+    </div>
+  )
+}

--- a/packages/frontend/src/components/group-panel.tsx
+++ b/packages/frontend/src/components/group-panel.tsx
@@ -2,12 +2,12 @@ import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { RefreshCw, UserPlus, Users, Trophy, History, Crown, UserMinus, Trash2, LogOut, Pencil, Bell, BellOff, CalendarClock, Lock, Newspaper, Send } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
-import { Card, CardHeader, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { EmptyState } from '@/components/empty-state'
 import { track } from '@/lib/analytics'
 import {
   ResponsiveDialog,
@@ -41,7 +41,12 @@ interface VoteHistoryEntry {
   createdBy: string
 }
 
-interface GroupSidebarProps {
+/** Which slice of the group detail this panel renders. The "tonight"
+ *  surface lives directly in GroupPage; this component owns the four
+ *  secondary tabs. */
+export type GroupPanelSection = 'members' | 'history' | 'stats' | 'settings'
+
+interface GroupPanelProps {
   members: Member[]
   groupId: string
   groupName: string
@@ -76,14 +81,14 @@ interface GroupSidebarProps {
   /** Sends a one-off test message to the linked Discord channel so the
    *  owner can confirm the digest will land before relying on the schedule. */
   onTestReleasesDigest: () => Promise<void>
-  /** When true, renders a compact layout for mobile bottom sheets (no Card wrappers) */
-  compact?: boolean
+  /** Which secondary section this panel instance renders. */
+  section: GroupPanelSection
 }
 
-/** Small uppercase divider label that groups the sidebar action buttons
- *  into member / group / premium / danger clusters so destructive and
- *  routine actions are no longer an undifferentiated stack. */
-function SidebarSectionLabel({ children }: { children: string }) {
+/** Small uppercase divider label that groups the settings actions into
+ *  member / group / premium / danger clusters so destructive and routine
+ *  actions are no longer an undifferentiated stack. */
+function PanelSectionLabel({ children }: { children: string }) {
   return (
     <p className="px-0.5 pt-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
       {children}
@@ -104,7 +109,7 @@ function getLastSeenLabel(
   return t('groups.lastSeen.offline')
 }
 
-export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken, voteHistory, voteHistoryTruncated, onlineMembers, lastSeenMap, currentUserId, currentUserRole, autoVoteSchedule, autoVoteDurationMinutes, releasesDigestEnabled, releasesDigestSchedule, releasesDigestCoopOnly, discordChannelId, onSync, onGenerateInvite, onLeaveGroup, onKickMember, onDeleteGroup, onRenameGroup, onDeleteHistory, onToggleNotifications, onUpdateAutoVote, onUpdateReleasesDigest, onTestReleasesDigest, compact = false }: GroupSidebarProps) {
+export function GroupPanel({ members, groupId, groupName, syncing, inviteToken, voteHistory, voteHistoryTruncated, onlineMembers, lastSeenMap, currentUserId, currentUserRole, autoVoteSchedule, autoVoteDurationMinutes, releasesDigestEnabled, releasesDigestSchedule, releasesDigestCoopOnly, discordChannelId, onSync, onGenerateInvite, onLeaveGroup, onKickMember, onDeleteGroup, onRenameGroup, onDeleteHistory, onToggleNotifications, onUpdateAutoVote, onUpdateReleasesDigest, onTestReleasesDigest, section }: GroupPanelProps) {
   const { t, i18n } = useTranslation()
   const navigate = useNavigate()
   const [confirmLeave, setConfirmLeave] = useState(false)
@@ -138,12 +143,9 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
   })
 
   const historySection = voteHistory.length > 0 && (
-    <div className={compact ? 'flex gap-2 sm:gap-3 overflow-x-auto scrollbar-none snap-x snap-mandatory pb-1 -mx-1 px-1' : 'space-y-2'}>
+    <div className="space-y-2">
       {voteHistory.map((session, index) => (
-        <div key={session.id} className={compact
-          ? 'flex-none w-[200px] snap-start rounded-lg border border-border bg-card/50 p-2 flex items-center gap-2 group/history'
-          : 'flex items-center gap-3 group/history'
-        }>
+        <div key={session.id} className="flex items-center gap-3 rounded-lg border border-border bg-card/50 p-2 group/history">
           <img
             src={getSteamHeaderImageUrl(session.winningGameAppId)}
             alt={session.winningGameName}
@@ -169,7 +171,7 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
                 <Button
                   variant="ghost"
                   size="icon"
-                  className={`size-8 min-h-[44px] min-w-[44px] text-muted-foreground hover:text-destructive active:bg-accent/10 ${compact ? 'opacity-100' : 'opacity-0 group-hover/history:opacity-100'} transition-opacity shrink-0`}
+                  className="size-8 min-h-[44px] min-w-[44px] text-muted-foreground hover:text-destructive active:bg-accent/10 shrink-0"
                   onClick={() => setConfirmDeleteHistory(session)}
                   aria-label={t('group.deleteHistory')}
                 >
@@ -207,28 +209,16 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
   const onlineCount = members.filter(m => onlineMembers.has(m.id)).length
 
   const membersHeader = (
-    <div className="flex items-center justify-between">
-      <div className="flex items-center gap-2">
-        <h2 className="font-semibold flex items-center gap-2 text-sm">
-          <Users className="size-4" />
-          {t('group.members', { count: members.length })}
-        </h2>
-        {onlineCount > 0 && (
-          <Badge variant="secondary" className="text-[10px] px-1.5 py-0 gap-1 font-normal">
-            <span className="size-1.5 rounded-full bg-online animate-pulse" />
-            {t('groups.onlineCount', { count: onlineCount })}
-          </Badge>
-        )}
-      </div>
-      {!compact && (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button variant="ghost" size="icon" onClick={onSync} disabled={syncing} aria-label={t('group.syncLibraries')} className="size-11 min-h-[44px] min-w-[44px] active:bg-accent/10">
-              <RefreshCw className={`size-4 ${syncing ? 'animate-spin text-primary' : ''}`} />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>{t('group.syncLibraries')}</TooltipContent>
-        </Tooltip>
+    <div className="flex items-center gap-2">
+      <h2 className="font-semibold flex items-center gap-2 text-sm">
+        <Users className="size-4" />
+        {t('group.members', { count: members.length })}
+      </h2>
+      {onlineCount > 0 && (
+        <Badge variant="secondary" className="text-[10px] px-1.5 py-0 gap-1 font-normal">
+          <span className="size-1.5 rounded-full bg-online animate-pulse" />
+          {t('groups.onlineCount', { count: onlineCount })}
+        </Badge>
       )}
     </div>
   )
@@ -255,7 +245,7 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
                 <AvatarFallback>{member.displayName.charAt(0).toUpperCase()}</AvatarFallback>
               </Avatar>
               <span
-                className={`absolute bottom-0 right-0 size-2.5 rounded-full border-2 ${compact ? 'border-background' : 'border-card'} ${isOnline ? 'bg-online animate-pulse' : 'bg-muted-foreground/40'}`}
+                className={`absolute bottom-0 right-0 size-2.5 rounded-full border-2 border-background ${isOnline ? 'bg-online animate-pulse' : 'bg-muted-foreground/40'}`}
                 aria-label={presenceLabel}
               />
             </button>
@@ -296,7 +286,7 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
                   <Button
                     variant="ghost"
                     size="icon"
-                    className={`size-11 min-h-[44px] min-w-[44px] text-muted-foreground hover:text-destructive active:bg-accent/10 ${compact ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'} transition-opacity`}
+                    className="size-11 min-h-[44px] min-w-[44px] text-muted-foreground hover:text-destructive active:bg-accent/10"
                     onClick={() => setConfirmKick(member)}
                     aria-label={t('group.kickMember', { name: member.displayName })}
                   >
@@ -321,18 +311,16 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
     <div className="space-y-4">
       {/* Membre — actions available to every member */}
       <div className="space-y-1.5">
-        <SidebarSectionLabel>{t('group.sectionMember')}</SidebarSectionLabel>
-        {compact && (
-          <Button
-            variant="outline"
-            className="w-full"
-            onClick={onSync}
-            disabled={syncing}
-          >
-            <RefreshCw className={`size-4 mr-2 ${syncing ? 'animate-spin text-primary' : ''}`} />
-            {t('group.syncLibraries')}
-          </Button>
-        )}
+        <PanelSectionLabel>{t('group.sectionMember')}</PanelSectionLabel>
+        <Button
+          variant="outline"
+          className="w-full"
+          onClick={onSync}
+          disabled={syncing}
+        >
+          <RefreshCw className={`size-4 mr-2 ${syncing ? 'animate-spin text-primary' : ''}`} />
+          {t('group.syncLibraries')}
+        </Button>
         <Button
           variant={notificationsEnabled ? 'outline' : 'ghost'}
           className={`w-full ${!notificationsEnabled ? 'text-muted-foreground' : ''}`}
@@ -350,7 +338,7 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
       {/* Groupe — owner-only group management */}
       {isOwner && (
         <div className="space-y-1.5">
-          <SidebarSectionLabel>{t('group.sectionGroup')}</SidebarSectionLabel>
+          <PanelSectionLabel>{t('group.sectionGroup')}</PanelSectionLabel>
           <Button
             variant="outline"
             className="w-full"
@@ -359,22 +347,13 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
             <Pencil className="size-4 mr-2" />
             {t('group.renameGroup')}
           </Button>
-          <Button
-            variant="outline"
-            className="w-full"
-            onClick={onGenerateInvite}
-          >
-            <UserPlus className="size-4 mr-2" />
-            {t('group.inviteFriend')}
-          </Button>
-          {inviteToken && <InviteLink token={inviteToken} />}
         </div>
       )}
 
       {/* Premium — owner-only scheduled automations */}
       {isOwner && (
         <div className="space-y-1.5">
-          <SidebarSectionLabel>{t('group.sectionPremium')}</SidebarSectionLabel>
+          <PanelSectionLabel>{t('group.sectionPremium')}</PanelSectionLabel>
           {/* Auto-vote settings */}
           {isPremium ? (
             <Button
@@ -453,7 +432,7 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
 
       {/* Zone de danger — irreversible actions, fenced off from routine ones */}
       <div className="space-y-1.5 border-t border-border pt-3">
-        <SidebarSectionLabel>{t('group.sectionDanger')}</SidebarSectionLabel>
+        <PanelSectionLabel>{t('group.sectionDanger')}</PanelSectionLabel>
         {!isOwner && (
           <Button
             variant="ghost"
@@ -479,59 +458,46 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
   )
 
   return (
-    <aside className="space-y-3">
-      {compact ? (
-        // Compact layout for mobile bottom sheets — no Card wrappers
+    <div className="space-y-4">
+      {section === 'members' && (
         <div className="space-y-3">
-          {historySection && (
-            <div className="space-y-2">
-              <h2 className="font-semibold flex items-center gap-2 text-sm">
-                <History className="size-4" />
-                {t('group.history')}
-              </h2>
-              {historySection}
-              {historyUpgradeCta}
-            </div>
-          )}
-          <GameRecommendations groupId={groupId} compact />
-          <GroupStats groupId={groupId} compact />
           {membersHeader}
           {membersList}
-          {actionButtons}
-        </div>
-      ) : (
-        // Desktop layout with Card wrappers
-        <>
-          {historySection && (
-            <Card>
-              <CardHeader className="p-3 sm:p-4 pb-2 sm:pb-3">
-                <h2 className="font-semibold flex items-center gap-2 text-sm">
-                  <History className="size-4" />
-                  {t('group.history')}
-                </h2>
-              </CardHeader>
-              <CardContent className="p-3 sm:p-4 pt-0 space-y-2">
-                {historySection}
-                {historyUpgradeCta}
-              </CardContent>
-            </Card>
+          {isOwner && (
+            <div className="space-y-1.5 border-t border-border pt-3">
+              <Button variant="outline" className="w-full" onClick={onGenerateInvite}>
+                <UserPlus className="size-4 mr-2" />
+                {t('group.inviteFriend')}
+              </Button>
+              {inviteToken && <InviteLink token={inviteToken} />}
+            </div>
           )}
-
-          <GameRecommendations groupId={groupId} />
-
-          <GroupStats groupId={groupId} />
-
-          <Card>
-            <CardHeader className="p-3 sm:p-4 pb-2 sm:pb-3 space-y-0">
-              {membersHeader}
-            </CardHeader>
-            <CardContent className="p-3 sm:p-4 pt-0 space-y-2 sm:space-y-3">
-              {membersList}
-              {actionButtons}
-            </CardContent>
-          </Card>
-        </>
+        </div>
       )}
+
+      {section === 'history' && (
+        historySection ? (
+          <div className="space-y-2">
+            {historySection}
+            {historyUpgradeCta}
+          </div>
+        ) : (
+          <EmptyState
+            icon={History}
+            title={t('group.historyEmptyTitle')}
+            description={t('group.historyEmptyDescription')}
+          />
+        )
+      )}
+
+      {section === 'stats' && (
+        <div className="space-y-3">
+          <GameRecommendations groupId={groupId} />
+          <GroupStats groupId={groupId} />
+        </div>
+      )}
+
+      {section === 'settings' && actionButtons}
 
       {/* Leave confirmation dialog */}
       <ResponsiveDialog open={confirmLeave} onOpenChange={setConfirmLeave}>
@@ -804,6 +770,6 @@ export function GroupSidebar({ members, groupId, groupName, syncing, inviteToken
           </form>
         </ResponsiveDialogContent>
       </ResponsiveDialog>
-    </aside>
+    </div>
   )
 }

--- a/packages/frontend/src/components/group-tabs.tsx
+++ b/packages/frontend/src/components/group-tabs.tsx
@@ -1,0 +1,58 @@
+import { Sparkles, Users, History, BarChart3, Settings, type LucideIcon } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { cn } from '@/lib/utils'
+
+export type GroupTab = 'tonight' | 'members' | 'history' | 'stats' | 'settings'
+
+const GROUP_TABS: readonly GroupTab[] = ['tonight', 'members', 'history', 'stats', 'settings']
+
+const TAB_META: Record<GroupTab, { icon: LucideIcon; labelKey: string }> = {
+  tonight: { icon: Sparkles, labelKey: 'group.tabTonight' },
+  members: { icon: Users, labelKey: 'group.tabMembers' },
+  history: { icon: History, labelKey: 'group.tabHistory' },
+  stats: { icon: BarChart3, labelKey: 'group.tabStats' },
+  settings: { icon: Settings, labelKey: 'group.tabSettings' },
+}
+
+interface GroupTabsProps {
+  active: GroupTab
+  onChange: (tab: GroupTab) => void
+}
+
+/** Persistent, labelled navigation for the group detail page. Replaces the
+ *  old hidden mobile bottom-sheet + desktop sidebar so every group feature
+ *  has a visible home on both viewports. */
+export function GroupTabs({ active, onChange }: GroupTabsProps) {
+  const { t } = useTranslation()
+
+  return (
+    <div
+      role="tablist"
+      aria-label={t('group.tabsLabel')}
+      className="flex gap-1 overflow-x-auto scrollbar-none border-b border-border -mx-3 px-3 sm:mx-0 sm:px-0"
+    >
+      {GROUP_TABS.map((tab) => {
+        const { icon: Icon, labelKey } = TAB_META[tab]
+        const isActive = active === tab
+        return (
+          <button
+            key={tab}
+            type="button"
+            role="tab"
+            aria-selected={isActive}
+            onClick={() => onChange(tab)}
+            className={cn(
+              'flex items-center gap-1.5 whitespace-nowrap border-b-2 -mb-px px-3 py-2.5 text-sm font-medium min-h-[44px] transition-colors',
+              isActive
+                ? 'border-primary text-foreground'
+                : 'border-transparent text-muted-foreground hover:text-foreground',
+            )}
+          >
+            <Icon className="size-4 shrink-0" />
+            {t(labelKey)}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/packages/frontend/src/components/group-tabs.tsx
+++ b/packages/frontend/src/components/group-tabs.tsx
@@ -17,12 +17,15 @@ const TAB_META: Record<GroupTab, { icon: LucideIcon; labelKey: string }> = {
 interface GroupTabsProps {
   active: GroupTab
   onChange: (tab: GroupTab) => void
+  /** When true, the Tonight tab carries a live-vote indicator so an
+   *  in-progress vote is visible from any other tab. */
+  voteLive?: boolean
 }
 
 /** Persistent, labelled navigation for the group detail page. Replaces the
  *  old hidden mobile bottom-sheet + desktop sidebar so every group feature
  *  has a visible home on both viewports. */
-export function GroupTabs({ active, onChange }: GroupTabsProps) {
+export function GroupTabs({ active, onChange, voteLive = false }: GroupTabsProps) {
   const { t } = useTranslation()
 
   return (
@@ -50,6 +53,12 @@ export function GroupTabs({ active, onChange }: GroupTabsProps) {
           >
             <Icon className="size-4 shrink-0" />
             {t(labelKey)}
+            {tab === 'tonight' && voteLive && (
+              <span
+                className="size-1.5 rounded-full bg-neon animate-pulse"
+                aria-hidden="true"
+              />
+            )}
           </button>
         )
       })}

--- a/packages/frontend/src/components/vote-setup-dialog.tsx
+++ b/packages/frontend/src/components/vote-setup-dialog.tsx
@@ -182,6 +182,14 @@ export function VoteSetupDialog({ open, onOpenChange, members, groupId, onlineMe
     setPreviewCount(null)
   }
 
+  // One-tap path: start the vote straight from the member-selection step
+  // with no game filters and no scheduling. The live common-game count is
+  // already shown above, so the confirm step adds nothing for this case.
+  const handleQuickStart = () => {
+    onStartVote(Array.from(selectedIds), undefined, undefined)
+    onOpenChange(false)
+  }
+
   const handleConfirm = () => {
     const scheduled = isScheduled && scheduledDate ? new Date(scheduledDate).toISOString() : undefined
     const filtersParam = hasActiveGameFilters ? gameFilters : undefined
@@ -280,14 +288,29 @@ export function VoteSetupDialog({ open, onOpenChange, members, groupId, onlineMe
               ) : null}
             </div>
 
-            <div className="flex flex-col sm:flex-row sm:justify-between items-center gap-2 mt-4">
+            <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-2 mt-4">
               <span className="text-xs text-muted-foreground">
                 {t('voteSetup.selectedCount', { count: selectedIds.size })}
               </span>
-              <Button onClick={handleNext} disabled={!canProceed || loadingPreview} className="w-full sm:w-auto">
-                {loadingPreview && <Loader2 className="size-4 mr-2 animate-spin" />}
-                {t('voteSetup.next')}
-              </Button>
+              <div className="flex gap-2 w-full sm:w-auto">
+                <Button
+                  variant="ghost"
+                  onClick={handleNext}
+                  disabled={!canProceed || loadingPreview}
+                  className="flex-1 sm:flex-initial"
+                >
+                  {loadingPreview && <Loader2 className="size-4 mr-2 animate-spin" />}
+                  {t('voteSetup.moreOptions')}
+                </Button>
+                <Button
+                  onClick={handleQuickStart}
+                  disabled={!canProceed || loadingPreview}
+                  className="flex-1 sm:flex-initial"
+                >
+                  <Vote className="size-4 mr-2" />
+                  {t('voteSetup.startVote')}
+                </Button>
+              </div>
             </div>
           </>
         )}

--- a/packages/frontend/src/hooks/useActiveVoteSync.ts
+++ b/packages/frontend/src/hooks/useActiveVoteSync.ts
@@ -1,0 +1,32 @@
+import { useEffect } from 'react'
+import { getSocket } from '@/lib/socket'
+import { useAuthStore } from '@/stores/auth.store'
+import { useGroupStore } from '@/stores/group.store'
+
+/**
+ * Keeps the group list fresh so the global "vote in progress" banner can
+ * react app-wide. Fetches the groups once on login and refetches whenever a
+ * notification arrives — vote start and vote close both emit one — so the
+ * banner appears and clears without the user having to visit the dashboard.
+ */
+export function useActiveVoteSync() {
+  const userId = useAuthStore((s) => s.user?.id ?? null)
+
+  useEffect(() => {
+    if (!userId) return
+
+    const refetch = () => {
+      void useGroupStore.getState().fetchGroups().catch(() => {
+        // Non-critical: a stale banner is harmless, the vote page handles
+        // an already-closed session gracefully.
+      })
+    }
+
+    refetch()
+    const socket = getSocket()
+    socket.on('notification:new', refetch)
+    return () => {
+      socket.off('notification:new', refetch)
+    }
+  }, [userId])
+}

--- a/packages/frontend/src/i18n/locales/en.json
+++ b/packages/frontend/src/i18n/locales/en.json
@@ -252,6 +252,12 @@
     "historyEmptyTitle": "No game nights yet",
     "historyEmptyDescription": "Your vote history will show up here after your first game night."
   },
+  "voteBanner": {
+    "single": "A vote is in progress in “{{name}}”",
+    "multiple": "{{count}} votes in progress",
+    "join": "Join",
+    "view": "View"
+  },
   "filterPresets": {
     "label": "Vibe",
     "coopNight": "Co-op night",

--- a/packages/frontend/src/i18n/locales/en.json
+++ b/packages/frontend/src/i18n/locales/en.json
@@ -287,6 +287,7 @@
     "selectAll": "Select all",
     "selectedCount": "{{count}} player(s) selected",
     "next": "Next",
+    "moreOptions": "More options",
     "confirmTitle": "Start vote?",
     "confirmDescription": "{{players}} players selected — {{games}} games in common.",
     "confirmDescriptionNoPreview": "{{players}} players selected.",

--- a/packages/frontend/src/i18n/locales/en.json
+++ b/packages/frontend/src/i18n/locales/en.json
@@ -242,7 +242,15 @@
     "discordBannerHint": "Announcements and votes will be posted automatically in the channel you pick.",
     "discordBannerCta": "Link a channel",
     "discordBannerDialogTitle": "Link a Discord channel",
-    "discordLinkedFallback": "Discord linked"
+    "discordLinkedFallback": "Discord linked",
+    "tabsLabel": "Group sections",
+    "tabTonight": "Tonight",
+    "tabMembers": "Members",
+    "tabHistory": "History",
+    "tabStats": "Stats",
+    "tabSettings": "Settings",
+    "historyEmptyTitle": "No game nights yet",
+    "historyEmptyDescription": "Your vote history will show up here after your first game night."
   },
   "filterPresets": {
     "label": "Vibe",

--- a/packages/frontend/src/i18n/locales/fr.json
+++ b/packages/frontend/src/i18n/locales/fr.json
@@ -259,7 +259,15 @@
     "discordBannerHint": "Les annonces et votes seront postés automatiquement dans le salon de ton choix.",
     "discordBannerCta": "Lier un salon",
     "discordBannerDialogTitle": "Lier un salon Discord",
-    "discordLinkedFallback": "Discord lié"
+    "discordLinkedFallback": "Discord lié",
+    "tabsLabel": "Sections du groupe",
+    "tabTonight": "Ce soir",
+    "tabMembers": "Membres",
+    "tabHistory": "Historique",
+    "tabStats": "Stats",
+    "tabSettings": "Réglages",
+    "historyEmptyTitle": "Aucune soirée jouée",
+    "historyEmptyDescription": "L'historique des votes apparaîtra ici après votre première soirée."
   },
   "filterPresets": {
     "label": "Ambiance",

--- a/packages/frontend/src/i18n/locales/fr.json
+++ b/packages/frontend/src/i18n/locales/fr.json
@@ -304,6 +304,7 @@
     "selectAll": "Tout sélectionner",
     "selectedCount": "{{count}} joueur(s) sélectionné(s)",
     "next": "Suivant",
+    "moreOptions": "Plus d'options",
     "confirmTitle": "Lancer le vote ?",
     "confirmDescription": "{{players}} joueurs sélectionnés — {{games}} jeux en commun.",
     "confirmDescriptionNoPreview": "{{players}} joueurs sélectionnés.",

--- a/packages/frontend/src/i18n/locales/fr.json
+++ b/packages/frontend/src/i18n/locales/fr.json
@@ -269,6 +269,12 @@
     "historyEmptyTitle": "Aucune soirée jouée",
     "historyEmptyDescription": "L'historique des votes apparaîtra ici après votre première soirée."
   },
+  "voteBanner": {
+    "single": "Un vote est en cours dans « {{name}} »",
+    "multiple": "{{count}} votes sont en cours",
+    "join": "Rejoindre",
+    "view": "Voir"
+  },
   "filterPresets": {
     "label": "Ambiance",
     "coopNight": "Soirée coop",

--- a/packages/frontend/src/lib/analytics.ts
+++ b/packages/frontend/src/lib/analytics.ts
@@ -25,6 +25,7 @@ export type AnalyticsEvent =
   | 'group.create_failed'
   | 'group.hero_start_vote'
   | 'group.hero_join_vote'
+  | 'group.row_join_vote'
   | 'invite.generated'
   | 'invite.link_copied'
   | 'invite.shared'

--- a/packages/frontend/src/pages/AdminPage.tsx
+++ b/packages/frontend/src/pages/AdminPage.tsx
@@ -9,8 +9,7 @@ import {
 import { toast } from 'sonner'
 import { useTranslation } from 'react-i18next'
 import { motion, AnimatePresence, type Variants } from 'framer-motion'
-import { AppHeader } from '@/components/app-header'
-import { AppFooter } from '@/components/app-footer'
+import { PageHeader } from '@/components/app-layout'
 import { AdminHealthCard } from '@/components/admin-health-card'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -516,12 +515,12 @@ export function AdminPage() {
   if (!user?.isAdmin) return null
 
   return (
-    <div className="min-h-dvh flex flex-col bg-background">
-      <AppHeader maxWidth="wide">
+    <>
+      <PageHeader>
         <Button variant="ghost" size="icon" onClick={() => navigate('/')}>
           <ArrowLeft className="size-5" />
         </Button>
-      </AppHeader>
+      </PageHeader>
 
       <main
         id="main-content"
@@ -942,8 +941,7 @@ export function AdminPage() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
-      <AppFooter />
-    </div>
+    </>
   )
 }
 

--- a/packages/frontend/src/pages/ComparePage.tsx
+++ b/packages/frontend/src/pages/ComparePage.tsx
@@ -2,8 +2,7 @@ import { useEffect, useMemo } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { ArrowLeft, Gamepad2, Trophy } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
-import { AppHeader } from '@/components/app-header'
-import { AppFooter } from '@/components/app-footer'
+import { PageHeader } from '@/components/app-layout'
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -66,12 +65,12 @@ export function ComparePage() {
 
   if (!a || !b || a === b) {
     return (
-      <div className="min-h-dvh flex flex-col">
-        <AppHeader>
+      <>
+        <PageHeader>
           <Button variant="ghost" size="icon" onClick={() => navigate(-1)}>
             <ArrowLeft className="size-5" />
           </Button>
-        </AppHeader>
+        </PageHeader>
         <main id="main-content" className="max-w-2xl mx-auto w-full p-4 flex-1 flex items-center justify-center text-center">
           <div>
             <h1 className="text-lg font-semibold">{t('compare.impossibleTitle')}</h1>
@@ -80,19 +79,18 @@ export function ComparePage() {
             </p>
           </div>
         </main>
-        <AppFooter />
-      </div>
+      </>
     )
   }
 
   if (isLoading && !result) {
     return (
-      <div className="min-h-dvh flex flex-col">
-        <AppHeader>
+      <>
+        <PageHeader>
           <Button variant="ghost" size="icon" onClick={() => navigate(-1)}>
             <ArrowLeft className="size-5" />
           </Button>
-        </AppHeader>
+        </PageHeader>
         <main
           id="main-content"
           className="max-w-3xl mx-auto w-full p-4 space-y-4"
@@ -105,19 +103,18 @@ export function ComparePage() {
           <Skeleton className="h-6 w-32" />
           {[1, 2, 3].map((i) => <Skeleton key={i} className="h-16 rounded-xl" />)}
         </main>
-        <AppFooter />
-      </div>
+      </>
     )
   }
 
   if (error || !result) {
     return (
-      <div className="min-h-dvh flex flex-col">
-        <AppHeader>
+      <>
+        <PageHeader>
           <Button variant="ghost" size="icon" onClick={() => navigate(-1)}>
             <ArrowLeft className="size-5" />
           </Button>
-        </AppHeader>
+        </PageHeader>
         <main id="main-content" className="max-w-2xl mx-auto w-full p-4 flex-1 flex items-center justify-center text-center">
           <div>
             <h1 className="text-lg font-semibold">{t('compare.unavailableTitle')}</h1>
@@ -129,8 +126,7 @@ export function ComparePage() {
             </Button>
           </div>
         </main>
-        <AppFooter />
-      </div>
+      </>
     )
   }
 
@@ -140,12 +136,12 @@ export function ComparePage() {
   const nameB = meIsB ? t('compare.you') : result.b.displayName
 
   return (
-    <div className="min-h-dvh flex flex-col">
-      <AppHeader>
+    <>
+      <PageHeader>
         <Button variant="ghost" size="icon" onClick={() => navigate(-1)}>
           <ArrowLeft className="size-5" />
         </Button>
-      </AppHeader>
+      </PageHeader>
 
       <main id="main-content" className="max-w-3xl mx-auto w-full p-4 space-y-6 pb-12">
         <h1 className="sr-only">{t('compare.srHeading', { a: nameA, b: nameB })}</h1>
@@ -249,8 +245,7 @@ export function ComparePage() {
           </section>
         )}
       </main>
-      <AppFooter />
-    </div>
+    </>
   )
 }
 

--- a/packages/frontend/src/pages/GroupPage.tsx
+++ b/packages/frontend/src/pages/GroupPage.tsx
@@ -20,8 +20,7 @@ import {
   ResponsiveDialogTitle,
   ResponsiveDialogDescription,
 } from '@/components/ui/responsive-dialog'
-import { AppHeader } from '@/components/app-header'
-import { AppFooter } from '@/components/app-footer'
+import { PageHeader } from '@/components/app-layout'
 import { GroupPanel } from '@/components/group-panel'
 import { GroupTabs, type GroupTab } from '@/components/group-tabs'
 import { GameGrid, type GameFilters } from '@/components/game-grid'
@@ -450,10 +449,10 @@ export function GroupPage() {
 
   if (!currentGroup) {
     return (
-      <div className="min-h-dvh flex flex-col">
-        <AppHeader maxWidth="wide">
+      <>
+        <PageHeader>
           <Skeleton className="size-5 rounded" />
-        </AppHeader>
+        </PageHeader>
         <main id="main-content" className="max-w-5xl mx-auto p-4 w-full">
           <div
             role="status"
@@ -466,8 +465,7 @@ export function GroupPage() {
             <Skeleton className="h-[400px] w-full rounded-lg" />
           </div>
         </main>
-        <AppFooter />
-      </div>
+      </>
     )
   }
 
@@ -505,8 +503,8 @@ export function GroupPage() {
   }
 
   return (
-    <div className="min-h-dvh flex flex-col">
-      <AppHeader maxWidth="wide">
+    <>
+      <PageHeader>
         <div className="flex items-center gap-2 min-w-0 flex-1">
           <Button variant="ghost" size="icon" onClick={() => navigate('/')} aria-label={t('group.back')} className="shrink-0">
             <ArrowLeft className="size-5" />
@@ -519,7 +517,7 @@ export function GroupPage() {
             </Badge>
           )}
         </div>
-      </AppHeader>
+      </PageHeader>
 
       <main id="main-content" className="w-full max-w-5xl mx-auto px-3 sm:px-4 py-4 min-w-0">
         <GroupTabs active={activeTab} onChange={setActiveTab} />
@@ -722,8 +720,6 @@ export function GroupPage() {
           </div>
         </ResponsiveDialogContent>
       </ResponsiveDialog>
-
-      <AppFooter />
-    </div>
+    </>
   )
 }

--- a/packages/frontend/src/pages/GroupPage.tsx
+++ b/packages/frontend/src/pages/GroupPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useCallback, useMemo, useRef } from 'react'
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom'
-import { ArrowLeft, Users as UsersIcon, Link2 } from 'lucide-react'
+import { ArrowLeft, Link2 } from 'lucide-react'
 import { toast } from 'sonner'
 import { useTranslation } from 'react-i18next'
 import { motion } from 'framer-motion'
@@ -11,7 +11,6 @@ import { api, ApiError } from '@/lib/api'
 import { track } from '@/lib/analytics'
 import { getSocket } from '@/lib/socket'
 import { Button } from '@/components/ui/button'
-import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
 import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
 import {
@@ -23,7 +22,8 @@ import {
 } from '@/components/ui/responsive-dialog'
 import { AppHeader } from '@/components/app-header'
 import { AppFooter } from '@/components/app-footer'
-import { GroupSidebar } from '@/components/group-sidebar'
+import { GroupPanel } from '@/components/group-panel'
+import { GroupTabs, type GroupTab } from '@/components/group-tabs'
 import { GameGrid, type GameFilters } from '@/components/game-grid'
 import { RandomPickModal } from '@/components/random-pick-modal'
 import { VoteSetupDialog } from '@/components/vote-setup-dialog'
@@ -31,6 +31,10 @@ import { TonightPickHero } from '@/components/tonight-pick-hero'
 import { PersonaBadge } from '@/components/persona-badge'
 import { DiscordSetupInstructions } from '@/components/discord-setup-instructions'
 import { useDocumentTitle } from '@/hooks/useDocumentTitle'
+
+function isGroupTab(value: string | null): value is GroupTab {
+  return value === 'tonight' || value === 'members' || value === 'history' || value === 'stats' || value === 'settings'
+}
 
 export function GroupPage() {
   const { t } = useTranslation()
@@ -56,7 +60,6 @@ export function GroupPage() {
     sortBy: 'popularity',
   })
   const [voteSetupOpen, setVoteSetupOpen] = useState(false)
-  const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false)
   const [randomPickOpen, setRandomPickOpen] = useState(false)
   const [onlineUserIds, setOnlineUserIds] = useState<string[]>([])
   const [todayPersona, setTodayPersona] = useState<{ id: string; name: string; embedColor: number; introMessage: string } | null>(null)
@@ -431,27 +434,74 @@ export function GroupPage() {
   const lastSeenMap = lastSeenMapRef.current
   const currentUserRole = currentGroup?.members.find(m => m.id === user?.id)?.role || 'member'
 
+  // Active group-detail tab, mirrored in the URL (`?tab=`) so a section is
+  // deep-linkable and the browser back button leaves the group rather than
+  // cycling tabs. Defaults to "tonight" — the play-a-game-now surface.
+  const tabParam = searchParams.get('tab')
+  const activeTab: GroupTab = isGroupTab(tabParam) ? tabParam : 'tonight'
+  const setActiveTab = useCallback((next: GroupTab) => {
+    setSearchParams((prev) => {
+      const params = new URLSearchParams(prev)
+      if (next === 'tonight') params.delete('tab')
+      else params.set('tab', next)
+      return params
+    }, { replace: true })
+  }, [setSearchParams])
+
   if (!currentGroup) {
     return (
       <div className="min-h-dvh flex flex-col">
         <AppHeader maxWidth="wide">
           <Skeleton className="size-5 rounded" />
         </AppHeader>
-        <main id="main-content" className="max-w-6xl mx-auto p-4">
+        <main id="main-content" className="max-w-5xl mx-auto p-4 w-full">
           <div
             role="status"
             aria-busy="true"
             aria-live="polite"
             aria-label={t('common.loading', 'Chargement…')}
-            className="lg:grid lg:grid-cols-[280px_1fr] lg:gap-6"
+            className="space-y-4"
           >
-            <Skeleton className="hidden lg:block h-[300px] rounded-lg" />
+            <Skeleton className="h-10 w-full rounded-lg" />
             <Skeleton className="h-[400px] w-full rounded-lg" />
           </div>
         </main>
         <AppFooter />
       </div>
     )
+  }
+
+  // Shared props for the four secondary tab panels (members / history /
+  // stats / settings). Built once so the giant prop list isn't repeated.
+  const panelProps = {
+    members: currentGroup.members,
+    groupId: id!,
+    groupName: currentGroup.name,
+    syncing,
+    inviteToken,
+    voteHistory,
+    voteHistoryTruncated,
+    onlineMembers,
+    lastSeenMap,
+    currentUserId: user?.id || '',
+    currentUserRole,
+    autoVoteSchedule: currentGroup.autoVoteSchedule,
+    autoVoteDurationMinutes: currentGroup.autoVoteDurationMinutes,
+    releasesDigestEnabled: currentGroup.releasesDigestEnabled,
+    releasesDigestSchedule: currentGroup.releasesDigestSchedule,
+    releasesDigestCoopOnly: currentGroup.releasesDigestCoopOnly,
+    discordChannelId: currentGroup.discordChannelId,
+    onSync: handleSync,
+    onGenerateInvite: handleGenerateInvite,
+    onLeaveGroup: handleLeaveGroup,
+    onKickMember: handleKickMember,
+    onDeleteGroup: handleDeleteGroup,
+    onRenameGroup: handleRenameGroup,
+    onDeleteHistory: handleDeleteHistory,
+    onToggleNotifications: handleToggleNotifications,
+    onUpdateAutoVote: handleUpdateAutoVote,
+    onUpdateReleasesDigest: handleUpdateReleasesDigest,
+    onTestReleasesDigest: handleTestReleasesDigest,
   }
 
   return (
@@ -471,81 +521,17 @@ export function GroupPage() {
         </div>
       </AppHeader>
 
-      <main id="main-content" className="w-full max-w-6xl mx-auto px-3 sm:px-4 lg:px-6 py-4 min-w-0">
-        {/* Mobile: compact member pill strip — replaces the old "Ouvrir"
-            mini-bar. Tapping it still opens the sidebar sheet, but the
-            visual weight is cut in half and the bouncing chevron is gone. */}
-        <button
-          type="button"
-          className="lg:hidden mb-3 w-full min-h-[40px] rounded-full border border-border/60 bg-card/30 px-3 py-1.5 active:bg-card/60 active:scale-[0.99] transition-all"
-          onClick={() => setMobileSidebarOpen(true)}
-          aria-label={t('group.openSidebar')}
-        >
-          <div className="flex items-center gap-2 min-w-0">
-            <div className="flex -space-x-1.5 shrink-0">
-              {currentGroup.members.slice(0, 4).map((member) => (
-                <Avatar key={member.id} className="size-6 ring-2 ring-background">
-                  <AvatarImage src={member.avatarUrl} alt={member.displayName} />
-                  <AvatarFallback className="text-[9px]">{member.displayName.charAt(0).toUpperCase()}</AvatarFallback>
-                </Avatar>
-              ))}
-              {currentGroup.members.length > 4 && (
-                <div className="size-6 rounded-full bg-muted ring-2 ring-background flex items-center justify-center text-[9px] text-muted-foreground font-medium">
-                  +{currentGroup.members.length - 4}
-                </div>
-              )}
-            </div>
-            <div className="flex-1 min-w-0 text-left flex items-center gap-2">
-              <span className="text-xs text-muted-foreground whitespace-nowrap">
-                {t('group.members', { count: currentGroup.members.length })}
-              </span>
-              {onlineUserIds.length > 0 && (
-                <span className="flex items-center gap-1 text-[11px] text-online whitespace-nowrap">
-                  <span className="size-1.5 rounded-full bg-online animate-pulse" />
-                  {t('group.onlineCount', { count: onlineUserIds.length })}
-                </span>
-              )}
-            </div>
-            <UsersIcon className="size-3.5 text-muted-foreground shrink-0" />
-          </div>
-        </button>
+      <main id="main-content" className="w-full max-w-5xl mx-auto px-3 sm:px-4 py-4 min-w-0">
+        <GroupTabs active={activeTab} onChange={setActiveTab} />
 
-        <div className="lg:grid lg:grid-cols-[280px_minmax(0,1fr)] lg:gap-6">
-          {/* Sidebar — hidden on mobile, shown on lg+ */}
-          <div className="hidden lg:block min-w-0">
-            <GroupSidebar
-              members={currentGroup.members}
-              groupId={id!}
-              groupName={currentGroup.name}
-              syncing={syncing}
-              inviteToken={inviteToken}
-              voteHistory={voteHistory}
-              voteHistoryTruncated={voteHistoryTruncated}
-              onlineMembers={onlineMembers}
-              lastSeenMap={lastSeenMap}
-              currentUserId={user?.id || ''}
-              currentUserRole={currentUserRole}
-              autoVoteSchedule={currentGroup.autoVoteSchedule}
-              autoVoteDurationMinutes={currentGroup.autoVoteDurationMinutes}
-              releasesDigestEnabled={currentGroup.releasesDigestEnabled}
-              releasesDigestSchedule={currentGroup.releasesDigestSchedule}
-              releasesDigestCoopOnly={currentGroup.releasesDigestCoopOnly}
-              discordChannelId={currentGroup.discordChannelId}
-              onSync={handleSync}
-              onGenerateInvite={handleGenerateInvite}
-              onLeaveGroup={handleLeaveGroup}
-              onKickMember={handleKickMember}
-              onDeleteGroup={handleDeleteGroup}
-              onRenameGroup={handleRenameGroup}
-              onDeleteHistory={handleDeleteHistory}
-              onToggleNotifications={handleToggleNotifications}
-              onUpdateAutoVote={handleUpdateAutoVote}
-              onUpdateReleasesDigest={handleUpdateReleasesDigest}
-              onTestReleasesDigest={handleTestReleasesDigest}
-            />
-          </div>
+        <div className="pt-4">
+          {activeTab !== 'tonight' && (
+            <div className="max-w-2xl mx-auto">
+              <GroupPanel section={activeTab} {...panelProps} />
+            </div>
+          )}
 
-          {/* Main content: hero + games grid */}
+          {activeTab === 'tonight' && (
           <div className="space-y-4 min-w-0">
             {/* Owner-only prompt: if the group has no Discord channel
                 bound yet, surface a persistent banner inviting the owner
@@ -622,68 +608,6 @@ export function GroupPage() {
               onJoinActiveVote={() => navigate(`/groups/${id}/vote`)}
             />
 
-            {/* Mobile: fixed bottom action bar — kept as the persistent
-                primary CTA on small screens so the vote is always one tap
-                away even when the user has scrolled the grid. Flips to
-                "join vote" when a session is already open so the user
-                isn't walked through the setup dialog for nothing. */}
-            <div className="fixed bottom-0 left-0 right-0 z-40 sm:hidden bg-background/95 backdrop-blur-sm border-t border-border px-3 pt-2 pb-[max(1rem,env(safe-area-inset-bottom))]">
-              <Button
-                onClick={openVoteFlow}
-                className="w-full h-12 gap-2 active:scale-[0.98] transition-transform"
-              >
-                {activeVoteSession ? (
-                  <span className="font-heading font-bold">{t('group.joinActiveVote')}</span>
-                ) : (
-                  <>
-                    <span className="font-heading font-bold">{t('group.startVote')}</span>
-                    <span className="opacity-80 text-sm">· {t('group.commonGamesCount', { count: commonGames.length })}</span>
-                  </>
-                )}
-              </Button>
-            </div>
-            {/* Spacer for fixed bottom bar on mobile */}
-            <div className="h-16 sm:hidden" />
-
-            <RandomPickModal
-              open={randomPickOpen}
-              onOpenChange={setRandomPickOpen}
-              games={commonGames}
-            />
-
-            <VoteSetupDialog
-              open={voteSetupOpen}
-              onOpenChange={setVoteSetupOpen}
-              members={currentGroup.members}
-              groupId={id!}
-              onlineMembers={onlineMembers}
-              activeFilter={activeFilter}
-              onStartVote={handleStartVote}
-            />
-
-            {/* Link-a-Discord-channel dialog — opened from the banner
-                above. Channel binding is driven by the bot's
-                `/wawptn-setup` slash command, so this dialog only shows
-                the two-step instructions and an invite-bot button. */}
-            <ResponsiveDialog open={discordDialogOpen} onOpenChange={setDiscordDialogOpen}>
-              <ResponsiveDialogContent>
-                <ResponsiveDialogHeader>
-                  <ResponsiveDialogTitle>{t('group.discordBannerDialogTitle')}</ResponsiveDialogTitle>
-                  <ResponsiveDialogDescription>
-                    {t('group.discordBannerHint')}
-                  </ResponsiveDialogDescription>
-                </ResponsiveDialogHeader>
-                <div className="mt-4 space-y-4">
-                  <DiscordSetupInstructions />
-                  <div className="flex items-center justify-end">
-                    <Button variant="secondary" onClick={() => setDiscordDialogOpen(false)}>
-                      {t('common.close', 'Fermer')}
-                    </Button>
-                  </div>
-                </div>
-              </ResponsiveDialogContent>
-            </ResponsiveDialog>
-
             <GameGrid
               games={commonGames}
               loading={loadingGames}
@@ -734,48 +658,71 @@ export function GroupPage() {
               onApplyPreset={(patch) => setGameFilters(prev => ({ ...prev, ...patch }))}
             />
           </div>
+          )}
         </div>
 
-        {/* Mobile: sidebar as responsive dialog sheet with snap points */}
-        <ResponsiveDialog open={mobileSidebarOpen} onOpenChange={setMobileSidebarOpen} snapPoints={[0.55, 1]}>
-          <ResponsiveDialogContent>
-            <ResponsiveDialogHeader>
-              <ResponsiveDialogTitle>{currentGroup.name}</ResponsiveDialogTitle>
-            </ResponsiveDialogHeader>
-            <GroupSidebar
-              members={currentGroup.members}
-              groupId={id!}
-              groupName={currentGroup.name}
-              syncing={syncing}
-              inviteToken={inviteToken}
-              voteHistory={voteHistory}
-              voteHistoryTruncated={voteHistoryTruncated}
-              onlineMembers={onlineMembers}
-              lastSeenMap={lastSeenMap}
-              currentUserId={user?.id || ''}
-              currentUserRole={currentUserRole}
-              autoVoteSchedule={currentGroup.autoVoteSchedule}
-              autoVoteDurationMinutes={currentGroup.autoVoteDurationMinutes}
-              releasesDigestEnabled={currentGroup.releasesDigestEnabled}
-              releasesDigestSchedule={currentGroup.releasesDigestSchedule}
-              releasesDigestCoopOnly={currentGroup.releasesDigestCoopOnly}
-              discordChannelId={currentGroup.discordChannelId}
-              onSync={handleSync}
-              onGenerateInvite={handleGenerateInvite}
-              onLeaveGroup={handleLeaveGroup}
-              onKickMember={handleKickMember}
-              onDeleteGroup={handleDeleteGroup}
-              onRenameGroup={handleRenameGroup}
-              onDeleteHistory={handleDeleteHistory}
-              onToggleNotifications={handleToggleNotifications}
-              onUpdateAutoVote={handleUpdateAutoVote}
-              onUpdateReleasesDigest={handleUpdateReleasesDigest}
-              onTestReleasesDigest={handleTestReleasesDigest}
-              compact
-            />
-          </ResponsiveDialogContent>
-        </ResponsiveDialog>
+        {/* Spacer so the mobile fixed action bar never covers content. */}
+        <div className="h-20 sm:hidden" />
       </main>
+
+      {/* Mobile: persistent bottom action bar — keeps the vote CTA one tap
+          away from every tab on small screens. Flips to "join vote" when a
+          session is already open so the user isn't walked through the setup
+          dialog for nothing. */}
+      <div className="fixed bottom-0 left-0 right-0 z-40 sm:hidden bg-background/95 backdrop-blur-sm border-t border-border px-3 pt-2 pb-[max(1rem,env(safe-area-inset-bottom))]">
+        <Button
+          onClick={openVoteFlow}
+          className="w-full h-12 gap-2 active:scale-[0.98] transition-transform"
+        >
+          {activeVoteSession ? (
+            <span className="font-heading font-bold">{t('group.joinActiveVote')}</span>
+          ) : (
+            <>
+              <span className="font-heading font-bold">{t('group.startVote')}</span>
+              <span className="opacity-80 text-sm">· {t('group.commonGamesCount', { count: commonGames.length })}</span>
+            </>
+          )}
+        </Button>
+      </div>
+
+      {/* Dialogs — mounted regardless of the active tab so the vote / random
+          pick / Discord flows can be triggered from anywhere (incl. the
+          `?startVote=1` deep link from the dashboard). */}
+      <RandomPickModal
+        open={randomPickOpen}
+        onOpenChange={setRandomPickOpen}
+        games={commonGames}
+      />
+
+      <VoteSetupDialog
+        open={voteSetupOpen}
+        onOpenChange={setVoteSetupOpen}
+        members={currentGroup.members}
+        groupId={id!}
+        onlineMembers={onlineMembers}
+        activeFilter={activeFilter}
+        onStartVote={handleStartVote}
+      />
+
+      <ResponsiveDialog open={discordDialogOpen} onOpenChange={setDiscordDialogOpen}>
+        <ResponsiveDialogContent>
+          <ResponsiveDialogHeader>
+            <ResponsiveDialogTitle>{t('group.discordBannerDialogTitle')}</ResponsiveDialogTitle>
+            <ResponsiveDialogDescription>
+              {t('group.discordBannerHint')}
+            </ResponsiveDialogDescription>
+          </ResponsiveDialogHeader>
+          <div className="mt-4 space-y-4">
+            <DiscordSetupInstructions />
+            <div className="flex items-center justify-end">
+              <Button variant="secondary" onClick={() => setDiscordDialogOpen(false)}>
+                {t('common.close', 'Fermer')}
+              </Button>
+            </div>
+          </div>
+        </ResponsiveDialogContent>
+      </ResponsiveDialog>
+
       <AppFooter />
     </div>
   )

--- a/packages/frontend/src/pages/GroupPage.tsx
+++ b/packages/frontend/src/pages/GroupPage.tsx
@@ -90,7 +90,7 @@ export function GroupPage() {
       // `freeLimitApplied` tells us whether to show an upgrade CTA beneath
       // the list.
       const history = await api.getVoteHistory(groupId)
-      setVoteHistory(history.data.filter((h) => h.winningGameName).slice(0, 5))
+      setVoteHistory(history.data.filter((h) => h.winningGameName))
       setVoteHistoryTruncated(history.freeLimitApplied)
     } catch {
       // Non-critical, fail silently
@@ -520,7 +520,7 @@ export function GroupPage() {
       </PageHeader>
 
       <main id="main-content" className="w-full max-w-5xl mx-auto px-3 sm:px-4 py-4 min-w-0">
-        <GroupTabs active={activeTab} onChange={setActiveTab} />
+        <GroupTabs active={activeTab} onChange={setActiveTab} voteLive={!!activeVoteSession} />
 
         <div className="pt-4">
           {activeTab !== 'tonight' && (

--- a/packages/frontend/src/pages/GroupsPage.tsx
+++ b/packages/frontend/src/pages/GroupsPage.tsx
@@ -19,8 +19,6 @@ import {
   ResponsiveDialogTitle,
   ResponsiveDialogDescription,
 } from '@/components/ui/responsive-dialog'
-import { AppHeader } from '@/components/app-header'
-import { AppFooter } from '@/components/app-footer'
 import { InviteLink } from '@/components/invite-link'
 import { useDocumentTitle } from '@/hooks/useDocumentTitle'
 
@@ -243,9 +241,7 @@ export function GroupsPage() {
   }, [heroGroup, navigate])
 
   return (
-    <div className="min-h-dvh flex flex-col">
-      <AppHeader />
-
+    <>
       <main
         id="main-content"
         ref={mainRef}
@@ -536,9 +532,7 @@ export function GroupsPage() {
           </div>
         </div>
       )}
-
-      <AppFooter />
-    </div>
+    </>
   )
 }
 

--- a/packages/frontend/src/pages/GroupsPage.tsx
+++ b/packages/frontend/src/pages/GroupsPage.tsx
@@ -428,8 +428,9 @@ export function GroupsPage() {
           </ResponsiveDialogContent>
         </ResponsiveDialog>
 
-        {/* Loading skeleton */}
-        {loading ? (
+        {/* Loading skeleton — only on the first load. A background refetch
+            (e.g. the global vote-banner sync) keeps the list on screen. */}
+        {loading && groups.length === 0 ? (
           <div
             className="space-y-3"
             role="status"

--- a/packages/frontend/src/pages/GroupsPage.tsx
+++ b/packages/frontend/src/pages/GroupsPage.tsx
@@ -609,29 +609,60 @@ interface CompactGroupRowProps {
 
 function CompactGroupRow({ group }: CompactGroupRowProps) {
   const { t } = useTranslation()
+  const navigate = useNavigate()
   const isActive = !!group.activeVoteSession
 
+  // No live vote: the whole row is one link to the group page, where the
+  // prominent "tonight" CTA lives.
+  if (!isActive) {
+    return (
+      <Link
+        to={`/groups/${group.id}`}
+        className={cn(
+          'flex items-center justify-between gap-3 px-4 py-3 rounded-lg border border-border hover:bg-muted/40 transition-colors',
+          group.role === 'owner' && 'border-l-2 border-l-reward/40',
+        )}
+      >
+        <div className="min-w-0 flex-1">
+          <span className="font-medium truncate block">{group.name}</span>
+          <span className="text-xs text-muted-foreground">
+            {t('groups.membersCount', { count: group.memberCount })}
+          </span>
+        </div>
+      </Link>
+    )
+  }
+
+  // A vote is live: surface a direct "join" shortcut so the user doesn't
+  // have to open the group page and hunt for it.
   return (
-    <Link
-      to={`/groups/${group.id}`}
+    <div
       className={cn(
-        'flex items-center justify-between gap-3 px-4 py-3 rounded-lg border border-border hover:bg-muted/40 transition-colors',
+        'flex items-center gap-3 pl-4 pr-2 py-2 rounded-lg border border-neon/40 bg-neon/5',
         group.role === 'owner' && 'border-l-2 border-l-reward/40',
       )}
     >
-      <div className="min-w-0 flex-1">
+      <Link
+        to={`/groups/${group.id}`}
+        className="min-w-0 flex-1 py-1 hover:opacity-80 transition-opacity"
+      >
         <span className="font-medium truncate block">{group.name}</span>
         <span className="text-xs text-muted-foreground">
           {t('groups.membersCount', { count: group.memberCount })}
         </span>
-      </div>
-      {isActive && (
-        <span className="inline-flex items-center gap-1.5 rounded-full bg-neon/10 px-2 py-0.5 text-[11px] font-semibold text-neon shrink-0">
-          <span className="size-1.5 rounded-full bg-neon animate-pulse" aria-hidden="true" />
-          {t('groups.voteOngoing')}
-        </span>
-      )}
-    </Link>
+      </Link>
+      <Button
+        size="sm"
+        onClick={() => {
+          track('group.row_join_vote')
+          navigate(`/groups/${group.id}/vote`)
+        }}
+        className="shrink-0 h-9 gap-1.5 animate-pulse"
+      >
+        <Vote className="size-3.5" />
+        {t('groups.joinVote')}
+      </Button>
+    </div>
   )
 }
 

--- a/packages/frontend/src/pages/ProfilePage.tsx
+++ b/packages/frontend/src/pages/ProfilePage.tsx
@@ -10,8 +10,7 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { PlatformIcon } from '@/components/icons/platforms'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
-import { AppHeader } from '@/components/app-header'
-import { AppFooter } from '@/components/app-footer'
+import { PageHeader } from '@/components/app-layout'
 import { Button } from '@/components/ui/button'
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
 import { Badge } from '@/components/ui/badge'
@@ -331,12 +330,12 @@ export function ProfilePage() {
   /* ── Loading skeleton ── */
   if (loading) {
     return (
-      <div className="min-h-dvh flex flex-col">
-        <AppHeader>
+      <>
+        <PageHeader>
           <Button variant="ghost" size="icon" onClick={() => navigate('/')}>
             <ArrowLeft className="size-5" />
           </Button>
-        </AppHeader>
+        </PageHeader>
         <main
           id="main-content"
           className="max-w-2xl mx-auto p-4 space-y-6"
@@ -351,8 +350,7 @@ export function ProfilePage() {
             {[1, 2, 3].map(i => <Skeleton key={i} className="h-[4.5rem] rounded-xl" />)}
           </div>
         </main>
-        <AppFooter />
-      </div>
+      </>
     )
   }
 
@@ -362,12 +360,12 @@ export function ProfilePage() {
   const otherGames = profile.topGames?.slice(1)
 
   return (
-    <div className="min-h-dvh flex flex-col">
-      <AppHeader>
+    <>
+      <PageHeader>
         <Button variant="ghost" size="icon" onClick={() => navigate('/')}>
           <ArrowLeft className="size-5" />
         </Button>
-      </AppHeader>
+      </PageHeader>
 
       <motion.main
         id="main-content"
@@ -786,7 +784,6 @@ export function ProfilePage() {
           </motion.section>
         )}
       </motion.main>
-      <AppFooter />
-    </div>
+    </>
   )
 }

--- a/packages/frontend/src/pages/SubscriptionPage.tsx
+++ b/packages/frontend/src/pages/SubscriptionPage.tsx
@@ -3,8 +3,6 @@ import { useNavigate, useSearchParams } from 'react-router-dom'
 import { ArrowLeft, Crown, CreditCard, ExternalLink } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
-import { AppHeader } from '@/components/app-header'
-import { AppFooter } from '@/components/app-footer'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
@@ -175,9 +173,7 @@ export function SubscriptionPage() {
   const canManageSubscription = isPremium && source === 'stripe'
 
   return (
-    <div className="min-h-dvh flex flex-col bg-background">
-      <AppHeader />
-      <main id="main-content" className="max-w-2xl mx-auto px-4 py-8">
+    <main id="main-content" className="max-w-2xl mx-auto px-4 py-8">
         <Button variant="ghost" size="sm" onClick={() => navigate(-1)} className="mb-4">
           <ArrowLeft className="size-4 mr-2" />
           {t('group.back')}
@@ -313,8 +309,6 @@ export function SubscriptionPage() {
             )}
           </CardContent>
         </Card>
-      </main>
-      <AppFooter />
-    </div>
+    </main>
   )
 }

--- a/packages/frontend/src/pages/UserProfilePage.tsx
+++ b/packages/frontend/src/pages/UserProfilePage.tsx
@@ -2,8 +2,7 @@ import { useEffect } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { ArrowLeft, Clock, GitCompare, Lock, RefreshCw, Trophy } from 'lucide-react'
 import { useTranslation, Trans } from 'react-i18next'
-import { AppHeader } from '@/components/app-header'
-import { AppFooter } from '@/components/app-footer'
+import { PageHeader } from '@/components/app-layout'
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -63,31 +62,30 @@ export function UserProfilePage() {
 
   if (isLoading && !profile) {
     return (
-      <div className="min-h-dvh flex flex-col">
-        <AppHeader>
+      <>
+        <PageHeader>
           <Button variant="ghost" size="icon" onClick={() => navigate(-1)}>
             <ArrowLeft className="size-5" />
           </Button>
-        </AppHeader>
+        </PageHeader>
         <main id="main-content" className="max-w-2xl mx-auto w-full p-4 space-y-4">
           <Skeleton className="h-40 rounded-2xl" />
           <Skeleton className="h-6 w-32" />
           <Skeleton className="h-24 rounded-xl" />
           <Skeleton className="h-24 rounded-xl" />
         </main>
-        <AppFooter />
-      </div>
+      </>
     )
   }
 
   if (error || !profile) {
     return (
-      <div className="min-h-dvh flex flex-col">
-        <AppHeader>
+      <>
+        <PageHeader>
           <Button variant="ghost" size="icon" onClick={() => navigate(-1)}>
             <ArrowLeft className="size-5" />
           </Button>
-        </AppHeader>
+        </PageHeader>
         <main id="main-content" className="max-w-2xl mx-auto w-full p-4 flex-1 flex items-center justify-center">
           <div className="text-center space-y-3">
             <Lock className="size-8 mx-auto text-muted-foreground" />
@@ -100,8 +98,7 @@ export function UserProfilePage() {
             </Button>
           </div>
         </main>
-        <AppFooter />
-      </div>
+      </>
     )
   }
 
@@ -109,12 +106,12 @@ export function UserProfilePage() {
   const topCommon = profile.commonGamesWithViewer.slice(0, 3)
 
   return (
-    <div className="min-h-dvh flex flex-col">
-      <AppHeader>
+    <>
+      <PageHeader>
         <Button variant="ghost" size="icon" onClick={() => navigate(-1)}>
           <ArrowLeft className="size-5" />
         </Button>
-      </AppHeader>
+      </PageHeader>
 
       <main id="main-content" className="max-w-2xl mx-auto w-full p-4 space-y-6 pb-12">
         {/* ── Header card ── */}
@@ -274,7 +271,6 @@ export function UserProfilePage() {
           </div>
         )}
       </main>
-      <AppFooter />
-    </div>
+    </>
   )
 }


### PR DESCRIPTION
The group detail page buried members, history, stats and settings in a
desktop-only sidebar and a mobile bottom-sheet opened from an unlabelled
avatar pill, so most features were undiscoverable — especially on phones.

Restructure the page around a persistent, labelled tab strip (Tonight /
Members / History / Stats / Settings) shown identically on every
viewport. The tab is mirrored in the URL (`?tab=`) so sections are
deep-linkable. The former GroupSidebar becomes a section-aware GroupPanel
(group-sidebar.tsx renamed to group-panel.tsx); the vote CTA, random pick
and Discord dialogs are hoisted out of the tab switch so they stay
reachable from any tab.

https://claude.ai/code/session_01BbnYbazUKf3sSRGNMLpFa3