### PR TITLE
fix(backend): trust the reverse proxy so req.ip is the real client IP

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -51,6 +51,13 @@ async function main() {
   const app = express()
   const httpServer = createServer(app)
 
+  // Trust the first reverse proxy (Traefik in the reference deploy). Without
+  // this, `req.ip` returns the proxy's container address, which collapses
+  // every anonymous client onto a single rate-limit bucket and writes the
+  // wrong IP into the admin audit log. One hop matches the production
+  // topology (client → Traefik → app); add more if a CDN is stacked in front.
+  app.set('trust proxy', 1)
+
   // Security headers
   app.use(helmet({
     contentSecurityPolicy: {


### PR DESCRIPTION
## Summary

Express was missing `app.set('trust proxy', ...)`, so behind Traefik (the reference deploy, see `compose.yml`) `req.ip` returned the proxy container's address instead of the real client IP.

That collapses every anonymous client onto a single rate-limit bucket — one attacker can drain the limit for everyone — and writes the proxy's IP into `admin_audit_log` instead of the actor's, breaking the forensic intent the audit log was built for.

## Fix

`app.set('trust proxy', 1)` matches the production topology (client → Traefik → app). Locally, no `X-Forwarded-For` is sent so `req.ip` still falls back to the socket address. Raise the value if a CDN is later stacked in front.

## Affected code paths

- `index.ts:97-108` — `apiLimiter` IP fallback key
- `index.ts:118-131` — `stripeBilledLimiter` IP fallback key
- `domain/admin-audit-log.ts:64` — actor IP recorded on every admin action (the in-file comment already calls out the `trust proxy` requirement)

## Test plan

- [x] `npm run build` (types + backend) — clean
- [x] `npm run test --workspace=@wawptn/backend` — 105/105 pass
- [ ] Manual: deploy to a staging instance behind Traefik, send a request, confirm `req.ip` and the audit log show the client IP rather than the Traefik container IP

https://claude.ai/code/session_01FLPQA4Gm6rwPJCjYureDrK

---
_Generated by [Claude Code](https://claude.ai/code/session_01FLPQA4Gm6rwPJCjYureDrK)_