### PR TITLE
feat(group): improve Stats tab readability and completeness

### DIFF
--- a/packages/frontend/src/components/game-recommendations.tsx
+++ b/packages/frontend/src/components/game-recommendations.tsx
@@ -1,8 +1,10 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Lightbulb } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
-import { Card, CardHeader, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
+import { Skeleton } from '@/components/ui/skeleton'
+import { CollapsibleCard } from '@/components/ui/collapsible-card'
+import { GameThumb } from '@/components/game-thumb'
 import { PremiumGate } from '@/components/premium-gate'
 import { api } from '@/lib/api'
 
@@ -15,85 +17,86 @@ interface Recommendation {
 
 interface GameRecommendationsProps {
   groupId: string
-  compact?: boolean
 }
 
-export function GameRecommendations({ groupId, compact = false }: GameRecommendationsProps) {
+export function GameRecommendations({ groupId }: GameRecommendationsProps) {
   const { t } = useTranslation()
   const [recommendations, setRecommendations] = useState<Recommendation[]>([])
-  const fetchedGroupId = useRef<string | null>(null)
+  const [loaded, setLoaded] = useState(false)
+  const [trackedGroup, setTrackedGroup] = useState(groupId)
+
+  // Reset to the loading state when the group changes (see GroupStats).
+  if (groupId !== trackedGroup) {
+    setTrackedGroup(groupId)
+    setRecommendations([])
+    setLoaded(false)
+  }
 
   useEffect(() => {
     let cancelled = false
-    fetchedGroupId.current = groupId
     api.getRecommendations(groupId)
       .then((data) => {
-        if (!cancelled) setRecommendations(data.recommendations)
+        if (cancelled) return
+        setRecommendations(data.recommendations)
+        setLoaded(true)
       })
       .catch(() => {
-        // Non-critical, fail silently (includes premium_required 403)
+        // Non-critical (includes premium_required 403). Mark loaded so the
+        // empty state shows instead of an endless skeleton.
+        if (!cancelled) setLoaded(true)
       })
     return () => { cancelled = true }
   }, [groupId])
 
+  // The common "never played together" case uses the quietest variant so a
+  // uniform list reads calmly; the rarer, more actionable reasons stand out.
   const reasonBadge = (reason: string) => {
     switch (reason) {
       case 'never_played':
-        return <Badge variant="default" className="text-[10px] px-1.5 py-0 shrink-0">{t('recommendations.neverPlayed')}</Badge>
+        return <Badge variant="outline" className="text-[10px] px-1.5 py-0 shrink-0">{t('recommendations.neverPlayed')}</Badge>
       case 'not_played_long':
         return <Badge variant="secondary" className="text-[10px] px-1.5 py-0 shrink-0">{t('recommendations.notPlayedLong')}</Badge>
       case 'popular_forgotten':
-        return <Badge variant="outline" className="text-[10px] px-1.5 py-0 shrink-0">{t('recommendations.popularForgotten')}</Badge>
+        return <Badge variant="default" className="text-[10px] px-1.5 py-0 shrink-0">{t('recommendations.popularForgotten')}</Badge>
       default:
         return null
     }
   }
 
-  const wrapper = (content: React.ReactNode) => {
-    if (compact) {
-      return (
-        <div className="space-y-2">
-          <h2 className="font-semibold flex items-center gap-2 text-sm">
-            <Lightbulb className="size-4" />
-            {t('recommendations.title')}
-          </h2>
-          {content}
-        </div>
-      )
-    }
-    return (
-      <Card>
-        <CardHeader className="pb-3">
-          <h2 className="font-semibold flex items-center gap-2 text-sm">
-            <Lightbulb className="size-4" />
-            {t('recommendations.title')}
-          </h2>
-        </CardHeader>
-        <CardContent>{content}</CardContent>
-      </Card>
-    )
-  }
-
-  return wrapper(
-    <PremiumGate from="recommendations">
-      {recommendations.length === 0 ? null : (
-        <div className="space-y-2">
-          {recommendations.map((game) => (
-            <div key={game.steamAppId} className="flex items-center gap-3">
-              <img
-                src={game.headerImageUrl}
-                alt={game.gameName}
-                className="w-16 h-[34px] rounded-md object-cover shrink-0"
-                loading="lazy"
-              />
-              <div className="flex-1 min-w-0">
-                <p className="text-sm font-medium truncate">{game.gameName}</p>
-                {reasonBadge(game.reason)}
+  return (
+    <CollapsibleCard title={t('recommendations.title')} icon={Lightbulb}>
+      <PremiumGate from="recommendations">
+        {!loaded ? (
+          <div className="space-y-2">
+            <Skeleton className="h-[34px]" />
+            <Skeleton className="h-[34px]" />
+            <Skeleton className="h-[34px]" />
+          </div>
+        ) : recommendations.length === 0 ? (
+          <div className="flex flex-col items-center gap-1.5 py-6 text-center">
+            <Lightbulb className="size-8 text-muted-foreground/40 mb-1" aria-hidden="true" />
+            <p className="text-sm font-medium">{t('recommendations.emptyTitle')}</p>
+            <p className="text-xs text-muted-foreground max-w-[16rem]">{t('recommendations.emptyDescription')}</p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {recommendations.map((game) => (
+              <div key={game.steamAppId} className="flex items-center gap-3">
+                <GameThumb
+                  appId={game.steamAppId}
+                  name={game.gameName}
+                  src={game.headerImageUrl}
+                  className="w-16 h-[34px]"
+                />
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium truncate" title={game.gameName}>{game.gameName}</p>
+                  {reasonBadge(game.reason)}
+                </div>
               </div>
-            </div>
-          ))}
-        </div>
-      )}
-    </PremiumGate>
+            ))}
+          </div>
+        )}
+      </PremiumGate>
+    </CollapsibleCard>
   )
 }

--- a/packages/frontend/src/components/game-thumb.tsx
+++ b/packages/frontend/src/components/game-thumb.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react'
+import { cn } from '@/lib/utils'
+import { resolveSteamHeaderImage } from '@/lib/steam-cdn'
+
+interface GameThumbProps {
+  appId: number
+  name: string
+  /** Pre-resolved image URL (e.g. from the API); falls back to the Steam CDN. */
+  src?: string | null
+  className?: string
+}
+
+/** Steam header thumbnail with a graceful fallback. Steam's CDN 404s for
+ *  delisted apps, DLC and non-game entries; on error we render a tiled
+ *  placeholder with the game's initial so the row keeps its height instead
+ *  of collapsing and overlapping neighbouring text. */
+export function GameThumb({ appId, name, src, className }: GameThumbProps) {
+  const [failed, setFailed] = useState(false)
+
+  if (failed) {
+    return (
+      <div
+        className={cn(
+          'flex items-center justify-center rounded bg-muted text-muted-foreground text-xs font-bold uppercase shrink-0',
+          className,
+        )}
+        aria-hidden="true"
+      >
+        {name.charAt(0)}
+      </div>
+    )
+  }
+
+  return (
+    <img
+      src={resolveSteamHeaderImage(appId, src)}
+      alt=""
+      className={cn('rounded object-cover bg-muted shrink-0', className)}
+      loading="lazy"
+      onError={() => setFailed(true)}
+    />
+  )
+}

--- a/packages/frontend/src/components/group-stats.tsx
+++ b/packages/frontend/src/components/group-stats.tsx
@@ -1,12 +1,14 @@
-import { useEffect, useRef, useState } from 'react'
-import { BarChart3, Trophy, Users, Vote, ChevronDown, ChevronUp } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { BarChart3, Trophy, Users, Vote, RefreshCw } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
-import { Card, CardHeader, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/skeleton'
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
-import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
+import { CollapsibleCard } from '@/components/ui/collapsible-card'
+import { GameThumb } from '@/components/game-thumb'
 import { api } from '@/lib/api'
-import { getSteamHeaderImageUrl } from '@/lib/steam-cdn'
+import { cn } from '@/lib/utils'
 
 interface GroupStatsData {
   totalSessions: number
@@ -16,47 +18,85 @@ interface GroupStatsData {
   recentWinners: { gameName: string; steamAppId: number; closedAt: string }[]
 }
 
+type Status = 'loading' | 'error' | 'ready'
+
 interface GroupStatsProps {
   groupId: string
-  compact?: boolean
 }
 
-export function GroupStats({ groupId, compact = false }: GroupStatsProps) {
+const SECTION_LABEL =
+  'text-xs font-semibold uppercase text-muted-foreground tracking-wide flex items-center gap-1.5'
+
+export function GroupStats({ groupId }: GroupStatsProps) {
   const { t, i18n } = useTranslation()
   const [stats, setStats] = useState<GroupStatsData | null>(null)
-  const [expanded, setExpanded] = useState(false)
-  const fetchedGroupId = useRef<string | null>(null)
+  const [status, setStatus] = useState<Status>('loading')
+  const [request, setRequest] = useState(0)
+  const [trackedGroup, setTrackedGroup] = useState(groupId)
+
+  // Reset to the loading state when the group changes, so a stale group's
+  // stats never flash before the new fetch resolves.
+  if (groupId !== trackedGroup) {
+    setTrackedGroup(groupId)
+    setStats(null)
+    setStatus('loading')
+  }
 
   useEffect(() => {
     let cancelled = false
-    fetchedGroupId.current = groupId
     api.getGroupStats(groupId)
       .then((data) => {
-        if (!cancelled) setStats(data)
+        if (cancelled) return
+        setStats(data)
+        setStatus('ready')
       })
       .catch(() => {
-        // Non-critical, fail silently
+        if (!cancelled) setStatus('error')
       })
     return () => { cancelled = true }
-  }, [groupId])
+  }, [groupId, request])
 
-  if (!stats || stats.totalSessions === 0) return null
+  return (
+    <CollapsibleCard title={t('stats.title')} icon={BarChart3}>
+      {status === 'loading' && <StatsSkeleton />}
 
-  const content = (
+      {status === 'error' && (
+        <div className="flex flex-col items-center gap-3 py-6 text-center">
+          <p className="text-sm text-muted-foreground">{t('stats.loadError')}</p>
+          <Button variant="outline" size="sm" onClick={() => { setStatus('loading'); setRequest((n) => n + 1) }}>
+            <RefreshCw className="size-4 mr-1.5" aria-hidden="true" />
+            {t('common.retry')}
+          </Button>
+        </div>
+      )}
+
+      {status === 'ready' && stats && (
+        stats.totalSessions === 0
+          ? <StatsEmpty />
+          : <StatsContent stats={stats} language={i18n.language} />
+      )}
+    </CollapsibleCard>
+  )
+}
+
+function StatsContent({ stats, language }: { stats: GroupStatsData; language: string }) {
+  const { t } = useTranslation()
+
+  return (
     <div className="space-y-4">
       {/* Summary counters */}
       <div className="grid grid-cols-2 gap-3">
-        <div className="flex items-center gap-2 rounded-md bg-muted/50 p-2.5">
-          <Vote className="size-4 text-primary shrink-0" />
+        <div className="flex items-center gap-2.5 rounded-lg bg-muted/50 p-3">
+          <Vote className="size-5 text-primary shrink-0" aria-hidden="true" />
           <div>
-            <p className="text-lg font-bold leading-tight">{stats.totalSessions}</p>
+            <p className="text-xl font-bold leading-tight text-primary">{stats.totalSessions}</p>
             <p className="text-xs text-muted-foreground">{t('stats.sessions')}</p>
           </div>
         </div>
-        <div className="flex items-center gap-2 rounded-md bg-muted/50 p-2.5">
-          <BarChart3 className="size-4 text-primary shrink-0" />
+        <div className="flex items-center gap-2.5 rounded-lg bg-muted/50 p-3">
+          <BarChart3 className="size-5 text-primary shrink-0" aria-hidden="true" />
           <div>
-            <p className="text-lg font-bold leading-tight">{stats.totalVotes}</p>
+            <p className="text-xl font-bold leading-tight text-primary">{stats.totalVotes}</p>
             <p className="text-xs text-muted-foreground">{t('stats.votes')}</p>
           </div>
         </div>
@@ -65,35 +105,38 @@ export function GroupStats({ groupId, compact = false }: GroupStatsProps) {
       {/* Top games */}
       {stats.topGames.length > 0 && (
         <div className="space-y-2">
-          <h3 className="text-xs font-semibold uppercase text-muted-foreground tracking-wide flex items-center gap-1.5">
-            <Trophy className="size-3.5" />
+          <h3 className={SECTION_LABEL}>
+            <Trophy className="size-3.5" aria-hidden="true" />
             {t('stats.topGames')}
           </h3>
           <div className="space-y-1.5">
-            {stats.topGames.map((game, index) => (
-              <div key={game.steamAppId} className="flex items-center gap-2.5">
-                <span className="text-xs font-bold text-muted-foreground w-4 text-right shrink-0">
-                  {index + 1}.
-                </span>
-                <img
-                  src={getSteamHeaderImageUrl(game.steamAppId)}
-                  alt={game.gameName}
-                  className="w-12 h-[22px] rounded object-cover shrink-0"
-                  loading="lazy"
-                />
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="text-sm truncate flex-1">{game.gameName}</span>
-                  </TooltipTrigger>
-                  <TooltipContent side="top" className="text-xs">
-                    {game.gameName}
-                  </TooltipContent>
-                </Tooltip>
-                <Badge variant="secondary" className="shrink-0 text-xs">
-                  {game.winCount} {game.winCount > 1 ? t('stats.wins') : t('stats.win')}
-                </Badge>
-              </div>
-            ))}
+            {stats.topGames.map((game, index) => {
+              const winRate = game.totalNominations > 0
+                ? Math.round((game.winCount / game.totalNominations) * 100)
+                : null
+              return (
+                <div key={game.steamAppId} className="flex items-center gap-2.5">
+                  <span
+                    className={cn(
+                      'text-sm font-bold w-4 text-right shrink-0',
+                      index === 0 ? 'text-reward' : 'text-muted-foreground',
+                    )}
+                  >
+                    {index + 1}
+                  </span>
+                  <GameThumb appId={game.steamAppId} name={game.gameName} className="w-14 h-[26px]" />
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm truncate" title={game.gameName}>{game.gameName}</p>
+                    {winRate !== null && (
+                      <p className="text-xs text-muted-foreground">{t('stats.winRate', { rate: winRate })}</p>
+                    )}
+                  </div>
+                  <Badge variant="secondary" className="shrink-0 text-xs">
+                    {game.winCount} {game.winCount > 1 ? t('stats.wins') : t('stats.win')}
+                  </Badge>
+                </div>
+              )
+            })}
           </div>
         </div>
       )}
@@ -101,25 +144,18 @@ export function GroupStats({ groupId, compact = false }: GroupStatsProps) {
       {/* Member participation */}
       {stats.memberParticipation.length > 0 && (
         <div className="space-y-2">
-          <h3 className="text-xs font-semibold uppercase text-muted-foreground tracking-wide flex items-center gap-1.5">
-            <Users className="size-3.5" />
+          <h3 className={SECTION_LABEL}>
+            <Users className="size-3.5" aria-hidden="true" />
             {t('stats.participation')}
           </h3>
           <div className="space-y-1.5">
             {stats.memberParticipation.map((member) => (
               <div key={member.userId} className="flex items-center gap-2.5">
                 <Avatar className="size-6 shrink-0">
-                  <AvatarImage src={member.avatarUrl} alt={member.displayName} />
+                  <AvatarImage src={member.avatarUrl} alt="" />
                   <AvatarFallback className="text-xs">{member.displayName.charAt(0).toUpperCase()}</AvatarFallback>
                 </Avatar>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="text-sm truncate flex-1">{member.displayName}</span>
-                  </TooltipTrigger>
-                  <TooltipContent side="top" className="text-xs">
-                    {member.displayName}
-                  </TooltipContent>
-                </Tooltip>
+                <span className="text-sm truncate flex-1" title={member.displayName}>{member.displayName}</span>
                 <span className="text-xs text-muted-foreground shrink-0">
                   {t('stats.memberVotes', { count: member.voteCount })}
                 </span>
@@ -132,29 +168,17 @@ export function GroupStats({ groupId, compact = false }: GroupStatsProps) {
       {/* Recent winners */}
       {stats.recentWinners.length > 0 && (
         <div className="space-y-2">
-          <h3 className="text-xs font-semibold uppercase text-muted-foreground tracking-wide flex items-center gap-1.5">
-            <Trophy className="size-3.5" />
+          <h3 className={SECTION_LABEL}>
+            <Trophy className="size-3.5" aria-hidden="true" />
             {t('stats.recentWinners')}
           </h3>
           <div className="space-y-1.5">
             {stats.recentWinners.map((winner, index) => (
               <div key={`${winner.steamAppId}-${index}`} className="flex items-center gap-2.5">
-                <img
-                  src={getSteamHeaderImageUrl(winner.steamAppId)}
-                  alt={winner.gameName}
-                  className="w-12 h-[22px] rounded object-cover shrink-0"
-                  loading="lazy"
-                />
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="text-sm truncate flex-1">{winner.gameName}</span>
-                  </TooltipTrigger>
-                  <TooltipContent side="top" className="text-xs">
-                    {winner.gameName}
-                  </TooltipContent>
-                </Tooltip>
+                <GameThumb appId={winner.steamAppId} name={winner.gameName} className="w-14 h-[26px]" />
+                <span className="text-sm truncate flex-1" title={winner.gameName}>{winner.gameName}</span>
                 <span className="text-xs text-muted-foreground shrink-0">
-                  {new Intl.DateTimeFormat(i18n.language, { day: 'numeric', month: 'short' }).format(new Date(winner.closedAt))}
+                  {new Intl.DateTimeFormat(language, { day: 'numeric', month: 'short' }).format(new Date(winner.closedAt))}
                 </span>
               </div>
             ))}
@@ -163,50 +187,31 @@ export function GroupStats({ groupId, compact = false }: GroupStatsProps) {
       )}
     </div>
   )
+}
 
-  if (compact) {
-    return (
-      <div className="space-y-2">
-        <button
-          type="button"
-          className="w-full flex items-center justify-between"
-          onClick={() => setExpanded(!expanded)}
-          aria-expanded={expanded}
-          aria-controls="group-stats-panel-compact"
-        >
-          <h2 className="font-semibold flex items-center gap-2 text-sm">
-            <BarChart3 className="size-4" aria-hidden="true" />
-            {t('stats.title')}
-          </h2>
-          {expanded ? <ChevronUp className="size-4 text-muted-foreground" aria-hidden="true" /> : <ChevronDown className="size-4 text-muted-foreground" aria-hidden="true" />}
-        </button>
-        {expanded && <div id="group-stats-panel-compact">{content}</div>}
-      </div>
-    )
-  }
-
+function StatsSkeleton() {
   return (
-    <Card>
-      <CardHeader className="pb-3">
-        <button
-          type="button"
-          className="w-full flex items-center justify-between"
-          onClick={() => setExpanded(!expanded)}
-          aria-expanded={expanded}
-          aria-controls="group-stats-panel"
-        >
-          <h2 className="font-semibold flex items-center gap-2 text-sm">
-            <BarChart3 className="size-4" aria-hidden="true" />
-            {t('stats.title')}
-          </h2>
-          {expanded ? <ChevronUp className="size-4 text-muted-foreground" aria-hidden="true" /> : <ChevronDown className="size-4 text-muted-foreground" aria-hidden="true" />}
-        </button>
-      </CardHeader>
-      {expanded && (
-        <CardContent id="group-stats-panel">
-          {content}
-        </CardContent>
-      )}
-    </Card>
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 gap-3">
+        <Skeleton className="h-[58px]" />
+        <Skeleton className="h-[58px]" />
+      </div>
+      <div className="space-y-2">
+        <Skeleton className="h-3.5 w-24" />
+        <Skeleton className="h-7" />
+        <Skeleton className="h-7" />
+      </div>
+    </div>
+  )
+}
+
+function StatsEmpty() {
+  const { t } = useTranslation()
+  return (
+    <div className="flex flex-col items-center gap-1.5 py-6 text-center">
+      <BarChart3 className="size-8 text-muted-foreground/40 mb-1" aria-hidden="true" />
+      <p className="text-sm font-medium">{t('stats.emptyTitle')}</p>
+      <p className="text-xs text-muted-foreground max-w-[16rem]">{t('stats.emptyDescription')}</p>
+    </div>
   )
 }

--- a/packages/frontend/src/components/ui/collapsible-card.tsx
+++ b/packages/frontend/src/components/ui/collapsible-card.tsx
@@ -1,0 +1,42 @@
+import { useId, useState, type ReactNode } from 'react'
+import { ChevronDown, ChevronUp, type LucideIcon } from 'lucide-react'
+import { Card, CardHeader, CardContent } from '@/components/ui/card'
+
+interface CollapsibleCardProps {
+  title: string
+  icon: LucideIcon
+  /** Whether the panel starts open. Stats-style surfaces default to open. */
+  defaultExpanded?: boolean
+  children: ReactNode
+}
+
+/** A Card whose body can be folded away behind its header. Shared so every
+ *  collapsible surface keeps the same header, chevron and a11y wiring
+ *  (`aria-expanded` / `aria-controls`, a 44px touch target, a unique id). */
+export function CollapsibleCard({ title, icon: Icon, defaultExpanded = true, children }: CollapsibleCardProps) {
+  const [expanded, setExpanded] = useState(defaultExpanded)
+  const panelId = useId()
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <button
+          type="button"
+          className="w-full flex items-center justify-between gap-2 min-h-[44px]"
+          onClick={() => setExpanded((v) => !v)}
+          aria-expanded={expanded}
+          aria-controls={panelId}
+        >
+          <h2 className="font-semibold flex items-center gap-2 text-sm">
+            <Icon className="size-4" aria-hidden="true" />
+            {title}
+          </h2>
+          {expanded
+            ? <ChevronUp className="size-4 text-muted-foreground" aria-hidden="true" />
+            : <ChevronDown className="size-4 text-muted-foreground" aria-hidden="true" />}
+        </button>
+      </CardHeader>
+      {expanded && <CardContent id={panelId}>{children}</CardContent>}
+    </Card>
+  )
+}

--- a/packages/frontend/src/i18n/locales/en.json
+++ b/packages/frontend/src/i18n/locales/en.json
@@ -426,7 +426,11 @@
     "win": "win",
     "participation": "Participation",
     "memberVotes": "{{count}} votes",
-    "recentWinners": "Recent winners"
+    "recentWinners": "Recent winners",
+    "winRate": "{{rate}}% win rate",
+    "emptyTitle": "No statistics yet",
+    "emptyDescription": "Start your first vote to see your group stats here.",
+    "loadError": "Couldn't load statistics."
   },
   "profile": {
     "title": "My Profile",
@@ -466,7 +470,9 @@
     "title": "Suggestions",
     "neverPlayed": "Never played together",
     "notPlayedLong": "Not played in a while",
-    "popularForgotten": "Popular but forgotten"
+    "popularForgotten": "Popular but forgotten",
+    "emptyTitle": "No suggestions right now",
+    "emptyDescription": "Sync your libraries to discover games to try together."
   },
   "landing": {
     "headline": "What are we playing tonight?",

--- a/packages/frontend/src/i18n/locales/fr.json
+++ b/packages/frontend/src/i18n/locales/fr.json
@@ -452,7 +452,11 @@
     "win": "victoire",
     "participation": "Participation",
     "memberVotes": "{{count}} votes",
-    "recentWinners": "Derniers gagnants"
+    "recentWinners": "Derniers gagnants",
+    "winRate": "{{rate}}% de victoires",
+    "emptyTitle": "Pas encore de statistiques",
+    "emptyDescription": "Lancez un premier vote pour voir apparaître les stats du groupe.",
+    "loadError": "Impossible de charger les statistiques."
   },
   "profile": {
     "title": "Mon Profil",
@@ -492,7 +496,9 @@
     "title": "Suggestions",
     "neverPlayed": "Jamais joué ensemble",
     "notPlayedLong": "Pas joué depuis longtemps",
-    "popularForgotten": "Populaire mais oublié"
+    "popularForgotten": "Populaire mais oublié",
+    "emptyTitle": "Aucune suggestion pour le moment",
+    "emptyDescription": "Synchronisez vos bibliothèques pour découvrir des jeux à essayer ensemble."
   },
   "landing": {
     "headline": "On joue à quoi ce soir ?",


### PR DESCRIPTION
The Stats tab could render an empty screen for new groups (GroupStats
returned null with 0 sessions), showed no loading/error feedback, broke
on missing Steam images, and mixed a collapsible card with a static one.

- Add loading, error (with retry) and empty states to GroupStats and
  GameRecommendations so the tab is never blank or silently broken.
- Extract a shared CollapsibleCard so both cards behave consistently,
  default to expanded, and carry correct aria/touch-target wiring.
- Extract GameThumb: Steam header image with an initial-tile fallback
  and a fixed box, fixing broken thumbnails and clipped row text.
- Surface a win rate in Top Games and give rank 1 a podium accent.
- Quiet the common "never played" suggestion badge so rarer, more
  actionable reasons stand out.
- Drop the dead `compact` prop and unused `fetchedGroupId` ref.

https://claude.ai/code/session_01UAAQFNy9xoXwQQM7DCSoKL