### PR TITLE
feat: add ambient WebGL aurora background layer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13948,6 +13948,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/ogl": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ogl/-/ogl-1.0.11.tgz",
+      "integrity": "sha512-kUpC154AFfxi16pmZUK4jk3J+8zxwTWGPo03EoYA8QPbzikHoaC82n6pNTbd+oEaJonaE8aPWBlX7ad9zrqLsA==",
+      "license": "Unlicense"
+    },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
@@ -18439,6 +18445,7 @@
         "i18next": "^25.8.14",
         "i18next-browser-languagedetector": "^8.2.1",
         "lucide-react": "^0.562.0",
+        "ogl": "^1.0.11",
         "radix-ui": "^1.4.3",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -27,6 +27,7 @@
     "i18next": "^25.8.14",
     "i18next-browser-languagedetector": "^8.2.1",
     "lucide-react": "^0.562.0",
+    "ogl": "^1.0.11",
     "radix-ui": "^1.4.3",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",

--- a/packages/frontend/src/components/aurora-background.tsx
+++ b/packages/frontend/src/components/aurora-background.tsx
@@ -1,0 +1,53 @@
+import { Component, lazy, Suspense, type ReactNode } from 'react'
+import { useMediaQuery } from '@/hooks/use-media-query'
+
+// `ogl` + the shader only load once this layer actually renders, keeping the
+// WebGL background off the initial/LCP bundle (consistent with the route-level
+// code splitting in App.tsx).
+const Aurora = lazy(() => import('@/components/react-bits/aurora'))
+
+// react-bits Aurora tuned for the "Neon Dusk" palette: a purple -> cyan ->
+// purple sweep, kept faint (low amplitude, soft blend, slow drift) so it
+// reads as atmosphere behind the UI rather than a foreground effect.
+const COLOR_STOPS = ['#7C3AED', '#22D3EE', '#A855F7']
+
+// The Aurora layer is purely decorative. If its chunk fails to load or the
+// device has no usable WebGL context, render nothing — the CSS gradient
+// layers in index.css already carry the background on their own.
+class SilentBoundary extends Component<{ children: ReactNode }, { failed: boolean }> {
+  state: { failed: boolean } = { failed: false }
+
+  static getDerivedStateFromError() {
+    return { failed: true }
+  }
+
+  render() {
+    return this.state.failed ? null : this.props.children
+  }
+}
+
+/**
+ * App-wide ambient WebGL background. Mounted once, above the routed tree, so
+ * the WebGL context is never torn down on navigation. Shows through wherever
+ * a page leaves its root transparent (landing page, chrome-less routes) —
+ * exactly like the existing CSS gradient mesh.
+ */
+export function AuroraBackground() {
+  const reduceMotion = useMediaQuery('(prefers-reduced-motion: reduce)')
+  // A continuous full-screen WebGL shader costs more than the CSS effects the
+  // "Mobile GPU relief" block in index.css already disables — so on coarse-
+  // pointer phones we skip the layer (and its `ogl` chunk) entirely.
+  const lowPowerViewport = useMediaQuery('(pointer: coarse) and (max-width: 768px)')
+
+  if (reduceMotion || lowPowerViewport) return null
+
+  return (
+    <div aria-hidden className="aurora-bg-layer">
+      <SilentBoundary>
+        <Suspense fallback={null}>
+          <Aurora colorStops={COLOR_STOPS} amplitude={0.7} blend={0.8} speed={0.35} />
+        </Suspense>
+      </SilentBoundary>
+    </div>
+  )
+}

--- a/packages/frontend/src/components/react-bits/aurora.tsx
+++ b/packages/frontend/src/components/react-bits/aurora.tsx
@@ -1,0 +1,222 @@
+/*
+ * Aurora — animated WebGL aurora-borealis background.
+ *
+ * Vendored from react-bits (https://github.com/DavidHDev/react-bits),
+ * ts-tailwind variant: src/ts-tailwind/Backgrounds/Aurora/Aurora.tsx.
+ * License: MIT + Commons Clause. Treated as project-owned code; the only
+ * changes from upstream are the two ESLint-disable comments below, which
+ * annotate intentional patterns (the latest-props read via propsRef inside
+ * the rAF loop, and the forward-referenced `program` binding) that this
+ * project's lint config would otherwise flag.
+ */
+import { useEffect, useRef } from 'react';
+import { Renderer, Program, Mesh, Color, Triangle } from 'ogl';
+
+const VERT = `#version 300 es
+in vec2 position;
+void main() {
+  gl_Position = vec4(position, 0.0, 1.0);
+}
+`;
+
+const FRAG = `#version 300 es
+precision highp float;
+
+uniform float uTime;
+uniform float uAmplitude;
+uniform vec3 uColorStops[3];
+uniform vec2 uResolution;
+uniform float uBlend;
+
+out vec4 fragColor;
+
+vec3 permute(vec3 x) {
+  return mod(((x * 34.0) + 1.0) * x, 289.0);
+}
+
+float snoise(vec2 v){
+  const vec4 C = vec4(
+      0.211324865405187, 0.366025403784439,
+      -0.577350269189626, 0.024390243902439
+  );
+  vec2 i  = floor(v + dot(v, C.yy));
+  vec2 x0 = v - i + dot(i, C.xx);
+  vec2 i1 = (x0.x > x0.y) ? vec2(1.0, 0.0) : vec2(0.0, 1.0);
+  vec4 x12 = x0.xyxy + C.xxzz;
+  x12.xy -= i1;
+  i = mod(i, 289.0);
+
+  vec3 p = permute(
+      permute(i.y + vec3(0.0, i1.y, 1.0))
+    + i.x + vec3(0.0, i1.x, 1.0)
+  );
+
+  vec3 m = max(
+      0.5 - vec3(
+          dot(x0, x0),
+          dot(x12.xy, x12.xy),
+          dot(x12.zw, x12.zw)
+      ),
+      0.0
+  );
+  m = m * m;
+  m = m * m;
+
+  vec3 x = 2.0 * fract(p * C.www) - 1.0;
+  vec3 h = abs(x) - 0.5;
+  vec3 ox = floor(x + 0.5);
+  vec3 a0 = x - ox;
+  m *= 1.79284291400159 - 0.85373472095314 * (a0*a0 + h*h);
+
+  vec3 g;
+  g.x  = a0.x  * x0.x  + h.x  * x0.y;
+  g.yz = a0.yz * x12.xz + h.yz * x12.yw;
+  return 130.0 * dot(m, g);
+}
+
+struct ColorStop {
+  vec3 color;
+  float position;
+};
+
+#define COLOR_RAMP(colors, factor, finalColor) {              \
+  int index = 0;                                            \
+  for (int i = 0; i < 2; i++) {                               \
+     ColorStop currentColor = colors[i];                    \
+     bool isInBetween = currentColor.position <= factor;    \
+     index = int(mix(float(index), float(i), float(isInBetween))); \
+  }                                                         \
+  ColorStop currentColor = colors[index];                   \
+  ColorStop nextColor = colors[index + 1];                  \
+  float range = nextColor.position - currentColor.position; \
+  float lerpFactor = (factor - currentColor.position) / range; \
+  finalColor = mix(currentColor.color, nextColor.color, lerpFactor); \
+}
+
+void main() {
+  vec2 uv = gl_FragCoord.xy / uResolution;
+
+  ColorStop colors[3];
+  colors[0] = ColorStop(uColorStops[0], 0.0);
+  colors[1] = ColorStop(uColorStops[1], 0.5);
+  colors[2] = ColorStop(uColorStops[2], 1.0);
+
+  vec3 rampColor;
+  COLOR_RAMP(colors, uv.x, rampColor);
+
+  float height = snoise(vec2(uv.x * 2.0 + uTime * 0.1, uTime * 0.25)) * 0.5 * uAmplitude;
+  height = exp(height);
+  height = (uv.y * 2.0 - height + 0.2);
+  float intensity = 0.6 * height;
+
+  float midPoint = 0.20;
+  float auroraAlpha = smoothstep(midPoint - uBlend * 0.5, midPoint + uBlend * 0.5, intensity);
+
+  vec3 auroraColor = intensity * rampColor;
+
+  fragColor = vec4(auroraColor * auroraAlpha, auroraAlpha);
+}
+`;
+
+interface AuroraProps {
+  colorStops?: string[];
+  amplitude?: number;
+  blend?: number;
+  time?: number;
+  speed?: number;
+}
+
+export default function Aurora(props: AuroraProps) {
+  const { colorStops = ['#5227FF', '#7cff67', '#5227FF'], amplitude = 1.0, blend = 0.5 } = props;
+  const propsRef = useRef<AuroraProps>(props);
+  propsRef.current = props;
+
+  const ctnDom = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const ctn = ctnDom.current;
+    if (!ctn) return;
+
+    const renderer = new Renderer({
+      alpha: true,
+      premultipliedAlpha: true,
+      antialias: true
+    });
+    const gl = renderer.gl;
+    gl.clearColor(0, 0, 0, 0);
+    gl.enable(gl.BLEND);
+    gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
+    gl.canvas.style.backgroundColor = 'transparent';
+
+    // eslint-disable-next-line prefer-const
+    let program: Program | undefined;
+
+    function resize() {
+      if (!ctn) return;
+      const width = ctn.offsetWidth;
+      const height = ctn.offsetHeight;
+      renderer.setSize(width, height);
+      if (program) {
+        program.uniforms.uResolution.value = [width, height];
+      }
+    }
+    window.addEventListener('resize', resize);
+
+    const geometry = new Triangle(gl);
+    if (geometry.attributes.uv) {
+      delete geometry.attributes.uv;
+    }
+
+    const colorStopsArray = colorStops.map(hex => {
+      const c = new Color(hex);
+      return [c.r, c.g, c.b];
+    });
+
+    program = new Program(gl, {
+      vertex: VERT,
+      fragment: FRAG,
+      uniforms: {
+        uTime: { value: 0 },
+        uAmplitude: { value: amplitude },
+        uColorStops: { value: colorStopsArray },
+        uResolution: { value: [ctn.offsetWidth, ctn.offsetHeight] },
+        uBlend: { value: blend }
+      }
+    });
+
+    const mesh = new Mesh(gl, { geometry, program });
+    ctn.appendChild(gl.canvas);
+
+    let animateId = 0;
+    const update = (t: number) => {
+      animateId = requestAnimationFrame(update);
+      const { time = t * 0.01, speed = 1.0 } = propsRef.current;
+      if (program) {
+        program.uniforms.uTime.value = time * speed * 0.1;
+        program.uniforms.uAmplitude.value = propsRef.current.amplitude ?? 1.0;
+        program.uniforms.uBlend.value = propsRef.current.blend ?? blend;
+        const stops = propsRef.current.colorStops ?? colorStops;
+        program.uniforms.uColorStops.value = stops.map((hex: string) => {
+          const c = new Color(hex);
+          return [c.r, c.g, c.b];
+        });
+        renderer.render({ scene: mesh });
+      }
+    };
+    animateId = requestAnimationFrame(update);
+
+    resize();
+
+    return () => {
+      cancelAnimationFrame(animateId);
+      window.removeEventListener('resize', resize);
+      if (ctn && gl.canvas.parentNode === ctn) {
+        ctn.removeChild(gl.canvas);
+      }
+      gl.getExtension('WEBGL_lose_context')?.loseContext();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [amplitude]);
+
+  return <div ref={ctnDom} className="w-full h-full" />;
+}

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -182,6 +182,21 @@
     background-repeat: repeat;
     background-size: 256px 256px;
   }
+
+  /* ── Aurora ambient layer (react-bits WebGL background) ──
+     Host for the <AuroraBackground> WebGL canvas. Sits beneath the gradient
+     mesh (body::before, z-index -2) and the fog layer (body::after, -1) as
+     the deepest band of atmosphere, so it shows through wherever a page
+     leaves its root transparent. Held faint and pointer-inert so it never
+     competes with content; the React layer is skipped entirely on coarse-
+     pointer phones and under prefers-reduced-motion. */
+  .aurora-bg-layer {
+    position: fixed;
+    inset: 0;
+    z-index: -3;
+    pointer-events: none;
+    opacity: 0.28;
+  }
 }
 
 /* ── Keyframes ── */

--- a/packages/frontend/src/main.tsx
+++ b/packages/frontend/src/main.tsx
@@ -5,6 +5,7 @@ import { TooltipProvider } from '@/components/ui/tooltip'
 import { Toaster } from 'sonner'
 import { ErrorBoundary } from '@/components/error-boundary'
 import { PwaUpdatePanel } from '@/components/pwa-update-panel'
+import { AuroraBackground } from '@/components/aurora-background'
 import App from './App'
 import './i18n'
 import './index.css'
@@ -13,6 +14,7 @@ createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <BrowserRouter>
       <TooltipProvider delayDuration={300}>
+        <AuroraBackground />
         <ErrorBoundary>
           <App />
         </ErrorBoundary>


### PR DESCRIPTION
## Summary
Adds an animated WebGL aurora-borealis background as a decorative ambient layer beneath the existing CSS gradient mesh. The layer is mounted once at the app root, persists across navigation, and gracefully degrades on low-power devices and when motion is reduced.

## Changes
- **New component:** `AuroraBackground` wrapper that conditionally renders the WebGL layer based on device capabilities and user preferences
  - Skips rendering on `prefers-reduced-motion: reduce`
  - Skips rendering on coarse-pointer phones (max-width: 768px) to avoid GPU overhead
  - Uses error boundary and lazy loading to keep the `ogl` chunk off the initial bundle
  
- **Vendored shader component:** `react-bits/aurora.tsx` — WebGL aurora renderer using `ogl` library
  - Simplex noise-based animated aurora effect with configurable color stops, amplitude, and blend
  - Tuned for "Neon Dusk" palette (purple → cyan → purple) at low opacity (0.28) to read as atmosphere
  - Handles canvas resize and cleanup on unmount
  
- **Styling:** Added `.aurora-bg-layer` fixed positioning at `z-index: -3` (beneath gradient mesh and fog layers) with `pointer-events: none` and reduced opacity
  
- **Dependencies:** Added `ogl@^1.0.11` for WebGL rendering

## Implementation Details
- The aurora layer is mounted in `main.tsx` above the routed tree, so the WebGL context persists across page navigation (no teardown/recreation overhead)
- Lazy-loaded via `React.lazy()` to defer `ogl` bundle until the component actually renders
- Uses `useMediaQuery` hooks to detect motion preferences and viewport type before rendering
- Wrapped in `SilentBoundary` error boundary — if the WebGL chunk fails to load or the device has no usable context, renders nothing and falls back to CSS gradients
- The shader uses Simplex noise for organic wave motion and color ramping for smooth gradient transitions

https://claude.ai/code/session_01RgAFLpQmgaQJTuttmQKfPb