### PR TITLE
fix(personas): honour group override expiry across bot and cache

### DIFF
--- a/packages/backend/src/domain/__tests__/persona-selection.test.ts
+++ b/packages/backend/src/domain/__tests__/persona-selection.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// vi.hoisted — variables available inside vi.mock factories
+// ---------------------------------------------------------------------------
+
+const { mockDb, dbResultQueue, dbCallCounts } = vi.hoisted(() => {
+  function chain(resolveValue: unknown = undefined): unknown {
+    const proxy: unknown = new Proxy(() => {}, {
+      get(_t, prop: string) {
+        if (prop === 'then') {
+          return (res: (v: unknown) => void, rej: (e: unknown) => void) =>
+            Promise.resolve(resolveValue).then(res, rej)
+        }
+        return (..._a: unknown[]) => proxy
+      },
+      apply() {
+        return proxy
+      },
+    })
+    return proxy
+  }
+
+  const dbResultQueue = new Map<string, unknown[]>()
+  const dbCallCounts = new Map<string, number>()
+
+  function nextResult(table: string): unknown {
+    const idx = dbCallCounts.get(table) ?? 0
+    dbCallCounts.set(table, idx + 1)
+    const arr = dbResultQueue.get(table)
+    if (!arr || arr.length === 0) return undefined
+    return arr[Math.min(idx, arr.length - 1)]
+  }
+
+  const mockDb = Object.assign((table: string) => chain(nextResult(table)), {
+    raw: (() => Promise.resolve()) as unknown,
+  })
+
+  return { mockDb, dbResultQueue, dbCallCounts }
+})
+
+vi.mock('@/infrastructure/database/connection.js', () => ({ db: mockDb }))
+
+// ---------------------------------------------------------------------------
+// Import module under test
+// ---------------------------------------------------------------------------
+
+import {
+  selectPersonaForGroup,
+  invalidateGroupPersonaCache,
+  hashCode,
+} from '../persona-selection.js'
+
+function setResult(table: string, ...values: unknown[]) {
+  dbResultQueue.set(table, values)
+}
+
+// Two active personas, ordered by created_at asc (as the real query does).
+const PERSONAS = [
+  { id: 'p-a', name: 'A', embed_color: 1, intro_message: 'a', is_active: true, created_at: new Date('2026-01-01') },
+  { id: 'p-b', name: 'B', embed_color: 2, intro_message: 'b', is_active: true, created_at: new Date('2026-01-02') },
+]
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('selectPersonaForGroup — time-boxed override expiry', () => {
+  beforeEach(() => {
+    dbResultQueue.clear()
+    dbCallCounts.clear()
+  })
+
+  it('drops a group override the moment it expires, even within the same Paris day (cache must not hold it stale)', async () => {
+    const groupId = 'grp-expiry'
+    // Unique key per test → isolate the module-level cache.
+    invalidateGroupPersonaCache(groupId)
+
+    // Pick the persona the daily hash would land on for this group/date, then
+    // override to the *other* one so the pick visibly changes after expiry.
+    const dateStr = '2026-06-02'
+    const hashed = PERSONAS[hashCode(`${dateStr}:${groupId}`) % PERSONAS.length]!
+    const overrideId = hashed.id === 'p-a' ? 'p-b' : 'p-a'
+
+    const expiry = new Date('2026-06-02T12:00:00Z')
+    setResult('personas', PERSONAS)
+    setResult('app_settings', []) // global defaults: rotation on, no override
+    setResult('group_persona_settings', {
+      rotation_enabled: null,
+      disabled_personas: null,
+      persona_override: overrideId,
+      override_expires_at: expiry,
+    })
+
+    // Before expiry (08:00 UTC = 10:00 Paris) → override wins.
+    const before = await selectPersonaForGroup(groupId, new Date('2026-06-02T08:00:00Z'))
+    expect(before?.id).toBe(overrideId)
+
+    // After expiry (18:00 UTC = 20:00 Paris, same Paris day) → rotation resumes.
+    // The cache from the first call must be treated as stale here.
+    const after = await selectPersonaForGroup(groupId, new Date('2026-06-02T18:00:00Z'))
+    expect(after?.id).toBe(hashed.id)
+    expect(after?.id).not.toBe(overrideId)
+  })
+
+  it('keeps serving a still-valid override from cache without recomputing', async () => {
+    const groupId = 'grp-valid'
+    invalidateGroupPersonaCache(groupId)
+
+    const expiry = new Date('2026-06-02T23:00:00Z')
+    setResult('personas', PERSONAS)
+    setResult('app_settings', [])
+    setResult('group_persona_settings', {
+      rotation_enabled: null,
+      disabled_personas: null,
+      persona_override: 'p-b',
+      override_expires_at: expiry,
+    })
+
+    const first = await selectPersonaForGroup(groupId, new Date('2026-06-02T08:00:00Z'))
+    expect(first?.id).toBe('p-b')
+
+    // A later read still inside the validity window returns the same override.
+    const second = await selectPersonaForGroup(groupId, new Date('2026-06-02T12:00:00Z'))
+    expect(second?.id).toBe('p-b')
+  })
+})

--- a/packages/backend/src/domain/persona-selection.ts
+++ b/packages/backend/src/domain/persona-selection.ts
@@ -70,6 +70,13 @@ export function parisDate(now: Date = new Date()): string {
 interface CacheEntry {
   date: string
   persona: DailyPersona
+  /**
+   * Epoch ms after which this entry must be recomputed, even though the
+   * Paris day hasn't rolled over yet. Set when the pick came from a
+   * time-boxed group override so the cache stops serving the override the
+   * moment it expires instead of holding it stale until midnight.
+   */
+  validUntil?: number
 }
 
 const personaCache = new Map<string, CacheEntry>()
@@ -172,7 +179,11 @@ export async function selectPersonaForGroup(
   const cacheKey = selectionKey(dateStr, groupId)
 
   const cached = personaCache.get(cacheKey)
-  if (cached && cached.date === dateStr) {
+  if (
+    cached &&
+    cached.date === dateStr &&
+    (cached.validUntil == null || now.getTime() < cached.validUntil)
+  ) {
     return cached.persona
   }
   pruneStale(dateStr)
@@ -225,8 +236,15 @@ export async function selectPersonaForGroup(
 
   if (!selected) return null
 
+  // If the pick came from a time-boxed group override, cap the cache TTL at
+  // the override's expiry so rotation resumes the instant it elapses.
+  const validUntil =
+    groupOverride && selected.id === groupOverride && groupSettings?.override_expires_at
+      ? groupSettings.override_expires_at.getTime()
+      : undefined
+
   const persona = toDailyPersona(selected)
-  personaCache.set(cacheKey, { date: dateStr, persona })
+  personaCache.set(cacheKey, { date: dateStr, persona, validUntil })
   return persona
 }
 
@@ -247,7 +265,11 @@ export async function selectPersonasForGroups(
   const uncached: string[] = []
   for (const gid of groupIds) {
     const hit = personaCache.get(selectionKey(dateStr, gid))
-    if (hit && hit.date === dateStr) {
+    if (
+      hit &&
+      hit.date === dateStr &&
+      (hit.validUntil == null || now.getTime() < hit.validUntil)
+    ) {
       result.set(gid, hit.persona)
     } else {
       uncached.push(gid)
@@ -307,8 +329,13 @@ export async function selectPersonasForGroups(
     }
     if (!selected) continue
 
+    const validUntil =
+      groupOverride && selected.id === groupOverride && gs?.override_expires_at
+        ? gs.override_expires_at.getTime()
+        : undefined
+
     const persona = toDailyPersona(selected)
-    personaCache.set(selectionKey(dateStr, gid), { date: dateStr, persona })
+    personaCache.set(selectionKey(dateStr, gid), { date: dateStr, persona, validUntil })
     result.set(gid, persona)
   }
 

--- a/packages/discord/src/scheduler.ts
+++ b/packages/discord/src/scheduler.ts
@@ -60,7 +60,16 @@ function getPersona() {
  */
 function getPersonaForChannel(channel: LinkedChannel) {
   const globalOverride = currentSettings?.persona_override || null
-  const groupOverride = channel.personaSettings.personaOverride || null
+  // A group override may be time-boxed via `overrideExpiresAt`. Once it has
+  // elapsed the backend drops it and resumes daily rotation, so we must do
+  // the same here — otherwise an expired override would stick forever on the
+  // bot side and the two ends would pick different personas for the group.
+  const expiresAt = channel.personaSettings.overrideExpiresAt
+  const groupOverrideExpired =
+    expiresAt != null && new Date(expiresAt).getTime() < Date.now()
+  const groupOverride = groupOverrideExpired
+    ? null
+    : channel.personaSettings.personaOverride || null
   const effectiveOverride = groupOverride ?? globalOverride
   if (effectiveOverride) {
     const forced = getPersonaById(effectiveOverride)


### PR DESCRIPTION
## Summary

A persona-feature bug hunt (walking the per-group "persona du jour" path from the web UI, the backend selector, and the Discord bot) surfaced two genuine bugs, both rooted in **group override expiry (`override_expires_at`) being under-handled**. A group can set a *time-boxed* persona override ("force the Coach until Friday"); `selectPersonaForGroup` correctly drops it after expiry and resumes daily rotation — but two other consumers didn't, breaking the documented *"both ends always pick the same persona for the same group on the same day"* invariant.

## Bugs fixed

**1. Discord scheduler ignored `overrideExpiresAt`.**
`getPersonaForChannel` (`packages/discord/src/scheduler.ts`) read `personaSettings.personaOverride` without ever consulting `overrideExpiresAt` — even though the `/api/discord/linked-channels` endpoint explicitly ships that field. An expired override therefore stuck **forever** on the bot side while the web UI had already reverted to rotation. Now the scheduler drops an override once its expiry has elapsed, exactly mirroring the backend.

**2. Backend persona cache served an expired override until midnight.**
`selectPersonaForGroup` / `selectPersonasForGroups` cached the resolved persona keyed on `(date, group)`, valid for the whole Paris day. Cache invalidation only fired on a settings `PATCH`, so when an override expired *during* the day, the cached pre-expiry persona kept being served until midnight. Cache entries derived from a time-boxed override now carry a `validUntil` (the expiry epoch), so rotation resumes the instant the override elapses.

## Tests

Added the first unit tests for the persona-selection domain (none existed):
- override is dropped the moment it expires within the same Paris day (the cache must not hold it stale) — verified to **fail** without the cache fix;
- a still-valid override keeps being served from cache.

## Verification
- `npm run build:backend` and `npm run build:discord` — both type-check clean.
- `npm run test -w @wawptn/backend` — 16 files / 105 tests pass (was 15 / 103).

https://claude.ai/code/session_01GrTVuruLMrS4ZJ9vjC5ryH

---
_Generated by [Claude Code](https://claude.ai/code/session_01GrTVuruLMrS4ZJ9vjC5ryH)_